### PR TITLE
docs: fix auth_methods link

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -234,7 +234,7 @@ client, err := core.NewToolboxClient(
 
 For Toolbox servers hosted on Google Cloud (e.g., Cloud Run) and requiring
 `Google ID token` authentication, the helper module
-[auth_methods](/core/auth_methods.go) provides utility functions.
+[auth_methods](/core/auth.go) provides utility functions.
 
 ### Step by Step Guide for Cloud Run
 


### PR DESCRIPTION
This PR fixes a broken link in the `core/README.md` file.

The link pointing to the `auth_methods` documentation was incorrect, leading to a 404 error. This change updates the link to the correct file path, ensuring users can navigate to the authentication helpers as intended.