### PR TITLE
chore: Add better assert condition for a flaky test

### DIFF
--- a/core/client_test.go
+++ b/core/client_test.go
@@ -332,7 +332,7 @@ func TestLoadToolAndLoadToolset(t *testing.T) {
 			t.Fatal("Expected an error for unused auth token in strict mode, but got nil")
 		}
 		// In strict mode, the error is reported for the first tool it doesn't apply to
-		if !strings.Contains(err.Error(), "validation failed for tool") {
+		if !strings.Contains(errStr, "validation failed for tool") || !strings.Contains(errStr, "unused auth tokens: unused-auth") { {
 			t.Errorf("Incorrect error for unused auth token in strict mode. Got: %v", err)
 		}
 	})


### PR DESCRIPTION
This particular test was flaky as the loadToolset runs an iteration through the map of Tools and the map iteration order is intentionally randomized.

This assert condition will correctly catch the error even if the map iteration order is random