### PR TITLE
chore: Add E2E code samples for various frameworks.

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -509,6 +509,11 @@ dynamicBoundTool, err := tool.ToolFrom(core.WithBindParamStringFunc("param", get
 > [!IMPORTANT]
 > You don't need to modify tool configurations to bind parameter values.
 
+
+# Using with Orchestration Frameworks
+
+To see how the MCP Toolbox Go SDK works with orchestration frameworks, check out the end-to-end examples in the [/samples/](https://github.com/googleapis/mcp-toolbox-sdk-go/tree/main/core/samples) folder.
+
 # Contributing
 
 Contributions are welcome! Please refer to the [DEVELOPER.md](./DEVELOPER.md)

--- a/core/samples/Genkit_example.md
+++ b/core/samples/Genkit_example.md
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/googleapis/mcp-toolbox-sdk-go/core"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/googlegenai"
+	"github.com/invopop/jsonschema"
+)
+
+// NewGenkitToolFromToolbox converts a custom ToolboxTool into a genkit ai.Tool
+func NewGenkitToolFromToolbox(tool *core.ToolboxTool, g *genkit.Genkit) ai.Tool {
+	jsonBytes, err := tool.InputSchema()
+	if err != nil {
+		return nil
+	}
+	var schema *jsonschema.Schema
+	if err := json.Unmarshal(jsonBytes, &schema); err != nil {
+		return nil
+	}
+
+	// Create a wrapper execution function with the necessary signature
+	executeFn := func(ctx *ai.ToolContext, input any) (string, error) {
+		result, err := tool.Invoke(ctx, input.(map[string]any))
+		if err != nil {
+			// Propagate errors from the tool invocation.
+			return "", err
+		}
+
+		return result.(string), nil
+	}
+
+	// Create a Genkit Tool
+	return genkit.DefineToolWithInputSchema(
+		g,
+		tool.Name(),
+		tool.Description(),
+		schema,
+		executeFn,
+	)
+}
+
+func main() {
+	ctx := context.Background()
+	toolboxClient, err := core.NewToolboxClient("http://127.0.0.1:5000")
+	if err != nil {
+		log.Fatalf("Failed to create Toolbox client: %v", err)
+	}
+
+	// Load the tool using the MCP Toolbox SDK.
+	searchHotelTool, err := toolboxClient.LoadTool("search-hotels-by-name", ctx)
+	if err != nil {
+		log.Fatalf("Failed to load tools: %v\nMake sure your Toolbox server is running and the tool is configured.", err)
+	}
+
+	g, err := genkit.Init(ctx,
+		genkit.WithPlugins(&googlegenai.GoogleAI{}),
+		genkit.WithDefaultModel("googleai/gemini-1.5-flash"), // Updated model name
+	)
+	if err != nil {
+		log.Fatalf("Failed to init genkit: %v\n", err)
+	}
+
+	// Convert your tool to a Genkit tool.
+	genkitTool := NewGenkitToolFromToolbox(searchHotelTool, g)
+
+	// Generate llm response using prompts and tools.
+	resp, err := genkit.Generate(ctx, g,
+		ai.WithPrompt("Find hotels in Basel with Basel in it's name."),
+		ai.WithTools(genkitTool),
+	)
+	if err != nil {
+		log.Fatalf("%v\n", err)
+	}
+	fmt.Println(resp.Text())
+}

--- a/core/samples/GoGenAI_example.md
+++ b/core/samples/GoGenAI_example.md
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/googleapis/mcp-toolbox-sdk-go/core"
+	"google.golang.org/genai"
+)
+
+// ConvertToGenaiTool translates a ToolboxTool into the genai.FunctionDeclaration format.
+func ConvertToGenaiTool(toolboxTool *core.ToolboxTool) *genai.Tool {
+
+	inputschema, err := toolboxTool.InputSchema()
+	if err != nil {
+		return &genai.Tool{}
+	}
+
+	var schema *genai.Schema
+	_ = json.Unmarshal(inputschema, &schema)
+	// First, create the function declaration.
+	funcDeclaration := &genai.FunctionDeclaration{
+		Name:        toolboxTool.Name(),
+		Description: toolboxTool.Description(),
+		Parameters:  schema,
+	}
+
+	// Then, wrap the function declaration in a genai.Tool struct.
+	return &genai.Tool{
+		FunctionDeclarations: []*genai.FunctionDeclaration{funcDeclaration},
+	}
+}
+
+// printResponse extracts and prints the relevant parts of the model's response.
+func printResponse(resp *genai.GenerateContentResponse) {
+	for _, cand := range resp.Candidates {
+		if cand.Content != nil {
+			for _, part := range cand.Content.Parts {
+				fmt.Println(part.Text)
+			}
+		}
+	}
+}
+
+func main() {
+	// Setup
+	ctx := context.Background()
+	apiKey := os.Getenv("GOOGLE_API_KEY")
+	toolboxURL := "http://localhost:5000"
+
+	// Initialize the Google GenAI client using the explicit ClientConfig.
+	client, err := genai.NewClient(ctx, &genai.ClientConfig{
+		APIKey: apiKey,
+	})
+	if err != nil {
+		log.Fatalf("Failed to create Google GenAI client: %v", err)
+	}
+
+	// Initialize the MCP Toolbox client.
+	toolboxClient, err := core.NewToolboxClient(toolboxURL)
+	if err != nil {
+		log.Fatalf("Failed to create Toolbox client: %v", err)
+	}
+
+	toolToLoad := "search-hotels-by-name"
+
+	// Load the tool using the MCP Toolbox SDK.
+	searchHotelTool, err := toolboxClient.LoadTool(toolToLoad, ctx)
+	if err != nil {
+		log.Fatalf("Failed to load tool '%s': %v\nMake sure your Toolbox server is running and the tool is configured.", toolToLoad, err)
+	}
+	log.Printf("Successfully loaded tool: %s\n", searchHotelTool.Name())
+
+	// Convert the Toolbox tool into the genai.FunctionDeclaration format.
+	genaiFormattedTool := ConvertToGenaiTool(searchHotelTool)
+
+	// Set up the generative model with the available tool.
+	modelName := "gemini-2.0-flash"
+	tools := []*genai.Tool{
+		genaiFormattedTool,
+	}
+
+	query := "Find hotels in Basel with Basel in it's name and share the names with me"
+
+	// Create the initial content prompt for the model.
+	contents := []*genai.Content{
+		genai.NewContentFromText(query, genai.RoleUser),
+	}
+	config := &genai.GenerateContentConfig{
+		Tools: tools,
+		ToolConfig: &genai.ToolConfig{
+			FunctionCallingConfig: &genai.FunctionCallingConfig{
+				Mode: genai.FunctionCallingConfigModeAny,
+			},
+		},
+	}
+	genContentResp, _ := client.Models.GenerateContent(ctx, modelName, contents, config)
+
+	printResponse(genContentResp)
+
+	functionCalls := genContentResp.FunctionCalls()
+	if len(functionCalls) == 0 {
+		log.Println("No function call returned by the AI. The model likely answered directly.")
+		return
+	}
+
+	// Process the first function call (the example assumes one for simplicity).
+	fc := functionCalls[0]
+	log.Printf("--- Gemini requested function call: %s ---\n", fc.Name)
+	log.Printf("--- Arguments: %+v ---\n", fc.Args)
+
+	var toolResultString string
+
+	if fc.Name == "search-hotels-by-name" {
+		toolResult, err := searchHotelTool.Invoke(ctx, fc.Args)
+		toolResultString = fmt.Sprintf("%v", toolResult)
+		if err != nil {
+			log.Fatalf("Failed to execute tool '%s': %v", fc.Name, err)
+		}
+
+	} else {
+		log.Println("LLM did not request our tool")
+	}
+	resultContents := []*genai.Content{
+		genai.NewContentFromText("The tool returned this result, share it with the user based of their previous querys"+toolResultString, genai.RoleUser),
+	}
+	finalResponse, err := client.Models.GenerateContent(ctx, modelName, resultContents, &genai.GenerateContentConfig{})
+	if err != nil {
+		log.Fatalf("Error calling GenerateContent (with function result): %v", err)
+	}
+	log.Println("=== Final Response from Model (after processing function result) ===")
+	printResponse(finalResponse)
+
+}

--- a/core/samples/LangChainGo_example.md
+++ b/core/samples/LangChainGo_example.md
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/googleapis/mcp-toolbox-sdk-go/core"
+	"github.com/tmc/langchaingo/llms"
+	"github.com/tmc/langchaingo/llms/googleai"
+)
+
+// ConvertToLangchainTool converts a generic core.ToolboxTool into a LangChainGo llms.Tool.
+func ConvertToLangchainTool(toolboxTool *core.ToolboxTool) llms.Tool {
+
+	// Fetch the tool's input schema
+	inputschema, err := toolboxTool.InputSchema()
+	if err != nil {
+		return llms.Tool{}
+	}
+
+	var paramsSchema map[string]any
+	_ = json.Unmarshal(inputschema, &paramsSchema)
+
+	// Convert into LangChain's llms.Tool
+	return llms.Tool{
+		Type: "function",
+		Function: &llms.FunctionDefinition{
+			Name:        toolboxTool.Name(),
+			Description: toolboxTool.Description(),
+			Parameters:  paramsSchema,
+		},
+	}
+}
+
+func main() {
+	genaiKey := os.Getenv("GOOGLE_API_KEY")
+	toolboxURL := "http://localhost:5000"
+	ctx := context.Background()
+
+	// Initialize the Google AI client (LLM).
+	llm, err := googleai.New(ctx, googleai.WithAPIKey(genaiKey), googleai.WithDefaultModel("gemini-1.5-flash"))
+	if err != nil {
+		log.Fatalf("Failed to create Google AI client: %v", err)
+	}
+
+	// Initialize the MCP Toolbox client.
+	toolboxClient, err := core.NewToolboxClient(toolboxURL)
+	if err != nil {
+		log.Fatalf("Failed to create Toolbox client: %v", err)
+	}
+
+	// Load the tool using the MCP Toolbox SDK.
+	searchHotelTool, err := toolboxClient.LoadTool("search-hotels-by-name", ctx)
+	if err != nil {
+		log.Fatalf("Failed to load tools: %v\nMake sure your Toolbox server is running and the tool is configured.", err)
+	}
+	log.Printf("Successfully loaded tool: %s\n", searchHotelTool.Name())
+
+	// Convert the loaded ToolboxTool into the format LangChainGo requires.
+	langchainFormattedTool := ConvertToLangchainTool(searchHotelTool)
+
+	// Start the conversation history.
+	messageHistory := []llms.MessageContent{
+		llms.TextParts(llms.ChatMessageTypeHuman, "Find hotels in Basel with Basel in it's name."),
+	}
+
+	log.Println("Asking the LLM with the provided tool...")
+
+	// Make the first call to the LLM, making it aware of the tool.
+	resp, err := llm.GenerateContent(ctx, messageHistory, llms.WithTools([]llms.Tool{langchainFormattedTool}))
+	if err != nil {
+		log.Fatalf("LLM call failed: %v", err)
+	}
+
+	// Add the model's response (which should be a tool call) to the history.
+	respChoice := resp.Choices[0]
+	assistantResponse := llms.TextParts(llms.ChatMessageTypeAI, respChoice.Content)
+	for _, tc := range respChoice.ToolCalls {
+		assistantResponse.Parts = append(assistantResponse.Parts, tc)
+	}
+	messageHistory = append(messageHistory, assistantResponse)
+
+	// Process each tool call requested by the model.
+	for _, tc := range respChoice.ToolCalls {
+		toolName := tc.FunctionCall.Name
+
+		switch tc.FunctionCall.Name {
+		case "search-hotels-by-name":
+			var args map[string]any
+			if err := json.Unmarshal([]byte(tc.FunctionCall.Arguments), &args); err != nil {
+				log.Fatalf("Failed to unmarshal arguments for tool '%s': %v", toolName, err)
+			}
+			toolResult, err := searchHotelTool.Invoke(ctx, args)
+			if err != nil {
+				log.Fatalf("Failed to execute tool '%s': %v", toolName, err)
+			}
+
+			// Create the tool call response message and add it to the history.
+			toolResponse := llms.MessageContent{
+				Role: llms.ChatMessageTypeTool,
+				Parts: []llms.ContentPart{
+					llms.ToolCallResponse{
+						Name:    toolName,
+						Content: fmt.Sprintf("%v", toolResult),
+					},
+				},
+			}
+			messageHistory = append(messageHistory, toolResponse)
+		default:
+			log.Fatalf("got unexpected function call: %v", tc.FunctionCall.Name)
+		}
+	}
+
+	// Final LLM Call for Natural Language Response
+	log.Println("Sending tool response back to LLM for a final answer...")
+
+	// Call the LLM again with the updated history, which now includes the tool's result.
+	finalResp, err := llm.GenerateContent(ctx, messageHistory)
+	if err != nil {
+		log.Fatalf("Final LLM call failed: %v", err)
+	}
+
+	// Display the Result
+	fmt.Println("\n======================================")
+	fmt.Println("Final Response from LLM:")
+	fmt.Println(finalResp.Choices[0].Content)
+	fmt.Println("======================================")
+}

