### PR TITLE
feat(renovate): add renovate configuration for auto-updating toolbox version in build file of Go SDK

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,57 +1,59 @@
 {
-  "extends": [
-    "config:recommended",
-    ":semanticCommitTypeAll(chore)",
-    ":ignoreUnstable",
-    "group:allNonMajor",
-    ":separateMajorReleases",
-    ":prConcurrentLimitNone",
-    ":prHourlyLimitNone",
-    ":preserveSemverRanges"
+  extends: [
+    'config:recommended',
+    ':semanticCommitTypeAll(chore)',
+    ':ignoreUnstable',
+    'group:allNonMajor',
+    ':separateMajorReleases',
+    ':prConcurrentLimitNone',
+    ':prHourlyLimitNone',
+    ':preserveSemverRanges',
   ],
-  "minimumReleaseAge": "3",
-  "rebaseWhen": "conflicted",
-  "dependencyDashboardLabels": [
-    "type: process"
+  minimumReleaseAge: '3',
+  rebaseWhen: 'conflicted',
+  dependencyDashboardLabels: [
+    'type: process',
   ],
-  "postUpdateOptions": [
-    "gomodTidy"
+  postUpdateOptions: [
+    'gomodTidy',
   ],
-  "packageRules": [
+  packageRules: [
     {
-      "groupName": "GitHub Actions",
-      "matchManagers": [
-        "github-actions"
+      groupName: 'GitHub Actions',
+      matchManagers: [
+        'github-actions',
       ],
-      "pinDigests": true
+      pinDigests: true,
     },
     {
-      "groupName": "Toolbox Server Version",
-      "matchPackageNames": [
-        "googleapis/genai-toolbox"
+      description: 'Auto-update genai-toolbox server version',
+      matchPackageNames: [
+        'googleapis/genai-toolbox',
       ],
-      "matchManagers": [
-        "regex"
+      matchManagers: [
+        'regex',
       ],
-      "branchName": "auto-update/toolbox-server-v{{newValue}}",
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ]
-    }
+      branchName: 'auto-update/toolbox-server-v{{newValue}}',
+      commitMessageTopic: 'MCP Toolbox server for integration tests',
+      groupName: false,
+      matchUpdateTypes: [
+        'minor',
+        'patch',
+      ],
+    },
   ],
-  "regexManagers": [
+  regexManagers: [
     {
-      "fileMatch": [
-        "integration.cloudbuild.yaml"
+      fileMatch: [
+        'integration.cloudbuild.yaml',
       ],
-      "matchStrings": [
-        "_TOOLBOX_VERSION: ['|\"]?(?<currentValue>v?\\d+\\.\\d+\\.\\d+)['|\"]?"
+      matchStrings: [
+        '_TOOLBOX_VERSION: [\'|"]?(?<currentValue>v?\\d+\\.\\d+\\.\\d+)[\'|"]?',
       ],
-      "datasourceTemplate": "github-releases",
-      "depNameTemplate": "googleapis/genai-toolbox",
-      "versioningTemplate": "semver",
-      "packageNameTemplate": "googleapis/genai-toolbox"
-    }
-  ]
+      datasourceTemplate: 'github-releases',
+      depNameTemplate: 'googleapis/genai-toolbox',
+      versioningTemplate: 'semver',
+      packageNameTemplate: 'googleapis/genai-toolbox',
+    },
+  ],
 }


### PR DESCRIPTION
## Description
This PR adds the official Renovate configuration (`renovate.json`) to the Go SDK repository.

This configuration enables **automated dependency tracking** for the upstream Toolbox server:

* **What it does:** Uses the `regexManagers` to watch the **googleapis/genai-toolbox** releases.
* **Action:** This Renovate configuration uses a regexManagers block with-

- `"datasourceTemplate": "github-releases"`
- `"depNameTemplate": "googleapis/genai-toolbox"`

This tells Renovate to:

Look for new versions of the dependency by checking the GitHub Releases of the repository specified in `depNameTemplate.`
In this case, Renovate polls or checks for new releases/tags on https://github.com/googleapis/genai-toolbox.
The `matchStrings` regex extracts the _current version_ (0.12.0) from `integration.cloudbuild.yaml`. Renovate then compares this to the versions available via GitHub releases for googleapis/genai-toolbox.
* **Maintenance:** This eliminates the need for manual version checks and updating.

### Local test results

[renovate-logs.txt](https://github.com/user-attachments/files/22510491/renovate-logs.txt)

## Relates issues

Resolves #82 
