### PR TITLE
chore: Seperate E2E tests from unit tests

### DIFF
--- a/core/client_test.go
+++ b/core/client_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 // Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/e2e_setup_test.go
+++ b/core/e2e_setup_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 // Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/e2e_test.go
+++ b/core/e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 // Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/options_test.go
+++ b/core/options_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 // Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/protocol_test.go
+++ b/core/protocol_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 // Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/tool_test.go
+++ b/core/tool_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 // Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/utils_test.go
+++ b/core/utils_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 // Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration.cloudbuild.yaml
+++ b/integration.cloudbuild.yaml
@@ -24,7 +24,7 @@ steps:
     script: |
       go get -d ./...
 
-  - id: "run-tests"
+  - id: "run-unit-tests"
     name: golang:1
     waitFor: ["install-dependencies"]
     env:

--- a/integration.cloudbuild.yaml
+++ b/integration.cloudbuild.yaml
@@ -33,7 +33,7 @@ steps:
       - name: "go"
         path: "/gopath"
     script: |
-      go test ./... -v -race
+      go test -tags=unit ./... -v -race
 
   - id: "run-e2e-tests"
     name: golang:1

--- a/integration.cloudbuild.yaml
+++ b/integration.cloudbuild.yaml
@@ -29,13 +29,25 @@ steps:
     waitFor: ["install-dependencies"]
     env:
       - "GOPATH=/gopath"
+    volumes:
+      - name: "go"
+        path: "/gopath"
+    script: |
+      go test ./... -v -race
+
+  - id: "run-e2e-tests"
+    name: golang:1
+    waitFor: ["install-dependencies"]
+    env:
+      - "GOPATH=/gopath"
       - TOOLBOX_VERSION=$_TOOLBOX_VERSION
       - GOOGLE_CLOUD_PROJECT=$PROJECT_ID
     volumes:
       - name: "go"
         path: "/gopath"
     script: |
-      go test ./... -v -race
+      go test -tags=e2e ./... -v -race
+  
 
 options:
   logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
This PR seperates the E2E tests from unit tests by using build tags.

This change will make sure the setup for E2E tests is not run for the unit tests.