--- a/core/samples/OpenAI_example.md
+++ b/core/samples/OpenAI_example.md
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/googleapis/mcp-toolbox-sdk-go/core"
+	openai "github.com/openai/openai-go"
+)
+
+// ConvertToOpenAITool converts a ToolboxTool into the go-openai library's Tool format.
+func ConvertToOpenAITool(toolboxTool *core.ToolboxTool) (openai.ChatCompletionToolParam, error) {
+	// Get the input schema
+	jsonSchemaBytes, err := toolboxTool.InputSchema()
+	if err != nil {
+		return openai.ChatCompletionToolParam{}, err
+	}
+
+	// Unmarshal the JSON bytes into FunctionParameters
+	var paramsSchema openai.FunctionParameters
+	if err := json.Unmarshal(jsonSchemaBytes, &paramsSchema); err != nil {
+		return openai.ChatCompletionToolParam{}, err
+	}
+
+	// Create and return the final tool parameter struct.
+	return openai.ChatCompletionToolParam{
+		Function: openai.FunctionDefinitionParam{
+			Name:        toolboxTool.Name(),
+			Description: openai.String(toolboxTool.Description()),
+			Parameters:  paramsSchema,
+		},
+	}, nil
+}
+
+func main() {
+	// Setup
+	ctx := context.Background()
+	toolboxURL := "http://localhost:5000"
+	openAIClient := openai.NewClient()
+
+	// Initialize the MCP Toolbox client.
+	toolboxClient, err := core.NewToolboxClient(toolboxURL)
+	if err != nil {
+		log.Fatalf("Failed to create Toolbox client: %v", err)
+	}
+
+	// --- 2. Load and Convert the Tool ---
+	toolToLoad := "search-hotels-by-name"
+	log.Printf("Attempting to load tool '%s' from Toolbox at %s...\n", toolToLoad, toolboxURL)
+
+	// Load the tool using the MCP Toolbox SDK.
+	searchHotelTool, err := toolboxClient.LoadTool(toolToLoad, ctx)
+	if err != nil {
+		log.Fatalf("Failed to load tool '%s': %v\nMake sure your Toolbox server is running and the tool is configured.", toolToLoad, err)
+	}
+	log.Printf("Successfully loaded tool: %s\n", searchHotelTool.Name())
+
+	// Convert the Toolbox tool into the OpenAI FunctionDeclaration format.
+	openAITool, err := ConvertToOpenAITool(searchHotelTool)
+	if err != nil {
+		log.Fatal("Unable to convert to OpenAI tool", err)
+	}
+
+	question := "Find hotels in Basel with Basel in it's name "
+
+	params := openai.ChatCompletionNewParams{
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.UserMessage(question),
+		},
+		Tools: []openai.ChatCompletionToolParam{openAITool},
+		Seed:  openai.Int(0),
+		Model: openai.ChatModelGPT4o,
+	}
+
+	log.Println("start")
+	// Make initial chat completion request
+	completion, err := openAIClient.Chat.Completions.New(ctx, params)
+	if err != nil {
+		panic(err)
+	}
+
+	log.Println("start1")
+	toolCalls := completion.Choices[0].Message.ToolCalls
+
+	// Return early if there are no tool calls
+	if len(toolCalls) == 0 {
+		fmt.Printf("No function call")
+		return
+	}
+
+	// If there is a was a function call, continue the conversation
+	params.Messages = append(params.Messages, completion.Choices[0].Message.ToParam())
+	for _, toolCall := range toolCalls {
+		if toolCall.Function.Name == "search-hotels-by-name" {
+			// Extract the location from the function call arguments
+			var args map[string]interface{}
+			err := json.Unmarshal([]byte(toolCall.Function.Arguments), &args)
+			if err != nil {
+				panic(err)
+			}
+
+			// Invoke the tool
+			result, err := searchHotelTool.Invoke(ctx, args)
+			if err != nil {
+				log.Fatal("Could not invoke tool", err)
+			}
+
+			params.Messages = append(params.Messages, openai.ToolMessage(result.(string), toolCall.ID))
+		}
+	}
+
+	completion, err = openAIClient.Chat.Completions.New(ctx, params)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(completion.Choices[0].Message.Content)
+}


### PR DESCRIPTION
This PR adds code samples for the end-to-end working of the MCP Toolbox Go Core SDK with various orchestration frameworks.

Supported frameworks:
- OpenAI
- Go GenAI
- LangChain Go
- Genkit Go

The code samples are in intentionally placed in markdown files to reduce unnecessary dependencies in our SDK. 