### PR TITLE
chore: Fix renovate to update toolbox server

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -45,7 +45,9 @@
     {
       customType: 'regex',
       managerFilePatterns: [
-        '**/integration.cloudbuild.yaml',
+        '/core/integration.cloudbuild.yaml',
+        '/tbadk/integration.cloudbuild.yaml',
+        '/tbgenkit/integration.cloudbuild.yaml',
       ],
       matchStrings: [
         '_TOOLBOX_VERSION: [\'|"]?(?<currentValue>v?\\d+\\.\\d+\\.\\d+)[\'|"]?',


### PR DESCRIPTION
Fixed renovate to update toolbox server in the integration cloud build config on every server release.

This fix is required due to regex failure in the recent multi module refactor