### PR TITLE
feat(renovate): remove custom branchName for genai-toolbox updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,6 +11,7 @@
   ],
   minimumReleaseAge: '3',
   rebaseWhen: 'conflicted',
+  configMigration: true,
   dependencyDashboardLabels: [
     'type: process',
   ],
@@ -33,7 +34,6 @@
       matchManagers: [
         'regex',
       ],
-      branchName: 'auto-update/toolbox-server-v{{newValue}}',
       commitMessageTopic: 'MCP Toolbox server for integration tests',
       matchUpdateTypes: [
         'minor',


### PR DESCRIPTION
### Description
This PR updates the Renovate configuration to enable the auto-closing of older, superseded PRs for the `genai-toolbox` dependency.

### Context
Previously, the `packageRules` for `googleapis/genai-toolbox` included a custom [`branchName`](https://docs.renovatebot.com/configuration-options/#branchname) (`auto-update/toolbox-server-v{{newValue}}`). While providing version-specific branches, this setup prevented Renovate's automated cleanup. Specifically, when a newer minor or patch version of genai-toolbox was released before an existing Renovate PR for an older version was merged, Renovate would not automatically close the superseded PR. This led to a build-up of obsolete Pull Requests.

This was caused by the direct usage of `branchName` in the configuration, which prevented Renovate from recognizing that the newer branch superseded the older one.

### Changes
- This PR removes the custom `"branchName"` field from the packageRules block matching "googleapis/genai-toolbox".
- By removing the custom branch name, Renovate will now group these genai-toolbox minor and patch updates together with other non-major updates. Because `"group:allNonMajor"` is included in the extends, these updates will be consolidated into a single default branch, typically named `renovate/all-minor-patch`.
- Added `configMigration: true` to allow Renovate to suggest migrations for other deprecated fields in a separate PR.
- Although the branch names for genai-toolbox updates will now be more generic, the Pull Request titles, generated by commit messages using `"commitMessageTopic": "MCP Toolbox server version in integration tests"`, will continue to clearly indicate that the PR is updating the MCP Toolbox server version.


This change will ensure a cleaner PR workflow for `genai-toolbox` updates going forward.