### PR TITLE
docs: Add documentation for MCP protocol support

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -136,6 +136,10 @@ The SDK supports multiple transport protocols for communicating with the Toolbox
 
 You can explicitly select a protocol using the `core.WithProtocol` option during client initialization. This is useful if you need to use the native Toolbox HTTP protocol or pin the client to a specific legacy version of MCP.
 
+> [!NOTE]
+> * **Native Toolbox Transport**: This uses the service's native **REST over HTTP** API.
+> * **MCP Transports**: These options use the **Model Context Protocol over HTTP**.
+
 ### Supported Protocols
 
 | Constant | Description |
@@ -168,7 +172,6 @@ client, err := core.NewToolboxClient(
     core.WithProtocol(core.MCPv20250326),
 )
 ```
-
 
 ## Loading Tools
 

--- a/tbadk/README.md
+++ b/tbadk/README.md
@@ -132,6 +132,10 @@ The SDK supports multiple transport protocols. By default, the client uses the l
 
 You can explicitly select a protocol using the `core.WithProtocol` option during client initialization.
 
+> [!NOTE]
+> * **Native Toolbox Transport**: This uses the service's native **REST over HTTP** API.
+> * **MCP Transports**: These options use the **Model Context Protocol over HTTP**.
+
 ### Supported Protocols
 
 | Constant | Description |


### PR DESCRIPTION
Adds documentation for the MCP Protocol Support in MCP Toolbox Go SDK