### PR TITLE
feat(core): OTel Instrumentation as per MCP Semantic Convention

### DIFF
--- a/core/client.go
+++ b/core/client.go
@@ -43,6 +43,7 @@ type ToolboxClient struct {
 	defaultOptionsSet   bool
 	clientName          string
 	clientVersion       string
+	telemetryEnabled    bool
 }
 
 // NewToolboxClient creates and configures a new, immutable client for interacting with a
@@ -90,13 +91,13 @@ func NewToolboxClient(url string, opts ...ClientOption) (*ToolboxClient, error) 
 
 	switch tc.protocol {
 	case MCPv20251125:
-		tc.transport, transportErr = mcp20251125.New(tc.baseURL, tc.httpClient, tc.clientName, tc.clientVersion)
+		tc.transport, transportErr = mcp20251125.New(tc.baseURL, tc.httpClient, tc.clientName, tc.clientVersion, tc.telemetryEnabled)
 	case MCPv20250618:
-		tc.transport, transportErr = mcp20250618.New(tc.baseURL, tc.httpClient, tc.clientName, tc.clientVersion)
+		tc.transport, transportErr = mcp20250618.New(tc.baseURL, tc.httpClient, tc.clientName, tc.clientVersion, tc.telemetryEnabled)
 	case MCPv20250326:
-		tc.transport, transportErr = mcp20250326.New(tc.baseURL, tc.httpClient, tc.clientName, tc.clientVersion)
+		tc.transport, transportErr = mcp20250326.New(tc.baseURL, tc.httpClient, tc.clientName, tc.clientVersion, tc.telemetryEnabled)
 	case MCPv20241105:
-		tc.transport, transportErr = mcp20241105.New(tc.baseURL, tc.httpClient, tc.clientName, tc.clientVersion)
+		tc.transport, transportErr = mcp20241105.New(tc.baseURL, tc.httpClient, tc.clientName, tc.clientVersion, tc.telemetryEnabled)
 	default:
 		return nil, fmt.Errorf("unsupported protocol version: %s", tc.protocol)
 	}
@@ -207,6 +208,12 @@ func (tc *ToolboxClient) newToolboxTool(
 	}
 
 	return tt, usedAuthKeys, usedBoundKeys, nil
+}
+
+// Close releases transport resources and records session duration telemetry
+// (if enabled). Call this when the client is no longer needed.
+func (tc *ToolboxClient) Close(ctx context.Context) error {
+	return tc.transport.Close(ctx)
 }
 
 // LoadTool fetches a manifest for a single tool

--- a/core/go.mod
+++ b/core/go.mod
@@ -7,6 +7,10 @@ require (
 	cloud.google.com/go/storage v1.61.3
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.11.1
+	go.opentelemetry.io/otel v1.40.0
+	go.opentelemetry.io/otel/metric v1.40.0
+	go.opentelemetry.io/otel/sdk v1.40.0
+	go.opentelemetry.io/otel/trace v1.40.0
 	golang.org/x/oauth2 v0.36.0
 	google.golang.org/api v0.272.0
 )
@@ -41,11 +45,7 @@ require (
 	go.opentelemetry.io/contrib/detectors/gcp v1.39.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.63.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
-	go.opentelemetry.io/otel v1.40.0 // indirect
-	go.opentelemetry.io/otel/metric v1.40.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.40.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.40.0 // indirect
-	go.opentelemetry.io/otel/trace v1.40.0 // indirect
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect

--- a/core/go.sum
+++ b/core/go.sum
@@ -101,6 +101,8 @@ go.opentelemetry.io/otel/sdk/metric v1.40.0 h1:mtmdVqgQkeRxHgRv4qhyJduP3fYJRMX4A
 go.opentelemetry.io/otel/sdk/metric v1.40.0/go.mod h1:4Z2bGMf0KSK3uRjlczMOeMhKU2rhUqdWNoKcYrtcBPg=
 go.opentelemetry.io/otel/trace v1.40.0 h1:WA4etStDttCSYuhwvEa8OP8I5EWu24lkOzp+ZYblVjw=
 go.opentelemetry.io/otel/trace v1.40.0/go.mod h1:zeAhriXecNGP/s2SEG3+Y8X9ujcJOTqQ5RgdEJcawiA=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=
 golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
 golang.org/x/net v0.52.0 h1:He/TN1l0e4mmR3QqHMT2Xab3Aj3L9qjbhRm78/6jrW0=

--- a/core/options.go
+++ b/core/options.go
@@ -101,6 +101,20 @@ func WithClientHeaderTokenSource(headerName string, value oauth2.TokenSource) Cl
 	}
 }
 
+// WithTelemetry enables OpenTelemetry tracing and metrics for MCP operations,
+// following the MCP Semantic Conventions:
+// https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp
+//
+// Configure your application's global TracerProvider and MeterProvider before
+// creating the client. When no provider is configured, OTel's no-op
+// implementation is used — no data is exported and there is zero overhead.
+func WithTelemetry(enabled bool) ClientOption {
+	return func(tc *ToolboxClient) error {
+		tc.telemetryEnabled = enabled
+		return nil
+	}
+}
+
 // WithDefaultToolOptions provides default Options that will be applied to every tool
 // loaded by this client.
 func WithDefaultToolOptions(opts ...ToolOption) ClientOption {

--- a/core/tool_test.go
+++ b/core/tool_test.go
@@ -40,7 +40,8 @@ type dummyTransport struct {
 	baseURL string
 }
 
-func (d *dummyTransport) BaseURL() string { return d.baseURL }
+func (d *dummyTransport) BaseURL() string                    { return d.baseURL }
+func (d *dummyTransport) Close(ctx context.Context) error   { return nil }
 func (d *dummyTransport) GetTool(ctx context.Context, name string, h map[string]string) (*transport.ManifestSchema, error) {
 	return nil, nil
 }
@@ -668,7 +669,7 @@ type mcpToolCallParams struct {
 func TestToolboxTool_Invoke(t *testing.T) {
 	// A base tool for successful invocations
 	createBaseTool := func(httpClient *http.Client, baseURL string) *ToolboxTool {
-		tr, _ := mcp.New(baseURL, httpClient, "test-client", "1.0.0")
+		tr, _ := mcp.New(baseURL, httpClient, "test-client", "1.0.0", false)
 
 		return &ToolboxTool{
 			name:        "weather",
@@ -1039,7 +1040,7 @@ func TestToolboxTool_Invoke_HttpsWarning(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			buf.Reset()
-			tr, _ := mcp.New(tt.baseURL, http.DefaultClient, "test-client", "1.0.0")
+			tr, _ := mcp.New(tt.baseURL, http.DefaultClient, "test-client", "1.0.0", false)
 
 			tool := &ToolboxTool{
 				name:      "test-tool",

--- a/core/transport/interface.go
+++ b/core/transport/interface.go
@@ -29,4 +29,7 @@ type Transport interface {
 
 	// InvokeTool executes a tool.
 	InvokeTool(ctx context.Context, toolName string, payload map[string]any, headers map[string]string) (any, error)
+
+	// Close releases transport resources and records session duration telemetry.
+	Close(ctx context.Context) error
 }

--- a/core/transport/mcp/base.go
+++ b/core/transport/mcp/base.go
@@ -22,6 +22,10 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport"
 )
@@ -32,6 +36,12 @@ type ToolContent struct {
 	Text string `json:"text"`
 }
 
+// sessionInfo holds state that is known only after the MCP handshake completes.
+type sessionInfo struct {
+	startTime       time.Time
+	protocolVersion string
+}
+
 // BaseMcpTransport holds the common state and logic for MCP HTTP transports.
 type BaseMcpTransport struct {
 	baseURL       string
@@ -39,10 +49,17 @@ type BaseMcpTransport struct {
 	ServerVersion string
 	initOnce      sync.Once
 	initErr       error
+	session       sessionInfo
 
 	// HandshakeHook is the abstract method _initialize_session.
 	// The specific version implementation will assign this function.
 	HandshakeHook func(ctx context.Context, headers map[string]string) error
+
+	// Telemetry instruments. Non-nil only when telemetry is enabled.
+	TelemetryEnabled           bool
+	Tracer                     trace.Tracer
+	OperationDurationHistogram metric.Float64Histogram
+	SessionDurationHistogram   metric.Float64Histogram
 }
 
 // BaseURL returns the base URL for the transport.
@@ -51,7 +68,7 @@ func (b *BaseMcpTransport) BaseURL() string {
 }
 
 // NewBaseTransport creates a new base transport.
-func NewBaseTransport(baseURL string, client *http.Client) (*BaseMcpTransport, error) {
+func NewBaseTransport(baseURL string, client *http.Client, telemetryEnabled bool) (*BaseMcpTransport, error) {
 	if client == nil {
 		client = &http.Client{}
 	}
@@ -76,10 +93,17 @@ func NewBaseTransport(baseURL string, client *http.Client) (*BaseMcpTransport, e
 	// Ensure trailing slash
 	fullURL += "/"
 
-	return &BaseMcpTransport{
-		baseURL:    fullURL,
-		HTTPClient: client,
-	}, nil
+	t := &BaseMcpTransport{
+		baseURL:          fullURL,
+		HTTPClient:       client,
+		TelemetryEnabled: telemetryEnabled,
+	}
+
+	if telemetryEnabled {
+		t.Tracer, t.OperationDurationHistogram, t.SessionDurationHistogram = InitTelemetry(SDKVersion)
+	}
+
+	return t, nil
 }
 
 // EnsureInitialized guarantees the session is ready before making requests.
@@ -92,6 +116,23 @@ func (b *BaseMcpTransport) EnsureInitialized(ctx context.Context, headers map[st
 		}
 	})
 	return b.initErr
+}
+
+// StartSession records the protocol version and session start time after the
+// MCP handshake completes. It should be called once per session from within
+// initializeSession when telemetry is enabled.
+func (b *BaseMcpTransport) StartSession(protocolVersion string) {
+	b.session = sessionInfo{startTime: time.Now(), protocolVersion: protocolVersion}
+}
+
+// Close records the session duration metric (if telemetry is enabled) and
+// releases any resources held by the transport.
+func (b *BaseMcpTransport) Close(ctx context.Context) error {
+	if b.TelemetryEnabled && !b.session.startTime.IsZero() {
+		duration := time.Since(b.session.startTime).Seconds()
+		RecordSessionDuration(ctx, b.SessionDurationHistogram, duration, b.session.protocolVersion, b.baseURL, nil)
+	}
+	return nil
 }
 
 // ProcessToolResultContent processes the tool result content, handling multiple JSON objects.

--- a/core/transport/mcp/base_test.go
+++ b/core/transport/mcp/base_test.go
@@ -57,7 +57,7 @@ func TestNewBaseTransport(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			tr, _ := NewBaseTransport(tc.baseURL, nil)
+			tr, _ := NewBaseTransport(tc.baseURL, nil, false)
 			if tr.BaseURL() != tc.expected {
 				t.Errorf("Expected URL %s, got %s", tc.expected, tr.BaseURL())
 			}
@@ -70,7 +70,7 @@ func TestNewBaseTransport(t *testing.T) {
 
 func TestEnsureInitialized(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		tr, _ := NewBaseTransport("http://example.com", nil)
+		tr, _ := NewBaseTransport("http://example.com", nil, false)
 		called := 0
 
 		testHeaders := map[string]string{"Authorization": "Bearer test"}
@@ -100,7 +100,7 @@ func TestEnsureInitialized(t *testing.T) {
 	})
 
 	t.Run("Failure", func(t *testing.T) {
-		tr, _ := NewBaseTransport("http://example.com", nil)
+		tr, _ := NewBaseTransport("http://example.com", nil, false)
 		expectedErr := errors.New("handshake failed")
 		tr.HandshakeHook = func(ctx context.Context, headers map[string]string) error {
 			return expectedErr
@@ -117,7 +117,7 @@ func TestEnsureInitialized(t *testing.T) {
 	})
 
 	t.Run("MissingHook", func(t *testing.T) {
-		tr, _ := NewBaseTransport("http://example.com", nil)
+		tr, _ := NewBaseTransport("http://example.com", nil, false)
 		// No hook defined
 		err := tr.EnsureInitialized(context.Background(), nil)
 		if err == nil {
@@ -127,7 +127,7 @@ func TestEnsureInitialized(t *testing.T) {
 }
 
 func TestConvertToolDefinition(t *testing.T) {
-	tr, _ := NewBaseTransport("http://example.com", nil)
+	tr, _ := NewBaseTransport("http://example.com", nil, false)
 
 	rawTool := map[string]any{
 		"name":        "complex_tool",
@@ -254,7 +254,7 @@ func TestConvertToolDefinition(t *testing.T) {
 }
 
 func TestConvertToolDefinitionWithDefaults(t *testing.T) {
-	tr, _ := NewBaseTransport("http://example.com", nil)
+	tr, _ := NewBaseTransport("http://example.com", nil, false)
 
 	rawTool := map[string]any{
 		"name": "default_tool",
@@ -311,7 +311,7 @@ func TestConvertToolDefinitionWithDefaults(t *testing.T) {
 
 func TestProcessToolResultContent(t *testing.T) {
 	// Setup a dummy transport (ProcessToolResultContent is a pure function, so state doesn't matter)
-	tr, _ := NewBaseTransport("http://example.com", nil)
+	tr, _ := NewBaseTransport("http://example.com", nil, false)
 
 	tests := []struct {
 		name     string
@@ -381,5 +381,51 @@ func TestProcessToolResultContent(t *testing.T) {
 				t.Errorf("\nExpected: %s\nGot:      %s", tc.expected, result)
 			}
 		})
+	}
+}
+
+// --------------------------------------------------------------------------
+// Close
+// --------------------------------------------------------------------------
+
+func TestClose_WithSessionStarted_RecordsSessionDuration(t *testing.T) {
+	tr, err := NewBaseTransport("http://example.com", nil, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Simulate that a session was started
+	tr.StartSession("2024-11-05")
+
+	// Close should not return an error
+	if err := tr.Close(context.Background()); err != nil {
+		t.Errorf("Close returned unexpected error: %v", err)
+	}
+}
+
+func TestClose_WithoutSessionStarted_DoesNotPanic(t *testing.T) {
+	tr, err := NewBaseTransport("http://example.com", nil, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// session.startTime is zero (not yet initialized) — Close should be a no-op
+
+	// Close should not panic or error when session was never started
+	if err := tr.Close(context.Background()); err != nil {
+		t.Errorf("Close returned unexpected error: %v", err)
+	}
+}
+
+func TestClose_WithTelemetryDisabled_DoesNotPanic(t *testing.T) {
+	tr, err := NewBaseTransport("http://example.com", nil, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Even with a session started, telemetry disabled should be a no-op
+	tr.StartSession("2024-11-05")
+	if err := tr.Close(context.Background()); err != nil {
+		t.Errorf("Close returned unexpected error: %v", err)
 	}
 }

--- a/core/transport/mcp/telemetry.go
+++ b/core/transport/mcp/telemetry.go
@@ -1,0 +1,291 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mcp provides OpenTelemetry telemetry utilities for the MCP protocol.
+//
+// This file implements telemetry following the MCP Semantic Conventions:
+// https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp
+//
+// To enable telemetry, configure OpenTelemetry in your application before
+// creating a ToolboxClient, then pass WithTelemetry(true) as a client option.
+// The SDK reads the globally configured TracerProvider and MeterProvider.
+// If no provider is configured, OpenTelemetry's no-op implementation is used:
+// no data is exported and there is zero overhead.
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/url"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// MCP semantic convention attribute names.
+// See: https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp
+const (
+	attrMCPMethodName       = "mcp.method.name"
+	attrMCPProtocolVersion  = "mcp.protocol.version"
+	attrMCPSessionID        = "mcp.session.id"
+	attrErrorType           = "error.type"
+	attrGenAIToolName       = "gen_ai.tool.name"
+	attrGenAIOperationName  = "gen_ai.operation.name"
+	attrGenAIPromptName     = "gen_ai.prompt.name"
+	attrServerAddress       = "server.address"
+	attrServerPort          = "server.port"
+	attrNetworkTransport    = "network.transport"
+	attrNetworkProtocolName = "network.protocol.name"
+
+	metricClientOperationDuration = "mcp.client.operation.duration"
+	metricClientSessionDuration   = "mcp.client.session.duration"
+	instrumentationScope          = "toolbox.mcp.sdk"
+)
+
+// SpanRef is an alias for trace.Span. Version-specific transport packages
+// use this type so they do not need to import the OTel trace package directly.
+type SpanRef = trace.Span
+
+// mcpDurationBuckets are the advisory histogram bucket boundaries (seconds).
+// See: https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/#metrics
+var mcpDurationBuckets = []float64{0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60, 120, 300}
+
+// InitTelemetry creates a Tracer, operation-duration Histogram, and
+// session-duration Histogram from the globally configured OTel providers.
+// If no provider is configured, OTel returns no-op instruments (zero
+// overhead, no data exported).
+func InitTelemetry(sdkVersion string) (trace.Tracer, metric.Float64Histogram, metric.Float64Histogram) {
+	tracer := otel.GetTracerProvider().Tracer(
+		instrumentationScope,
+		trace.WithInstrumentationVersion(sdkVersion),
+	)
+	meter := otel.GetMeterProvider().Meter(
+		instrumentationScope,
+		metric.WithInstrumentationVersion(sdkVersion),
+	)
+	opHist, err := meter.Float64Histogram(
+		metricClientOperationDuration,
+		metric.WithUnit("s"),
+		metric.WithDescription("Duration of MCP client operations (requests/notifications) from the time it was sent until the response or ack is received."),
+		metric.WithExplicitBucketBoundaries(mcpDurationBuckets...),
+	)
+	if err != nil {
+		log.Printf("toolbox-sdk: warning: failed to create %s histogram: %v", metricClientOperationDuration, err)
+	}
+	sessionHist, err := meter.Float64Histogram(
+		metricClientSessionDuration,
+		metric.WithUnit("s"),
+		metric.WithDescription("Total duration of MCP client sessions"),
+		metric.WithExplicitBucketBoundaries(mcpDurationBuckets...),
+	)
+	if err != nil {
+		log.Printf("toolbox-sdk: warning: failed to create %s histogram: %v", metricClientSessionDuration, err)
+	}
+	return tracer, opHist, sessionHist
+}
+
+// StartSpan creates an OTel client span for an MCP operation and extracts W3C
+// trace context headers for propagation to the server via the JSON-RPC _meta
+// field.
+//
+// The span must be closed by calling EndSpan when the operation completes.
+// Returns (nil, "", "") if the tracer is nil or span creation fails.
+//
+// See: https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/#context-propagation
+func StartSpan(
+	ctx context.Context,
+	tracer trace.Tracer,
+	methodName, protocolVersion, serverURL, toolName string,
+) (span trace.Span, traceparent, tracestate string) {
+	if tracer == nil {
+		return nil, "", ""
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("toolbox-sdk: warning: StartSpan failed: %v", r)
+			// clean up span if it was created to prevent memory leaks
+			if span != nil {
+				span.End()
+			}
+			span = nil
+			traceparent = ""
+			tracestate = ""
+		}
+	}()
+
+	spanName := methodName
+	if toolName != "" {
+		spanName = methodName + " " + toolName
+	}
+
+	_, span = tracer.Start(ctx, spanName, trace.WithSpanKind(trace.SpanKindClient))
+
+	host, port, scheme := extractServerInfo(serverURL)
+	span.SetAttributes(
+		attribute.String(attrMCPMethodName, methodName),
+		attribute.String(attrMCPProtocolVersion, protocolVersion),
+		attribute.String(attrServerAddress, host),
+		attribute.String(attrNetworkProtocolName, scheme),
+		attribute.String(attrNetworkTransport, "tcp"),
+	)
+	if port > 0 {
+		span.SetAttributes(attribute.Int(attrServerPort, port))
+	}
+	if toolName != "" {
+		span.SetAttributes(attribute.String(attrGenAIToolName, toolName))
+	}
+	if methodName == "tools/call" {
+		span.SetAttributes(attribute.String(attrGenAIOperationName, "execute_tool"))
+	}
+
+	// Activate the span temporarily to extract W3C traceparent/tracestate.
+	// These are injected into the JSON-RPC _meta field for server-side linking.
+	// See: https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/#context-propagation
+	spanCtx := trace.ContextWithSpan(ctx, span)
+	carrier := propagation.MapCarrier{}
+	propagation.TraceContext{}.Inject(spanCtx, carrier)
+	traceparent = carrier.Get("traceparent")
+	tracestate = carrier.Get("tracestate")
+
+	return span, traceparent, tracestate
+}
+
+// EndSpan ends a telemetry span. Safe to call with a nil span.
+// Sets error status and error.type attribute if err is non-nil.
+func EndSpan(span trace.Span, err error) {
+	if span == nil {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("toolbox-sdk: warning: EndSpan failed: %v", r)
+		}
+	}()
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		span.SetAttributes(attribute.String(attrErrorType, fmt.Sprintf("%T", err)))
+	}
+	span.End()
+}
+
+// RecordOperationDuration records the mcp.client.operation.duration metric.
+// Safe to call with a nil histogram.
+func RecordOperationDuration(
+	ctx context.Context,
+	hist metric.Float64Histogram,
+	durationSeconds float64,
+	methodName, protocolVersion, serverURL, toolName string,
+	err error,
+) {
+	if hist == nil {
+		return
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("toolbox-sdk: warning: RecordOperationDuration failed: %v", r)
+		}
+	}()
+
+	host, port, scheme := extractServerInfo(serverURL)
+	attrs := []attribute.KeyValue{
+		attribute.String(attrMCPMethodName, methodName),
+		attribute.String(attrMCPProtocolVersion, protocolVersion),
+		attribute.String(attrServerAddress, host),
+		attribute.String(attrNetworkProtocolName, scheme),
+		attribute.String(attrNetworkTransport, "tcp"),
+	}
+	if port > 0 {
+		attrs = append(attrs, attribute.Int(attrServerPort, port))
+	}
+	if toolName != "" {
+		attrs = append(attrs, attribute.String(attrGenAIToolName, toolName))
+	}
+	if methodName == "tools/call" {
+		attrs = append(attrs, attribute.String(attrGenAIOperationName, "execute_tool"))
+	}
+	if err != nil {
+		attrs = append(attrs, attribute.String(attrErrorType, fmt.Sprintf("%T", err)))
+	}
+	hist.Record(ctx, durationSeconds, metric.WithAttributes(attrs...))
+}
+
+// RecordSessionDuration records the mcp.client.session.duration metric.
+// Should be called when the transport session is closed.
+// Safe to call with a nil histogram.
+func RecordSessionDuration(
+	ctx context.Context,
+	hist metric.Float64Histogram,
+	durationSeconds float64,
+	protocolVersion, serverURL string,
+	err error,
+) {
+	if hist == nil {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("toolbox-sdk: warning: RecordSessionDuration failed: %v", r)
+		}
+	}()
+
+	host, port, scheme := extractServerInfo(serverURL)
+	attrs := []attribute.KeyValue{
+		attribute.String(attrMCPProtocolVersion, protocolVersion),
+		attribute.String(attrServerAddress, host),
+		attribute.String(attrNetworkProtocolName, scheme),
+		attribute.String(attrNetworkTransport, "tcp"),
+	}
+	if port > 0 {
+		attrs = append(attrs, attribute.Int(attrServerPort, port))
+	}
+	if err != nil {
+		attrs = append(attrs, attribute.String(attrErrorType, fmt.Sprintf("%T", err)))
+	}
+	hist.Record(ctx, durationSeconds, metric.WithAttributes(attrs...))
+}
+
+// RecordErrorFromJSONRPC marks the span as failed using a JSON-RPC error
+// response. Sets error.type to "jsonrpc.error.{code}" on the span.
+func RecordErrorFromJSONRPC(span trace.Span, errorCode int, errorMessage string) {
+	span.SetStatus(codes.Error, errorMessage)
+	span.SetAttributes(attribute.String(attrErrorType, fmt.Sprintf("jsonrpc.error.%d", errorCode)))
+}
+
+// extractServerInfo parses rawURL and returns the hostname, port, and scheme.
+func extractServerInfo(rawURL string) (host string, port int, scheme string) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL, 0, "http"
+	}
+	scheme = u.Scheme
+	if scheme == "" {
+		scheme = "http"
+	}
+	host = u.Hostname()
+	if host == "" {
+		host = u.Host
+	}
+	portStr := u.Port()
+	if portStr != "" {
+		fmt.Sscanf(portStr, "%d", &port) //nolint:errcheck
+	}
+	return
+}

--- a/core/transport/mcp/telemetry_test.go
+++ b/core/transport/mcp/telemetry_test.go
@@ -1,0 +1,302 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unit
+
+package mcp
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// newTestTracer returns a real SDK tracer backed by an in-memory span exporter
+// so tests can assert on span attributes without a real OTel backend.
+func newTestTracer(t *testing.T) (*tracetest.InMemoryExporter, *sdktrace.TracerProvider) {
+	t.Helper()
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	return exp, tp
+}
+
+// --------------------------------------------------------------------------
+// extractServerInfo
+// --------------------------------------------------------------------------
+
+func TestExtractServerInfo(t *testing.T) {
+	tests := []struct {
+		name       string
+		rawURL     string
+		wantHost   string
+		wantPort   int
+		wantScheme string
+	}{
+		{
+			name:       "http with explicit port",
+			rawURL:     "http://localhost:8080/mcp/",
+			wantHost:   "localhost",
+			wantPort:   8080,
+			wantScheme: "http",
+		},
+		{
+			name:       "https without explicit port",
+			rawURL:     "https://example.com/mcp/",
+			wantHost:   "example.com",
+			wantPort:   0,
+			wantScheme: "https",
+		},
+		{
+			name:       "path-only URL defaults scheme to http",
+			rawURL:     "/mcp/",
+			wantHost:   "",
+			wantPort:   0,
+			wantScheme: "http",
+		},
+		{
+			name:       "empty string returns defaults",
+			rawURL:     "",
+			wantHost:   "",
+			wantPort:   0,
+			wantScheme: "http",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			host, port, scheme := extractServerInfo(tc.rawURL)
+			if host != tc.wantHost {
+				t.Errorf("host: got %q, want %q", host, tc.wantHost)
+			}
+			if port != tc.wantPort {
+				t.Errorf("port: got %d, want %d", port, tc.wantPort)
+			}
+			if scheme != tc.wantScheme {
+				t.Errorf("scheme: got %q, want %q", scheme, tc.wantScheme)
+			}
+		})
+	}
+}
+
+// --------------------------------------------------------------------------
+// InitTelemetry
+// --------------------------------------------------------------------------
+
+func TestInitTelemetry_ReturnsInstruments(t *testing.T) {
+	tracer, opHist, sessHist := InitTelemetry("v0.1.0")
+	if tracer == nil {
+		t.Error("expected non-nil tracer")
+	}
+	if opHist == nil {
+		t.Error("expected non-nil operation duration histogram")
+	}
+	if sessHist == nil {
+		t.Error("expected non-nil session duration histogram")
+	}
+}
+
+// --------------------------------------------------------------------------
+// StartSpan
+// --------------------------------------------------------------------------
+
+func TestStartSpan_SpanAttributes(t *testing.T) {
+	exp, tp := newTestTracer(t)
+	tracer := tp.Tracer(instrumentationScope)
+
+	ctx := context.Background()
+	span, _, _ := StartSpan(ctx, tracer, "tools/call", "2024-11-05", "http://localhost:8080/mcp/", "my-tool")
+	EndSpan(span, nil)
+
+	spans := exp.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	got := spans[0]
+
+	if got.Name != "tools/call my-tool" {
+		t.Errorf("span name: got %q, want %q", got.Name, "tools/call my-tool")
+	}
+
+	attrMap := make(map[string]string)
+	for _, a := range got.Attributes {
+		attrMap[string(a.Key)] = a.Value.AsString()
+	}
+
+	checks := map[string]string{
+		attrMCPMethodName:       "tools/call",
+		attrMCPProtocolVersion:  "2024-11-05",
+		attrGenAIToolName:       "my-tool",
+		attrGenAIOperationName:  "execute_tool",
+		attrServerAddress:       "localhost",
+		attrNetworkProtocolName: "http",
+		attrNetworkTransport:    "tcp",
+	}
+	for key, want := range checks {
+		if got := attrMap[key]; got != want {
+			t.Errorf("attribute %s: got %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestStartSpan_NoToolName(t *testing.T) {
+	exp, tp := newTestTracer(t)
+	tracer := tp.Tracer(instrumentationScope)
+
+	ctx := context.Background()
+	span, _, _ := StartSpan(ctx, tracer, "tools/list", "2024-11-05", "http://localhost:8080/mcp/", "")
+	EndSpan(span, nil)
+
+	spans := exp.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	if spans[0].Name != "tools/list" {
+		t.Errorf("span name: got %q, want %q", spans[0].Name, "tools/list")
+	}
+}
+
+func TestStartSpan_NilTracer_ReturnsNilAndEmptyStrings(t *testing.T) {
+	ctx := context.Background()
+	span, traceparent, tracestate := StartSpan(ctx, nil, "tools/call", "2024-11-05", "http://localhost/", "tool")
+
+	if span != nil {
+		t.Error("expected nil span for nil tracer")
+	}
+	if traceparent != "" {
+		t.Error("expected empty traceparent for nil tracer")
+	}
+	if tracestate != "" {
+		t.Error("expected empty tracestate for nil tracer")
+	}
+}
+
+func TestStartSpan_PropagatesTraceContext(t *testing.T) {
+	_, tp := newTestTracer(t)
+	tracer := tp.Tracer(instrumentationScope)
+
+	ctx := context.Background()
+	span, traceparent, _ := StartSpan(ctx, tracer, "tools/call", "2024-11-05", "http://localhost:8080/mcp/", "my-tool")
+	EndSpan(span, nil)
+
+	// traceparent should be a non-empty W3C header (format: 00-<trace>-<span>-<flags>)
+	if traceparent == "" {
+		t.Error("expected non-empty traceparent for active span")
+	}
+}
+
+// --------------------------------------------------------------------------
+// EndSpan
+// --------------------------------------------------------------------------
+
+func TestEndSpan_NilSpan_DoesNotPanic(t *testing.T) {
+	EndSpan(nil, nil)
+	EndSpan(nil, errors.New("ignored"))
+}
+
+func TestEndSpan_SetsErrorAttributesOnFailure(t *testing.T) {
+	exp, tp := newTestTracer(t)
+	tracer := tp.Tracer(instrumentationScope)
+
+	ctx := context.Background()
+	span, _, _ := StartSpan(ctx, tracer, "tools/call", "2024-11-05", "http://localhost:8080/mcp/", "bad-tool")
+	EndSpan(span, errors.New("something went wrong"))
+
+	spans := exp.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+
+	found := false
+	for _, a := range spans[0].Attributes {
+		if string(a.Key) == attrErrorType {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected error.type attribute to be set on span when error is passed")
+	}
+}
+
+// --------------------------------------------------------------------------
+// RecordOperationDuration
+// --------------------------------------------------------------------------
+
+func TestRecordOperationDuration_NilHistogram_DoesNotPanic(t *testing.T) {
+	ctx := context.Background()
+	RecordOperationDuration(ctx, nil, 0.5, "tools/call", "2024-11-05", "http://localhost/mcp/", "tool", nil)
+	RecordOperationDuration(ctx, nil, 0.5, "tools/call", "2024-11-05", "http://localhost/mcp/", "tool", errors.New("err"))
+}
+
+func TestRecordOperationDuration_RecordsWithAttributes(t *testing.T) {
+	ctx := context.Background()
+	_, opHist, _ := InitTelemetry("v0.1.0")
+	// Smoke test: verify it runs without panicking
+	RecordOperationDuration(ctx, opHist, 0.123, "tools/call", "2024-11-05", "http://localhost:8080/mcp/", "my-tool", nil)
+	RecordOperationDuration(ctx, opHist, 0.456, "tools/list", "2024-11-05", "http://localhost:8080/mcp/", "", errors.New("err"))
+}
+
+// --------------------------------------------------------------------------
+// RecordErrorFromJSONRPC
+// --------------------------------------------------------------------------
+
+func TestRecordErrorFromJSONRPC(t *testing.T) {
+	exp, tp := newTestTracer(t)
+	tracer := tp.Tracer(instrumentationScope)
+
+	ctx := context.Background()
+	_, span := tracer.Start(ctx, "test-span")
+	RecordErrorFromJSONRPC(span, -32600, "Invalid Request")
+	span.End()
+
+	spans := exp.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+
+	attrMap := make(map[string]string)
+	for _, a := range spans[0].Attributes {
+		attrMap[string(a.Key)] = a.Value.AsString()
+	}
+
+	wantErrorType := "jsonrpc.error.-32600"
+	if got := attrMap[attrErrorType]; got != wantErrorType {
+		t.Errorf("error.type: got %q, want %q", got, wantErrorType)
+	}
+}
+
+// --------------------------------------------------------------------------
+// RecordSessionDuration
+// --------------------------------------------------------------------------
+
+func TestRecordSessionDuration_NilHistogram_DoesNotPanic(t *testing.T) {
+	ctx := context.Background()
+	RecordSessionDuration(ctx, nil, 1.5, "2024-11-05", "http://localhost/mcp/", nil)
+	RecordSessionDuration(ctx, nil, 1.5, "2024-11-05", "http://localhost/mcp/", errors.New("err"))
+}
+
+func TestRecordSessionDuration_WithError(t *testing.T) {
+	ctx := context.Background()
+	_, _, sessHist := InitTelemetry("v0.1.0")
+	RecordSessionDuration(ctx, sessHist, 3.14, "2024-11-05", "http://localhost:8080/mcp/", errors.New("connection reset"))
+}
+
+func TestRecordSessionDuration_NoError(t *testing.T) {
+	ctx := context.Background()
+	_, _, sessHist := InitTelemetry("v0.1.0")
+	RecordSessionDuration(ctx, sessHist, 10.0, "2025-06-18", "https://example.com/mcp/", nil)
+}

--- a/core/transport/mcp/v20241105/mcp.go
+++ b/core/transport/mcp/v20241105/mcp.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport"
@@ -44,8 +45,8 @@ type McpTransport struct {
 }
 
 // New creates a new version-specific transport instance.
-func New(baseURL string, client *http.Client, clientName string, clientVersion string) (*McpTransport, error) {
-	baseTransport, err := mcp.NewBaseTransport(baseURL, client)
+func New(baseURL string, client *http.Client, clientName string, clientVersion string, telemetryEnabled bool) (*McpTransport, error) {
+	baseTransport, err := mcp.NewBaseTransport(baseURL, client, telemetryEnabled)
 	if err != nil {
 		return nil, err
 	}
@@ -65,34 +66,52 @@ func New(baseURL string, client *http.Client, clientName string, clientVersion s
 	return t, nil
 }
 
-// ListTools fetches available tools
-func (t *McpTransport) ListTools(ctx context.Context, toolsetName string, headers map[string]string) (*transport.ManifestSchema, error) {
-	if err := t.EnsureInitialized(ctx, headers); err != nil {
+// ListTools fetches available tools.
+func (t *McpTransport) ListTools(ctx context.Context, toolsetName string, headers map[string]string) (manifest *transport.ManifestSchema, err error) {
+	if err = t.EnsureInitialized(ctx, headers); err != nil {
 		return nil, err
 	}
 
 	requestURL := t.BaseURL()
 	if toolsetName != "" {
-		var err error
 		requestURL, err = url.JoinPath(requestURL, toolsetName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to construct toolset URL: %w", err)
 		}
 	}
 
+	// Start telemetry span before the operation. In the finally-equivalent defer,
+	// record the operation duration metric and end the span.
+	var traceparent, tracestate string
+	if t.TelemetryEnabled {
+		var span mcp.SpanRef
+		operationStart := time.Now()
+		span, traceparent, tracestate = mcp.StartSpan(ctx, t.Tracer, "tools/list", t.protocolVersion, requestURL, "")
+		defer func() {
+			mcp.RecordOperationDuration(ctx, t.OperationDurationHistogram, time.Since(operationStart).Seconds(), "tools/list", t.protocolVersion, requestURL, "", err)
+			mcp.EndSpan(span, err)
+		}()
+	}
+
+	var listParams listToolsRequestParams
+	if traceparent != "" || tracestate != "" {
+		listParams.Meta = &mcpMeta{Traceparent: traceparent, Tracestate: tracestate}
+	}
+
 	var result listToolsResult
-	if err := t.sendRequest(ctx, requestURL, "tools/list", map[string]any{}, headers, &result); err != nil {
+	if err = t.sendRequest(ctx, requestURL, "tools/list", listParams, headers, &result); err != nil {
 		return nil, fmt.Errorf("failed to list tools: %w", err)
 	}
 
-	manifest := &transport.ManifestSchema{
+	manifest = &transport.ManifestSchema{
 		ServerVersion: t.ServerVersion,
 		Tools:         make(map[string]transport.ToolSchema),
 	}
 
 	for i, tool := range result.Tools {
 		if tool.Name == "" {
-			return nil, fmt.Errorf("received invalid tool definition at index %d: missing 'name' field", i)
+			err = fmt.Errorf("received invalid tool definition at index %d: missing 'name' field", i)
+			return nil, err
 		}
 
 		rawTool := map[string]any{
@@ -105,7 +124,8 @@ func (t *McpTransport) ListTools(ctx context.Context, toolsetName string, header
 			rawTool["_meta"] = tool.Meta
 		}
 
-		toolSchema, err := t.ConvertToolDefinition(rawTool)
+		var toolSchema transport.ToolSchema
+		toolSchema, err = t.ConvertToolDefinition(rawTool)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert schema for tool %s: %w", tool.Name, err)
 		}
@@ -116,7 +136,7 @@ func (t *McpTransport) ListTools(ctx context.Context, toolsetName string, header
 	return manifest, nil
 }
 
-// GetTool fetches a single tool
+// GetTool fetches a single tool.
 func (t *McpTransport) GetTool(ctx context.Context, toolName string, headers map[string]string) (*transport.ManifestSchema, error) {
 	manifest, err := t.ListTools(ctx, "", headers)
 	if err != nil {
@@ -134,24 +154,44 @@ func (t *McpTransport) GetTool(ctx context.Context, toolName string, headers map
 	}, nil
 }
 
-// InvokeTool executes a tool
-func (t *McpTransport) InvokeTool(ctx context.Context, toolName string, payload map[string]any, headers map[string]string) (any, error) {
-	if err := t.EnsureInitialized(ctx, headers); err != nil {
+// InvokeTool executes a tool.
+func (t *McpTransport) InvokeTool(ctx context.Context, toolName string, payload map[string]any, headers map[string]string) (output any, err error) {
+	if err = t.EnsureInitialized(ctx, headers); err != nil {
 		return "", err
+	}
+
+	// Start telemetry span before the operation. In the finally-equivalent defer,
+	// record the operation duration metric and end the span.
+	var traceparent, tracestate string
+	if t.TelemetryEnabled {
+		var span mcp.SpanRef
+		operationStart := time.Now()
+		span, traceparent, tracestate = mcp.StartSpan(ctx, t.Tracer, "tools/call", t.protocolVersion, t.BaseURL(), toolName)
+		defer func() {
+			mcp.RecordOperationDuration(ctx, t.OperationDurationHistogram, time.Since(operationStart).Seconds(), "tools/call", t.protocolVersion, t.BaseURL(), toolName, err)
+			mcp.EndSpan(span, err)
+		}()
+	}
+
+	var meta *mcpMeta
+	if traceparent != "" || tracestate != "" {
+		meta = &mcpMeta{Traceparent: traceparent, Tracestate: tracestate}
 	}
 
 	params := callToolRequestParams{
 		Name:      toolName,
 		Arguments: payload,
+		Meta:      meta,
 	}
 
 	var result callToolResult
-	if err := t.sendRequest(ctx, t.BaseURL(), "tools/call", params, headers, &result); err != nil {
+	if err = t.sendRequest(ctx, t.BaseURL(), "tools/call", params, headers, &result); err != nil {
 		return "", fmt.Errorf("failed to invoke tool '%s': %w", toolName, err)
 	}
 
 	if result.IsError {
-		return "", fmt.Errorf("tool execution resulted in error")
+		err = fmt.Errorf("tool execution resulted in error")
+		return "", err
 	}
 
 	baseContent := make([]mcp.ToolContent, len(result.Content))
@@ -162,13 +202,30 @@ func (t *McpTransport) InvokeTool(ctx context.Context, toolName string, payload 
 		}
 	}
 
-	output := t.ProcessToolResultContent(baseContent)
-
-	return output, nil
+	return t.ProcessToolResultContent(baseContent), nil
 }
 
 // initializeSession performs the initial handshake with the server.
-func (t *McpTransport) initializeSession(ctx context.Context, headers map[string]string) error {
+func (t *McpTransport) initializeSession(ctx context.Context, headers map[string]string) (err error) {
+	// Start telemetry span before the operation. In the finally-equivalent defer,
+	// record the operation duration metric and end the span.
+	var traceparent, tracestate string
+	if t.TelemetryEnabled {
+		t.StartSession(ProtocolVersion)
+		var span mcp.SpanRef
+		operationStart := time.Now()
+		span, traceparent, tracestate = mcp.StartSpan(ctx, t.Tracer, "initialize", t.protocolVersion, t.BaseURL(), "")
+		defer func() {
+			mcp.RecordOperationDuration(ctx, t.OperationDurationHistogram, time.Since(operationStart).Seconds(), "initialize", t.protocolVersion, t.BaseURL(), "", err)
+			mcp.EndSpan(span, err)
+		}()
+	}
+
+	var meta *mcpMeta
+	if traceparent != "" || tracestate != "" {
+		meta = &mcpMeta{Traceparent: traceparent, Tracestate: tracestate}
+	}
+
 	params := initializeRequestParams{
 		ProtocolVersion: t.protocolVersion,
 		Capabilities:    clientCapabilities{},
@@ -176,27 +233,31 @@ func (t *McpTransport) initializeSession(ctx context.Context, headers map[string
 			Name:    t.clientName,
 			Version: t.clientVersion,
 		},
+		Meta: meta,
 	}
 
 	var result initializeResult
-	if err := t.sendRequest(ctx, t.BaseURL(), "initialize", params, headers, &result); err != nil {
+	if err = t.sendRequest(ctx, t.BaseURL(), "initialize", params, headers, &result); err != nil {
 		return err
 	}
 
 	// Protocol Version Check
 	if result.ProtocolVersion != t.protocolVersion {
-		return fmt.Errorf("MCP version mismatch: client (%s) != server (%s)", t.protocolVersion, result.ProtocolVersion)
+		err = fmt.Errorf("MCP version mismatch: client (%s) != server (%s)", t.protocolVersion, result.ProtocolVersion)
+		return err
 	}
 
 	// Capabilities Check
 	if result.Capabilities.Tools == nil {
-		return fmt.Errorf("server does not support the 'tools' capability")
+		err = fmt.Errorf("server does not support the 'tools' capability")
+		return err
 	}
 
 	t.ServerVersion = result.ServerInfo.Version
 
 	// Confirm Handshake
-	return t.sendNotification(ctx, "notifications/initialized", map[string]any{}, headers)
+	err = t.sendNotification(ctx, "notifications/initialized", map[string]any{}, headers)
+	return err
 }
 
 // sendRequest sends a standard JSON-RPC request to the server.

--- a/core/transport/mcp/v20241105/mcp_test.go
+++ b/core/transport/mcp/v20241105/mcp_test.go
@@ -23,13 +23,16 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport/mcp"
 	"testing"
 
 	"maps"
 
+	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 // mockMCPServer is a helper to mock MCP JSON-RPC responses
@@ -138,7 +141,7 @@ func TestListTools(t *testing.T) {
 		}, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0", false)
 	ctx := context.Background()
 
 	t.Run("Success", func(t *testing.T) {
@@ -175,7 +178,7 @@ func TestListTools_ErrorOnEmptyName(t *testing.T) {
 		}, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0", false)
 	_, err := client.ListTools(context.Background(), "", nil)
 
 	assert.Error(t, err)
@@ -195,7 +198,7 @@ func TestGetTool_Success(t *testing.T) {
 		}, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0", false)
 	manifest, err := client.GetTool(context.Background(), "tool_a", nil)
 	require.NoError(t, err)
 	assert.Contains(t, manifest.Tools, "tool_a")
@@ -210,7 +213,7 @@ func TestGetTool_NotFound(t *testing.T) {
 		return listToolsResult{Tools: []mcpTool{}}, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0", false)
 	_, err := client.GetTool(context.Background(), "missing_tool", nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
@@ -237,7 +240,7 @@ func TestInvokeTool(t *testing.T) {
 		}, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0", false)
 	ctx := context.Background()
 
 	t.Run("Success", func(t *testing.T) {
@@ -264,7 +267,7 @@ func TestProtocolMismatch(t *testing.T) {
 		}, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0", false)
 
 	_, err := client.ListTools(context.Background(), "", nil)
 	assert.Error(t, err)
@@ -283,7 +286,7 @@ func TestInitialize_MissingCapabilities(t *testing.T) {
 		}, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0", false)
 	_, err := client.ListTools(context.Background(), "", nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "does not support the 'tools' capability")
@@ -291,7 +294,7 @@ func TestInitialize_MissingCapabilities(t *testing.T) {
 
 func TestConvertToolSchema(t *testing.T) {
 	// Use the transport's ConvertToolDefinition which delegates to the base/helper logic
-	tr, _ := New("http://example.com", nil, "custom-client", "1.0.0")
+	tr, _ := New("http://example.com", nil, "custom-client", "1.0.0", false)
 
 	rawTool := map[string]any{
 		"name":        "complex_tool",
@@ -341,7 +344,7 @@ func TestListTools_WithToolset(t *testing.T) {
 		return listToolsResult{Tools: []mcpTool{}}, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0", false)
 	toolsetName := "my-toolset"
 
 	_, err := client.ListTools(context.Background(), toolsetName, nil)
@@ -354,7 +357,7 @@ func TestRequest_NetworkError(t *testing.T) {
 	url := server.URL
 	server.Close()
 
-	client, _ := New(url, server.Client(), "custom-client", "1.0.0")
+	client, _ := New(url, server.Client(), "custom-client", "1.0.0", false)
 	_, err := client.ListTools(context.Background(), "", nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "http request failed")
@@ -367,7 +370,7 @@ func TestRequest_ServerError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0", false)
 	_, err := client.ListTools(context.Background(), "", nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "API request failed with status 500")
@@ -380,7 +383,7 @@ func TestRequest_BadJSON(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0", false)
 	_, err := client.ListTools(context.Background(), "", nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "response unmarshal failed")
@@ -388,7 +391,7 @@ func TestRequest_BadJSON(t *testing.T) {
 
 func TestRequest_NewRequestError(t *testing.T) {
 	// Bad URL triggers http.NewRequest error
-	_, err := New("http://bad\nurl.com", http.DefaultClient, "custom-client", "1.0.0")
+	_, err := New("http://bad\nurl.com", http.DefaultClient, "custom-client", "1.0.0", false)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "invalid control character in URL")
 }
@@ -396,7 +399,7 @@ func TestRequest_NewRequestError(t *testing.T) {
 func TestRequest_MarshalError(t *testing.T) {
 	server := newMockMCPServer(t)
 	defer server.Close()
-	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0", false)
 
 	// Force initialization first
 	_ = client.EnsureInitialized(context.Background(), nil)
@@ -419,7 +422,7 @@ func TestInvokeTool_ErrorResult(t *testing.T) {
 		}, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0", false)
 	_, err := client.InvokeTool(context.Background(), "tool", nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "tool execution resulted in error")
@@ -433,7 +436,7 @@ func TestInvokeTool_RPCError(t *testing.T) {
 		return nil, errors.New("internal server error")
 	}
 
-	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0", false)
 	_, err := client.InvokeTool(context.Background(), "tool", nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "internal server error")
@@ -453,7 +456,7 @@ func TestInvokeTool_ComplexContent(t *testing.T) {
 		}, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0", false)
 	res, err := client.InvokeTool(context.Background(), "t", nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "Part 1 Part 2", res)
@@ -469,7 +472,7 @@ func TestInvokeTool_EmptyResult(t *testing.T) {
 		}, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0", false)
 	res, err := client.InvokeTool(context.Background(), "t", nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "null", res)
@@ -491,7 +494,7 @@ func TestInvokeTool_ContentProcessing_Scenarios(t *testing.T) {
 			}, nil
 		}
 
-		client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0")
+		client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0", false)
 		result, err := client.InvokeTool(context.Background(), "tool", nil, nil)
 		require.NoError(t, err)
 
@@ -515,7 +518,7 @@ func TestInvokeTool_ContentProcessing_Scenarios(t *testing.T) {
 			}, nil
 		}
 
-		client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0")
+		client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0", false)
 		result, err := client.InvokeTool(context.Background(), "tool", nil, nil)
 		require.NoError(t, err)
 
@@ -539,7 +542,7 @@ func TestInvokeTool_ContentProcessing_Scenarios(t *testing.T) {
 			}, nil
 		}
 
-		client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0")
+		client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0", false)
 		result, err := client.InvokeTool(context.Background(), "tool", nil, nil)
 		require.NoError(t, err)
 
@@ -549,7 +552,7 @@ func TestInvokeTool_ContentProcessing_Scenarios(t *testing.T) {
 }
 
 func TestEnsureInitialized_PassesHeaders(t *testing.T) {
-	tr, err := New("http://fake.com", nil, "custom-client", "1.0.0")
+	tr, err := New("http://fake.com", nil, "custom-client", "1.0.0", false)
 	require.NoError(t, err)
 
 	capturedHeaders := make(map[string]string)
@@ -601,7 +604,7 @@ func TestInitializeSession_PassesHeadersToWire(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	tr, err := New(ts.URL, ts.Client(), "custom-client", "1.0.0")
+	tr, err := New(ts.URL, ts.Client(), "custom-client", "1.0.0", false)
 	require.NoError(t, err)
 
 	testHeaders := map[string]string{"Authorization": "Bearer token"}
@@ -610,12 +613,166 @@ func TestInitializeSession_PassesHeadersToWire(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// --------------------------------------------------------------------------
+// Telemetry integration tests
+// --------------------------------------------------------------------------
+
+// setupRealTracerProvider installs a real in-memory TracerProvider as the
+// global provider for the duration of a test, then restores the previous one.
+// Returns the exporter so callers can assert on recorded spans.
+func setupRealTracerProvider(t *testing.T) *tracetest.InMemoryExporter {
+	t.Helper()
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { otel.SetTracerProvider(prev) })
+	return exp
+}
+
+func TestListTools_WithTelemetry_PropagatesTraceparent(t *testing.T) {
+	setupRealTracerProvider(t)
+
+	server := newMockMCPServer(t)
+	defer server.Close()
+
+	server.handlers["tools/list"] = func(params json.RawMessage) (any, error) {
+		return listToolsResult{Tools: []mcpTool{}}, nil
+	}
+
+	client, err := New(server.URL, server.Client(), "client", "1.0.0", true)
+	require.NoError(t, err)
+
+	_, err = client.ListTools(context.Background(), "", nil)
+	require.NoError(t, err)
+
+	// Find the tools/list request and verify _meta.traceparent is present
+	var toolsListReq *jsonRPCRequest
+	for i, r := range server.requests {
+		if r.Method == "tools/list" {
+			toolsListReq = &server.requests[i]
+			break
+		}
+	}
+	require.NotNil(t, toolsListReq, "expected tools/list request to be captured")
+
+	paramsBytes, err := json.Marshal(toolsListReq.Params)
+	require.NoError(t, err)
+
+	var params listToolsRequestParams
+	require.NoError(t, json.Unmarshal(paramsBytes, &params))
+
+	assert.NotNil(t, params.Meta, "expected _meta to be set when telemetry is enabled")
+	if params.Meta != nil {
+		assert.NotEmpty(t, params.Meta.Traceparent, "expected traceparent to be set in _meta")
+	}
+}
+
+func TestInvokeTool_WithTelemetry_PropagatesTraceparent(t *testing.T) {
+	setupRealTracerProvider(t)
+
+	server := newMockMCPServer(t)
+	defer server.Close()
+
+	server.handlers["tools/call"] = func(params json.RawMessage) (any, error) {
+		return callToolResult{
+			Content: []textContent{{Type: "text", Text: "ok"}},
+		}, nil
+	}
+
+	client, err := New(server.URL, server.Client(), "client", "1.0.0", true)
+	require.NoError(t, err)
+
+	_, err = client.InvokeTool(context.Background(), "my_tool", nil, nil)
+	require.NoError(t, err)
+
+	var callReq *jsonRPCRequest
+	for i, r := range server.requests {
+		if r.Method == "tools/call" {
+			callReq = &server.requests[i]
+			break
+		}
+	}
+	require.NotNil(t, callReq, "expected tools/call request to be captured")
+
+	paramsBytes, err := json.Marshal(callReq.Params)
+	require.NoError(t, err)
+
+	var params callToolRequestParams
+	require.NoError(t, json.Unmarshal(paramsBytes, &params))
+
+	assert.NotNil(t, params.Meta, "expected _meta to be set when telemetry is enabled")
+	if params.Meta != nil {
+		assert.NotEmpty(t, params.Meta.Traceparent, "expected traceparent to be set in _meta")
+	}
+}
+
+func TestInitializeSession_WithTelemetry_PropagatesTraceparent(t *testing.T) {
+	setupRealTracerProvider(t)
+
+	server := newMockMCPServer(t)
+	defer server.Close()
+
+	client, err := New(server.URL, server.Client(), "client", "1.0.0", true)
+	require.NoError(t, err)
+
+	// Trigger initialization via ListTools
+	server.handlers["tools/list"] = func(params json.RawMessage) (any, error) {
+		return listToolsResult{Tools: []mcpTool{}}, nil
+	}
+	_, err = client.ListTools(context.Background(), "", nil)
+	require.NoError(t, err)
+
+	// Find the initialize request
+	var initReq *jsonRPCRequest
+	for i, r := range server.requests {
+		if r.Method == "initialize" {
+			initReq = &server.requests[i]
+			break
+		}
+	}
+	require.NotNil(t, initReq, "expected initialize request to be captured")
+
+	paramsBytes, err := json.Marshal(initReq.Params)
+	require.NoError(t, err)
+
+	var params initializeRequestParams
+	require.NoError(t, json.Unmarshal(paramsBytes, &params))
+
+	assert.NotNil(t, params.Meta, "expected _meta to be set when telemetry is enabled")
+	if params.Meta != nil {
+		assert.NotEmpty(t, params.Meta.Traceparent, "expected traceparent to be set in _meta")
+	}
+}
+
+func TestClose_WithTelemetry_RecordsSessionDuration(t *testing.T) {
+	setupRealTracerProvider(t)
+
+	server := newMockMCPServer(t)
+	defer server.Close()
+
+	server.handlers["tools/list"] = func(params json.RawMessage) (any, error) {
+		return listToolsResult{Tools: []mcpTool{}}, nil
+	}
+
+	client, err := New(server.URL, server.Client(), "client", "1.0.0", true)
+	require.NoError(t, err)
+
+	// Trigger initialization (sets session info via StartSession)
+	_, err = client.ListTools(context.Background(), "", nil)
+	require.NoError(t, err)
+
+	// Close should not panic and should succeed
+	err = client.Close(context.Background())
+	assert.NoError(t, err)
+}
+
 func TestNew_ClientVersion(t *testing.T) {
 	clientName := "test-client"
 
 	t.Run("Test with explicit version", func(t *testing.T) {
 		explicitVersion := "2.0.0"
-		tr1, err := New("http://example.com", nil, clientName, explicitVersion)
+		tr1, err := New("http://example.com", nil, clientName, explicitVersion, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -626,7 +783,7 @@ func TestNew_ClientVersion(t *testing.T) {
 	})
 
 	t.Run("Test with empty version uses SDKVersion", func(t *testing.T) {
-		tr2, err := New("http://example.com", nil, clientName, "")
+		tr2, err := New("http://example.com", nil, clientName, "", false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/core/transport/mcp/v20241105/types.go
+++ b/core/transport/mcp/v20241105/types.go
@@ -61,11 +61,24 @@ type serverCapabilities struct {
 	Tools   map[string]any `json:"tools,omitempty"`
 }
 
+// mcpMeta carries OpenTelemetry trace context for MCP context propagation.
+// See: https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/#context-propagation
+type mcpMeta struct {
+	Traceparent string `json:"traceparent,omitempty"`
+	Tracestate  string `json:"tracestate,omitempty"`
+}
+
 // initializeRequestParams holds the parameters for the 'initialize' handshake.
 type initializeRequestParams struct {
 	ProtocolVersion string             `json:"protocolVersion"`
 	Capabilities    clientCapabilities `json:"capabilities"`
 	ClientInfo      implementation     `json:"clientInfo"`
+	Meta            *mcpMeta           `json:"_meta,omitempty"`
+}
+
+// listToolsRequestParams holds the parameters for the 'tools/list' method.
+type listToolsRequestParams struct {
+	Meta *mcpMeta `json:"_meta,omitempty"`
 }
 
 // initializeResult holds the response from the 'initialize' handshake.
@@ -93,6 +106,7 @@ type listToolsResult struct {
 type callToolRequestParams struct {
 	Name      string         `json:"name"`
 	Arguments map[string]any `json:"arguments"`
+	Meta      *mcpMeta       `json:"_meta,omitempty"`
 }
 
 // textContent represents a single text block in a tool's output.

--- a/core/transport/mcp/v20250326/mcp.go
+++ b/core/transport/mcp/v20250326/mcp.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport"
@@ -38,7 +39,6 @@ var _ transport.Transport = &McpTransport{}
 // McpTransport implements the MCP v2025-03-26 protocol.
 type McpTransport struct {
 	*mcp.BaseMcpTransport
-
 	protocolVersion string
 	sessionId       string // Unique session ID for v2025-03-26
 	clientName      string
@@ -46,8 +46,8 @@ type McpTransport struct {
 }
 
 // New creates a new version-specific transport instance.
-func New(baseURL string, client *http.Client, clientName string, clientVersion string) (*McpTransport, error) {
-	baseTransport, err := mcp.NewBaseTransport(baseURL, client)
+func New(baseURL string, client *http.Client, clientName string, clientVersion string, telemetryEnabled bool) (*McpTransport, error) {
+	baseTransport, err := mcp.NewBaseTransport(baseURL, client, telemetryEnabled)
 	if err != nil {
 		return nil, err
 	}
@@ -67,33 +67,51 @@ func New(baseURL string, client *http.Client, clientName string, clientVersion s
 }
 
 // ListTools fetches available tools
-func (t *McpTransport) ListTools(ctx context.Context, toolsetName string, headers map[string]string) (*transport.ManifestSchema, error) {
-	if err := t.EnsureInitialized(ctx, headers); err != nil {
+func (t *McpTransport) ListTools(ctx context.Context, toolsetName string, headers map[string]string) (manifest *transport.ManifestSchema, err error) {
+	if err = t.EnsureInitialized(ctx, headers); err != nil {
 		return nil, err
 	}
 
 	// Append toolset name to base URL if provided
 	requestURL := t.BaseURL()
 	if toolsetName != "" {
-		var err error
 		requestURL, err = url.JoinPath(requestURL, toolsetName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to construct toolset URL: %w", err)
 		}
 	}
 
+	// Start telemetry span before the operation. In the finally-equivalent defer,
+	// record the operation duration metric and end the span.
+	var traceparent, tracestate string
+	if t.TelemetryEnabled {
+		var span mcp.SpanRef
+		operationStart := time.Now()
+		span, traceparent, tracestate = mcp.StartSpan(ctx, t.Tracer, "tools/list", t.protocolVersion, requestURL, "")
+		defer func() {
+			mcp.RecordOperationDuration(ctx, t.OperationDurationHistogram, time.Since(operationStart).Seconds(), "tools/list", t.protocolVersion, requestURL, "", err)
+			mcp.EndSpan(span, err)
+		}()
+	}
+
+	var listParams listToolsRequestParams
+	if traceparent != "" || tracestate != "" {
+		listParams.Meta = &mcpMeta{Traceparent: traceparent, Tracestate: tracestate}
+	}
+
 	var result listToolsResult
-	if _, err := t.sendRequest(ctx, requestURL, "tools/list", map[string]any{}, headers, &result); err != nil {
+	if _, err = t.sendRequest(ctx, requestURL, "tools/list", listParams, headers, &result); err != nil {
 		return nil, fmt.Errorf("failed to list tools: %w", err)
 	}
 
-	manifest := &transport.ManifestSchema{
+	manifest = &transport.ManifestSchema{
 		ServerVersion: t.ServerVersion,
 		Tools:         make(map[string]transport.ToolSchema),
 	}
 	for i, tool := range result.Tools {
 		if tool.Name == "" {
-			return nil, fmt.Errorf("received invalid tool definition at index %d: missing 'name' field", i)
+			err = fmt.Errorf("received invalid tool definition at index %d: missing 'name' field", i)
+			return nil, err
 		}
 
 		rawTool := map[string]any{
@@ -105,7 +123,8 @@ func (t *McpTransport) ListTools(ctx context.Context, toolsetName string, header
 			rawTool["_meta"] = tool.Meta
 		}
 
-		toolSchema, err := t.ConvertToolDefinition(rawTool)
+		var toolSchema transport.ToolSchema
+		toolSchema, err = t.ConvertToolDefinition(rawTool)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert schema for tool %s: %w", tool.Name, err)
 		}
@@ -134,22 +153,42 @@ func (t *McpTransport) GetTool(ctx context.Context, toolName string, headers map
 }
 
 // InvokeTool executes a tool
-func (t *McpTransport) InvokeTool(ctx context.Context, toolName string, payload map[string]any, headers map[string]string) (any, error) {
-	if err := t.EnsureInitialized(ctx, headers); err != nil {
+func (t *McpTransport) InvokeTool(ctx context.Context, toolName string, payload map[string]any, headers map[string]string) (output any, err error) {
+	if err = t.EnsureInitialized(ctx, headers); err != nil {
 		return "", err
+	}
+
+	// Start telemetry span before the operation. In the finally-equivalent defer,
+	// record the operation duration metric and end the span.
+	var traceparent, tracestate string
+	if t.TelemetryEnabled {
+		var span mcp.SpanRef
+		operationStart := time.Now()
+		span, traceparent, tracestate = mcp.StartSpan(ctx, t.Tracer, "tools/call", t.protocolVersion, t.BaseURL(), toolName)
+		defer func() {
+			mcp.RecordOperationDuration(ctx, t.OperationDurationHistogram, time.Since(operationStart).Seconds(), "tools/call", t.protocolVersion, t.BaseURL(), toolName, err)
+			mcp.EndSpan(span, err)
+		}()
+	}
+
+	var meta *mcpMeta
+	if traceparent != "" || tracestate != "" {
+		meta = &mcpMeta{Traceparent: traceparent, Tracestate: tracestate}
 	}
 
 	params := callToolRequestParams{
 		Name:      toolName,
 		Arguments: payload,
+		Meta:      meta,
 	}
 	var result callToolResult
-	if _, err := t.sendRequest(ctx, t.BaseURL(), "tools/call", params, headers, &result); err != nil {
+	if _, err = t.sendRequest(ctx, t.BaseURL(), "tools/call", params, headers, &result); err != nil {
 		return "", fmt.Errorf("failed to invoke tool '%s': %w", toolName, err)
 	}
 
 	if result.IsError {
-		return "", fmt.Errorf("tool execution resulted in error")
+		err = fmt.Errorf("tool execution resulted in error")
+		return "", err
 	}
 
 	baseContent := make([]mcp.ToolContent, len(result.Content))
@@ -160,13 +199,30 @@ func (t *McpTransport) InvokeTool(ctx context.Context, toolName string, payload 
 		}
 	}
 
-	output := t.ProcessToolResultContent(baseContent)
-
-	return output, nil
+	return t.ProcessToolResultContent(baseContent), nil
 }
 
 // initializeSession performs the initial handshake and extracts the Session ID.
-func (t *McpTransport) initializeSession(ctx context.Context, headers map[string]string) error {
+func (t *McpTransport) initializeSession(ctx context.Context, headers map[string]string) (err error) {
+	// Start telemetry span before the operation. In the finally-equivalent defer,
+	// record the operation duration metric and end the span.
+	var traceparent, tracestate string
+	if t.TelemetryEnabled {
+		t.StartSession(ProtocolVersion)
+		var span mcp.SpanRef
+		operationStart := time.Now()
+		span, traceparent, tracestate = mcp.StartSpan(ctx, t.Tracer, "initialize", t.protocolVersion, t.BaseURL(), "")
+		defer func() {
+			mcp.RecordOperationDuration(ctx, t.OperationDurationHistogram, time.Since(operationStart).Seconds(), "initialize", t.protocolVersion, t.BaseURL(), "", err)
+			mcp.EndSpan(span, err)
+		}()
+	}
+
+	var meta *mcpMeta
+	if traceparent != "" || tracestate != "" {
+		meta = &mcpMeta{Traceparent: traceparent, Tracestate: tracestate}
+	}
+
 	params := initializeRequestParams{
 		ProtocolVersion: t.protocolVersion,
 		Capabilities:    clientCapabilities{},
@@ -174,6 +230,7 @@ func (t *McpTransport) initializeSession(ctx context.Context, headers map[string
 			Name:    t.clientName,
 			Version: t.clientVersion,
 		},
+		Meta: meta,
 	}
 	var result initializeResult
 	req := jsonRPCRequest{
@@ -184,19 +241,22 @@ func (t *McpTransport) initializeSession(ctx context.Context, headers map[string
 	}
 
 	// Capture headers to check for Session ID
-	respHeaders, err := t.doRPC(ctx, t.BaseURL(), req, headers, &result)
+	var respHeaders http.Header
+	respHeaders, err = t.doRPC(ctx, t.BaseURL(), req, headers, &result)
 	if err != nil {
 		return err
 	}
 
 	// Protocol Version Check
 	if result.ProtocolVersion != t.protocolVersion {
-		return fmt.Errorf("MCP version mismatch: client (%s) != server (%s)", t.protocolVersion, result.ProtocolVersion)
+		err = fmt.Errorf("MCP version mismatch: client (%s) != server (%s)", t.protocolVersion, result.ProtocolVersion)
+		return err
 	}
 
 	// Capabilities Check
 	if result.Capabilities.Tools == nil {
-		return fmt.Errorf("server does not support the 'tools' capability")
+		err = fmt.Errorf("server does not support the 'tools' capability")
+		return err
 	}
 
 	t.ServerVersion = result.ServerInfo.Version
@@ -205,7 +265,8 @@ func (t *McpTransport) initializeSession(ctx context.Context, headers map[string
 	sessionId := respHeaders.Get("Mcp-Session-Id")
 
 	if sessionId == "" {
-		return fmt.Errorf("server did not return an Mcp-Session-Id")
+		err = fmt.Errorf("server did not return an Mcp-Session-Id")
+		return err
 	}
 	t.sessionId = sessionId
 

--- a/core/transport/mcp/v20250326/mcp_test.go
+++ b/core/transport/mcp/v20250326/mcp_test.go
@@ -30,6 +30,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 // mockMCPServer is a helper to mock MCP JSON-RPC responses
@@ -149,7 +152,7 @@ func TestInitialize_Success(t *testing.T) {
 	server := newMockMCPServer()
 	defer server.Close()
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 
 	// Trigger handshake via EnsureInitialized
 	err := client.EnsureInitialized(context.Background(), nil)
@@ -174,7 +177,7 @@ func TestInitialize_MissingSessionId(t *testing.T) {
 		}, nil, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	err := client.EnsureInitialized(context.Background(), nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "server did not return an Mcp-Session-Id")
@@ -190,7 +193,7 @@ func TestSessionId_Injection_InvokeTool(t *testing.T) {
 		}, nil, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	_, err := client.InvokeTool(context.Background(), "test-tool", map[string]any{"a": 1}, nil)
 	require.NoError(t, err)
 
@@ -218,7 +221,7 @@ func TestSessionId_Injection_ListTools(t *testing.T) {
 		return listToolsResult{Tools: []mcpTool{}}, nil, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	_, err := client.ListTools(context.Background(), "", nil)
 	require.NoError(t, err)
 
@@ -249,7 +252,7 @@ func TestListTools_MetaPreservation(t *testing.T) {
 		}, nil, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	manifest, err := client.ListTools(context.Background(), "", nil)
 	require.NoError(t, err)
 
@@ -271,7 +274,7 @@ func TestGetTool_Success(t *testing.T) {
 		}, nil, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	manifest, err := client.GetTool(context.Background(), "wanted", nil)
 	require.NoError(t, err)
 	assert.Contains(t, manifest.Tools, "wanted")
@@ -289,7 +292,7 @@ func TestInvokeTool_ErrorResult(t *testing.T) {
 		}, nil, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	_, err := client.InvokeTool(context.Background(), "tool", nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "tool execution resulted in error")
@@ -303,7 +306,7 @@ func TestInvokeTool_RPCError(t *testing.T) {
 		return nil, nil, errors.New("internal server error")
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	_, err := client.InvokeTool(context.Background(), "tool", nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "internal server error")
@@ -317,7 +320,7 @@ func TestListTools_WithAuthHeaders(t *testing.T) {
 		return listToolsResult{Tools: []mcpTool{}}, nil, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	headers := map[string]string{"Authorization": "secret"}
 
 	_, err := client.ListTools(context.Background(), "", headers)
@@ -336,7 +339,7 @@ func TestProtocolVersionMismatch(t *testing.T) {
 		}, nil, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	err := client.EnsureInitialized(context.Background(), nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "MCP version mismatch")
@@ -353,7 +356,7 @@ func TestInitialization_MissingCapabilities(t *testing.T) {
 		}, nil, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	err := client.EnsureInitialized(context.Background(), nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "does not support the 'tools' capability")
@@ -366,7 +369,7 @@ func TestRequest_NetworkError(t *testing.T) {
 	url := server.URL
 	server.Close()
 
-	client, _ := New(url, server.Client(), "test-client", "1.0.0")
+	client, _ := New(url, server.Client(), "test-client", "1.0.0", false)
 	_, err := client.ListTools(context.Background(), "", nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "http request failed")
@@ -379,7 +382,7 @@ func TestRequest_ServerError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	_, err := client.ListTools(context.Background(), "", nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "API request failed with status 500")
@@ -392,14 +395,14 @@ func TestRequest_BadJSON(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	_, err := client.ListTools(context.Background(), "", nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "response unmarshal failed")
 }
 
 func TestRequest_NewRequestError(t *testing.T) {
-	_, err := New("http://bad\nurl.com", http.DefaultClient, "test-client", "1.0.0")
+	_, err := New("http://bad\nurl.com", http.DefaultClient, "test-client", "1.0.0", false)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "invalid control character in URL")
 }
@@ -407,7 +410,7 @@ func TestRequest_NewRequestError(t *testing.T) {
 func TestRequest_MarshalError(t *testing.T) {
 	server := newMockMCPServer()
 	defer server.Close()
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 
 	// Force initialization first
 	_ = client.EnsureInitialized(context.Background(), nil)
@@ -426,7 +429,7 @@ func TestGetTool_NotFound(t *testing.T) {
 		return listToolsResult{Tools: []mcpTool{}}, nil, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	_, err := client.GetTool(context.Background(), "missing", nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
@@ -437,7 +440,7 @@ func TestListTools_InitFailure(t *testing.T) {
 	url := server.URL
 	server.Close()
 
-	client, _ := New(url, server.Client(), "test-client", "1.0.0")
+	client, _ := New(url, server.Client(), "test-client", "1.0.0", false)
 	_, err := client.ListTools(context.Background(), "", nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "http request failed")
@@ -470,7 +473,7 @@ func TestInit_NotificationFailure(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	err := client.EnsureInitialized(context.Background(), nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "server did not return an Mcp-Session-Id")
@@ -490,7 +493,7 @@ func TestInvokeTool_ComplexContent(t *testing.T) {
 		}, nil, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	res, err := client.InvokeTool(context.Background(), "t", nil, nil)
 	require.NoError(t, err)
 	// Only text types should be concatenated
@@ -507,7 +510,7 @@ func TestInvokeTool_EmptyResult(t *testing.T) {
 		}, nil, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	res, err := client.InvokeTool(context.Background(), "t", nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "null", res)
@@ -519,7 +522,7 @@ func TestDoRPC_204_NoContent(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	_, err := client.sendNotification(context.Background(), "test", nil, nil)
 	require.NoError(t, err)
 }
@@ -537,7 +540,7 @@ func TestListTools_ErrorOnEmptyName(t *testing.T) {
 		}, nil, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	_, err := client.ListTools(context.Background(), "", nil)
 
 	// Assert that we get an error now
@@ -561,7 +564,7 @@ func TestInvokeTool_ContentProcessing_Scenarios(t *testing.T) {
 			}, nil, nil // Return nil for headers and nil for error
 		}
 
-		client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+		client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 		result, err := client.InvokeTool(context.Background(), "tool", nil, nil)
 		require.NoError(t, err)
 
@@ -585,7 +588,7 @@ func TestInvokeTool_ContentProcessing_Scenarios(t *testing.T) {
 			}, nil, nil
 		}
 
-		client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+		client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 		result, err := client.InvokeTool(context.Background(), "tool", nil, nil)
 		require.NoError(t, err)
 
@@ -608,7 +611,7 @@ func TestInvokeTool_ContentProcessing_Scenarios(t *testing.T) {
 			}, nil, nil
 		}
 
-		client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+		client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 		result, err := client.InvokeTool(context.Background(), "tool", nil, nil)
 		require.NoError(t, err)
 
@@ -618,7 +621,7 @@ func TestInvokeTool_ContentProcessing_Scenarios(t *testing.T) {
 }
 
 func TestEnsureInitialized_PassesHeaders(t *testing.T) {
-	tr, err := New("http://fake.com", nil, "test-client", "1.0.0")
+	tr, err := New("http://fake.com", nil, "test-client", "1.0.0", false)
 	require.NoError(t, err)
 
 	capturedHeaders := make(map[string]string)
@@ -675,7 +678,7 @@ func TestInitializeSession_PassesHeadersToWire(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	tr, err := New(ts.URL, ts.Client(), "test-client", "1.0.0")
+	tr, err := New(ts.URL, ts.Client(), "test-client", "1.0.0", false)
 	require.NoError(t, err)
 
 	testHeaders := map[string]string{"Authorization": "Bearer token"}
@@ -689,7 +692,7 @@ func TestNew_ClientVersion(t *testing.T) {
 
 	t.Run("Test with explicit version", func(t *testing.T) {
 		explicitVersion := "2.0.0"
-		tr1, err := New("http://example.com", nil, clientName, explicitVersion)
+		tr1, err := New("http://example.com", nil, clientName, explicitVersion, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -700,7 +703,7 @@ func TestNew_ClientVersion(t *testing.T) {
 	})
 
 	t.Run("Test with empty version uses SDKVersion", func(t *testing.T) {
-		tr2, err := New("http://example.com", nil, clientName, "")
+		tr2, err := New("http://example.com", nil, clientName, "", false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -709,4 +712,152 @@ func TestNew_ClientVersion(t *testing.T) {
 			t.Errorf("expected clientVersion %q, got %q", mcp.SDKVersion, tr2.clientVersion)
 		}
 	})
+}
+
+// --------------------------------------------------------------------------
+// Telemetry integration tests
+// --------------------------------------------------------------------------
+
+// setupRealTracerProvider installs a real in-memory TracerProvider as the
+// global provider for the duration of a test, then restores the previous one.
+func setupRealTracerProvider(t *testing.T) *tracetest.InMemoryExporter {
+	t.Helper()
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { otel.SetTracerProvider(prev) })
+	return exp
+}
+
+func TestListTools_WithTelemetry_PropagatesTraceparent(t *testing.T) {
+	setupRealTracerProvider(t)
+
+	server := newMockMCPServer()
+	defer server.Close()
+
+	server.handlers["tools/list"] = func(params json.RawMessage) (any, map[string]string, error) {
+		return listToolsResult{Tools: []mcpTool{}}, nil, nil
+	}
+
+	client, err := New(server.URL, server.Client(), "client", "1.0.0", true)
+	require.NoError(t, err)
+
+	_, err = client.ListTools(context.Background(), "", nil)
+	require.NoError(t, err)
+
+	var toolsListReq *jsonRPCRequest
+	for i, r := range server.requests {
+		if r.Body.Method == "tools/list" {
+			toolsListReq = &server.requests[i].Body
+			break
+		}
+	}
+	require.NotNil(t, toolsListReq, "expected tools/list request to be captured")
+
+	paramsBytes, err := json.Marshal(toolsListReq.Params)
+	require.NoError(t, err)
+
+	var params listToolsRequestParams
+	require.NoError(t, json.Unmarshal(paramsBytes, &params))
+
+	assert.NotNil(t, params.Meta, "expected _meta to be set when telemetry is enabled")
+	if params.Meta != nil {
+		assert.NotEmpty(t, params.Meta.Traceparent, "expected traceparent to be set in _meta")
+	}
+}
+
+func TestInvokeTool_WithTelemetry_PropagatesTraceparent(t *testing.T) {
+	setupRealTracerProvider(t)
+
+	server := newMockMCPServer()
+	defer server.Close()
+
+	server.handlers["tools/call"] = func(params json.RawMessage) (any, map[string]string, error) {
+		return callToolResult{
+			Content: []textContent{{Type: "text", Text: "ok"}},
+		}, nil, nil
+	}
+
+	client, err := New(server.URL, server.Client(), "client", "1.0.0", true)
+	require.NoError(t, err)
+
+	_, err = client.InvokeTool(context.Background(), "my_tool", nil, nil)
+	require.NoError(t, err)
+
+	var callReq *jsonRPCRequest
+	for i, r := range server.requests {
+		if r.Body.Method == "tools/call" {
+			callReq = &server.requests[i].Body
+			break
+		}
+	}
+	require.NotNil(t, callReq, "expected tools/call request to be captured")
+
+	paramsBytes, err := json.Marshal(callReq.Params)
+	require.NoError(t, err)
+
+	var params callToolRequestParams
+	require.NoError(t, json.Unmarshal(paramsBytes, &params))
+
+	assert.NotNil(t, params.Meta, "expected _meta to be set when telemetry is enabled")
+	if params.Meta != nil {
+		assert.NotEmpty(t, params.Meta.Traceparent, "expected traceparent to be set in _meta")
+	}
+}
+
+func TestInitializeSession_WithTelemetry_PropagatesTraceparent(t *testing.T) {
+	setupRealTracerProvider(t)
+
+	server := newMockMCPServer()
+	defer server.Close()
+
+	client, err := New(server.URL, server.Client(), "client", "1.0.0", true)
+	require.NoError(t, err)
+
+	server.handlers["tools/list"] = func(params json.RawMessage) (any, map[string]string, error) {
+		return listToolsResult{Tools: []mcpTool{}}, nil, nil
+	}
+	_, err = client.ListTools(context.Background(), "", nil)
+	require.NoError(t, err)
+
+	var initReq *jsonRPCRequest
+	for i, r := range server.requests {
+		if r.Body.Method == "initialize" {
+			initReq = &server.requests[i].Body
+			break
+		}
+	}
+	require.NotNil(t, initReq, "expected initialize request to be captured")
+
+	paramsBytes, err := json.Marshal(initReq.Params)
+	require.NoError(t, err)
+
+	var params initializeRequestParams
+	require.NoError(t, json.Unmarshal(paramsBytes, &params))
+
+	assert.NotNil(t, params.Meta, "expected _meta to be set when telemetry is enabled")
+	if params.Meta != nil {
+		assert.NotEmpty(t, params.Meta.Traceparent, "expected traceparent to be set in _meta")
+	}
+}
+
+func TestClose_WithTelemetry_RecordsSessionDuration(t *testing.T) {
+	setupRealTracerProvider(t)
+
+	server := newMockMCPServer()
+	defer server.Close()
+
+	server.handlers["tools/list"] = func(params json.RawMessage) (any, map[string]string, error) {
+		return listToolsResult{Tools: []mcpTool{}}, nil, nil
+	}
+
+	client, err := New(server.URL, server.Client(), "client", "1.0.0", true)
+	require.NoError(t, err)
+
+	_, err = client.ListTools(context.Background(), "", nil)
+	require.NoError(t, err)
+
+	err = client.Close(context.Background())
+	assert.NoError(t, err)
 }

--- a/core/transport/mcp/v20250326/types.go
+++ b/core/transport/mcp/v20250326/types.go
@@ -61,11 +61,24 @@ type serverCapabilities struct {
 	Tools   map[string]any `json:"tools,omitempty"`
 }
 
+// mcpMeta carries OpenTelemetry trace context for MCP context propagation.
+// See: https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/#context-propagation
+type mcpMeta struct {
+	Traceparent string `json:"traceparent,omitempty"`
+	Tracestate  string `json:"tracestate,omitempty"`
+}
+
 // initializeRequestParams holds the parameters for the 'initialize' handshake.
 type initializeRequestParams struct {
 	ProtocolVersion string             `json:"protocolVersion"`
 	Capabilities    clientCapabilities `json:"capabilities"`
 	ClientInfo      implementation     `json:"clientInfo"`
+	Meta            *mcpMeta           `json:"_meta,omitempty"`
+}
+
+// listToolsRequestParams holds the parameters for the 'tools/list' method.
+type listToolsRequestParams struct {
+	Meta *mcpMeta `json:"_meta,omitempty"`
 }
 
 // initializeResult holds the response from the 'initialize' handshake.
@@ -93,6 +106,7 @@ type listToolsResult struct {
 type callToolRequestParams struct {
 	Name      string         `json:"name"`
 	Arguments map[string]any `json:"arguments"`
+	Meta      *mcpMeta       `json:"_meta,omitempty"`
 }
 
 // textContent represents a single text block in a tool's output.

--- a/core/transport/mcp/v20250618/mcp.go
+++ b/core/transport/mcp/v20250618/mcp.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport"
@@ -44,8 +45,8 @@ type McpTransport struct {
 }
 
 // New creates a new version-specific transport instance.
-func New(baseURL string, client *http.Client, clientName string, clientVersion string) (*McpTransport, error) {
-	baseTransport, err := mcp.NewBaseTransport(baseURL, client)
+func New(baseURL string, client *http.Client, clientName string, clientVersion string, telemetryEnabled bool) (*McpTransport, error) {
+	baseTransport, err := mcp.NewBaseTransport(baseURL, client, telemetryEnabled)
 	if err != nil {
 		return nil, err
 	}
@@ -65,33 +66,51 @@ func New(baseURL string, client *http.Client, clientName string, clientVersion s
 }
 
 // ListTools fetches available tools
-func (t *McpTransport) ListTools(ctx context.Context, toolsetName string, headers map[string]string) (*transport.ManifestSchema, error) {
-	if err := t.EnsureInitialized(ctx, headers); err != nil {
+func (t *McpTransport) ListTools(ctx context.Context, toolsetName string, headers map[string]string) (manifest *transport.ManifestSchema, err error) {
+	if err = t.EnsureInitialized(ctx, headers); err != nil {
 		return nil, err
 	}
 
 	requestURL := t.BaseURL()
 	if toolsetName != "" {
-		var err error
 		requestURL, err = url.JoinPath(requestURL, toolsetName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to construct toolset URL: %w", err)
 		}
 	}
 
+	// Start telemetry span before the operation. In the finally-equivalent defer,
+	// record the operation duration metric and end the span.
+	var traceparent, tracestate string
+	if t.TelemetryEnabled {
+		var span mcp.SpanRef
+		operationStart := time.Now()
+		span, traceparent, tracestate = mcp.StartSpan(ctx, t.Tracer, "tools/list", t.protocolVersion, requestURL, "")
+		defer func() {
+			mcp.RecordOperationDuration(ctx, t.OperationDurationHistogram, time.Since(operationStart).Seconds(), "tools/list", t.protocolVersion, requestURL, "", err)
+			mcp.EndSpan(span, err)
+		}()
+	}
+
+	var listParams listToolsRequestParams
+	if traceparent != "" || tracestate != "" {
+		listParams.Meta = &mcpMeta{Traceparent: traceparent, Tracestate: tracestate}
+	}
+
 	var result listToolsResult
-	if err := t.sendRequest(ctx, requestURL, "tools/list", map[string]any{}, headers, &result); err != nil {
+	if err = t.sendRequest(ctx, requestURL, "tools/list", listParams, headers, &result); err != nil {
 		return nil, fmt.Errorf("failed to list tools: %w", err)
 	}
 
-	manifest := &transport.ManifestSchema{
+	manifest = &transport.ManifestSchema{
 		ServerVersion: t.ServerVersion,
 		Tools:         make(map[string]transport.ToolSchema),
 	}
 
 	for i, tool := range result.Tools {
 		if tool.Name == "" {
-			return nil, fmt.Errorf("received invalid tool definition at index %d: missing 'name' field", i)
+			err = fmt.Errorf("received invalid tool definition at index %d: missing 'name' field", i)
+			return nil, err
 		}
 
 		rawTool := map[string]any{
@@ -103,7 +122,8 @@ func (t *McpTransport) ListTools(ctx context.Context, toolsetName string, header
 			rawTool["_meta"] = tool.Meta
 		}
 
-		toolSchema, err := t.ConvertToolDefinition(rawTool)
+		var toolSchema transport.ToolSchema
+		toolSchema, err = t.ConvertToolDefinition(rawTool)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert schema for tool %s: %w", tool.Name, err)
 		}
@@ -133,22 +153,43 @@ func (t *McpTransport) GetTool(ctx context.Context, toolName string, headers map
 }
 
 // InvokeTool executes a tool
-func (t *McpTransport) InvokeTool(ctx context.Context, toolName string, payload map[string]any, headers map[string]string) (any, error) {
-	if err := t.EnsureInitialized(ctx, headers); err != nil {
+func (t *McpTransport) InvokeTool(ctx context.Context, toolName string, payload map[string]any, headers map[string]string) (output any, err error) {
+	if err = t.EnsureInitialized(ctx, headers); err != nil {
 		return "", err
 	}
+
+	// Start telemetry span before the operation. In the finally-equivalent defer,
+	// record the operation duration metric and end the span.
+	var traceparent, tracestate string
+	if t.TelemetryEnabled {
+		var span mcp.SpanRef
+		operationStart := time.Now()
+		span, traceparent, tracestate = mcp.StartSpan(ctx, t.Tracer, "tools/call", t.protocolVersion, t.BaseURL(), toolName)
+		defer func() {
+			mcp.RecordOperationDuration(ctx, t.OperationDurationHistogram, time.Since(operationStart).Seconds(), "tools/call", t.protocolVersion, t.BaseURL(), toolName, err)
+			mcp.EndSpan(span, err)
+		}()
+	}
+
+	var meta *mcpMeta
+	if traceparent != "" || tracestate != "" {
+		meta = &mcpMeta{Traceparent: traceparent, Tracestate: tracestate}
+	}
+
 	params := callToolRequestParams{
 		Name:      toolName,
 		Arguments: payload,
+		Meta:      meta,
 	}
 
 	var result callToolResult
-	if err := t.sendRequest(ctx, t.BaseURL(), "tools/call", params, headers, &result); err != nil {
+	if err = t.sendRequest(ctx, t.BaseURL(), "tools/call", params, headers, &result); err != nil {
 		return "", fmt.Errorf("failed to invoke tool '%s': %w", toolName, err)
 	}
 
 	if result.IsError {
-		return "", fmt.Errorf("tool execution resulted in error")
+		err = fmt.Errorf("tool execution resulted in error")
+		return "", err
 	}
 
 	baseContent := make([]mcp.ToolContent, len(result.Content))
@@ -159,13 +200,30 @@ func (t *McpTransport) InvokeTool(ctx context.Context, toolName string, payload 
 		}
 	}
 
-	output := t.ProcessToolResultContent(baseContent)
-
-	return output, nil
+	return t.ProcessToolResultContent(baseContent), nil
 }
 
 // initializeSession performs the initial handshake with the server.
-func (t *McpTransport) initializeSession(ctx context.Context, headers map[string]string) error {
+func (t *McpTransport) initializeSession(ctx context.Context, headers map[string]string) (err error) {
+	// Start telemetry span before the operation. In the finally-equivalent defer,
+	// record the operation duration metric and end the span.
+	var traceparent, tracestate string
+	if t.TelemetryEnabled {
+		t.StartSession(ProtocolVersion)
+		var span mcp.SpanRef
+		operationStart := time.Now()
+		span, traceparent, tracestate = mcp.StartSpan(ctx, t.Tracer, "initialize", t.protocolVersion, t.BaseURL(), "")
+		defer func() {
+			mcp.RecordOperationDuration(ctx, t.OperationDurationHistogram, time.Since(operationStart).Seconds(), "initialize", t.protocolVersion, t.BaseURL(), "", err)
+			mcp.EndSpan(span, err)
+		}()
+	}
+
+	var meta *mcpMeta
+	if traceparent != "" || tracestate != "" {
+		meta = &mcpMeta{Traceparent: traceparent, Tracestate: tracestate}
+	}
+
 	params := initializeRequestParams{
 		ProtocolVersion: t.protocolVersion,
 		Capabilities:    clientCapabilities{},
@@ -173,27 +231,31 @@ func (t *McpTransport) initializeSession(ctx context.Context, headers map[string
 			Name:    t.clientName,
 			Version: t.clientVersion,
 		},
+		Meta: meta,
 	}
 
 	var result initializeResult
-	if err := t.sendRequest(ctx, t.BaseURL(), "initialize", params, headers, &result); err != nil {
+	if err = t.sendRequest(ctx, t.BaseURL(), "initialize", params, headers, &result); err != nil {
 		return err
 	}
 
 	// Protocol Version Check
 	if result.ProtocolVersion != t.protocolVersion {
-		return fmt.Errorf("MCP version mismatch: client (%s) != server (%s)", t.protocolVersion, result.ProtocolVersion)
+		err = fmt.Errorf("MCP version mismatch: client (%s) != server (%s)", t.protocolVersion, result.ProtocolVersion)
+		return err
 	}
 
 	// Capabilities Check
 	if result.Capabilities.Tools == nil {
-		return fmt.Errorf("server does not support the 'tools' capability")
+		err = fmt.Errorf("server does not support the 'tools' capability")
+		return err
 	}
 
 	t.ServerVersion = result.ServerInfo.Version
 
 	// Confirm Handshake
-	return t.sendNotification(ctx, "notifications/initialized", map[string]any{}, headers)
+	err = t.sendNotification(ctx, "notifications/initialized", map[string]any{}, headers)
+	return err
 }
 
 // sendRequest sends a standard JSON-RPC request to the server.

--- a/core/transport/mcp/v20250618/mcp_test.go
+++ b/core/transport/mcp/v20250618/mcp_test.go
@@ -28,6 +28,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 // capturedRequest holds both the RPC body and the HTTP headers for verification
@@ -127,7 +130,7 @@ func TestHeaders_Presence(t *testing.T) {
 	server := newMockMCPServer(t)
 	defer server.Close()
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	err := client.EnsureInitialized(context.Background(), nil)
 	require.NoError(t, err)
 
@@ -166,7 +169,7 @@ func TestListTools(t *testing.T) {
 		}, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	ctx := context.Background()
 
 	t.Run("Success", func(t *testing.T) {
@@ -207,7 +210,7 @@ func TestListTools_ErrorOnEmptyName(t *testing.T) {
 		}, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	_, err := client.ListTools(context.Background(), "", nil)
 
 	assert.Error(t, err)
@@ -227,7 +230,7 @@ func TestGetTool_Success(t *testing.T) {
 		}, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	manifest, err := client.GetTool(context.Background(), "tool_a", nil)
 	require.NoError(t, err)
 	assert.Contains(t, manifest.Tools, "tool_a")
@@ -242,7 +245,7 @@ func TestGetTool_NotFound(t *testing.T) {
 		return listToolsResult{Tools: []mcpTool{}}, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	_, err := client.GetTool(context.Background(), "missing_tool", nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
@@ -269,7 +272,7 @@ func TestInvokeTool(t *testing.T) {
 		}, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	ctx := context.Background()
 
 	t.Run("Success", func(t *testing.T) {
@@ -302,7 +305,7 @@ func TestProtocolMismatch(t *testing.T) {
 		}, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 
 	_, err := client.ListTools(context.Background(), "", nil)
 	assert.Error(t, err)
@@ -321,7 +324,7 @@ func TestInitialize_MissingCapabilities(t *testing.T) {
 		}, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	_, err := client.ListTools(context.Background(), "", nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "does not support the 'tools' capability")
@@ -329,7 +332,7 @@ func TestInitialize_MissingCapabilities(t *testing.T) {
 
 func TestConvertToolSchema(t *testing.T) {
 	// Use the transport's ConvertToolDefinition which delegates to the base/helper logic
-	tr, _ := New("http://example.com", nil, "test-client", "1.0.0")
+	tr, _ := New("http://example.com", nil, "test-client", "1.0.0", false)
 
 	rawTool := map[string]any{
 		"name":        "complex_tool",
@@ -379,7 +382,7 @@ func TestListTools_WithToolset(t *testing.T) {
 		return listToolsResult{Tools: []mcpTool{}}, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	toolsetName := "my-toolset"
 
 	_, err := client.ListTools(context.Background(), toolsetName, nil)
@@ -392,7 +395,7 @@ func TestRequest_NetworkError(t *testing.T) {
 	url := server.URL
 	server.Close()
 
-	client, _ := New(url, server.Client(), "test-client", "1.0.0")
+	client, _ := New(url, server.Client(), "test-client", "1.0.0", false)
 	_, err := client.ListTools(context.Background(), "", nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "http request failed")
@@ -405,7 +408,7 @@ func TestRequest_ServerError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	_, err := client.ListTools(context.Background(), "", nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "API request failed with status 500")
@@ -418,7 +421,7 @@ func TestRequest_BadJSON(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	_, err := client.ListTools(context.Background(), "", nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "response unmarshal failed")
@@ -426,7 +429,7 @@ func TestRequest_BadJSON(t *testing.T) {
 
 func TestRequest_NewRequestError(t *testing.T) {
 	// Bad URL triggers http.NewRequest error
-	_, err := New("http://bad\nurl.com", http.DefaultClient, "test-client", "1.0.0")
+	_, err := New("http://bad\nurl.com", http.DefaultClient, "test-client", "1.0.0", false)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid control character in URL")
 }
@@ -434,7 +437,7 @@ func TestRequest_NewRequestError(t *testing.T) {
 func TestRequest_MarshalError(t *testing.T) {
 	server := newMockMCPServer(t)
 	defer server.Close()
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 
 	// Force initialization first
 	_ = client.EnsureInitialized(context.Background(), nil)
@@ -457,7 +460,7 @@ func TestInvokeTool_ErrorResult(t *testing.T) {
 		}, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	_, err := client.InvokeTool(context.Background(), "tool", nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "tool execution resulted in error")
@@ -471,7 +474,7 @@ func TestInvokeTool_RPCError(t *testing.T) {
 		return nil, errors.New("internal server error")
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	_, err := client.InvokeTool(context.Background(), "tool", nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "internal server error")
@@ -491,7 +494,7 @@ func TestInvokeTool_ComplexContent(t *testing.T) {
 		}, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	res, err := client.InvokeTool(context.Background(), "t", nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "Part 1 Part 2", res)
@@ -507,7 +510,7 @@ func TestInvokeTool_EmptyResult(t *testing.T) {
 		}, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	res, err := client.InvokeTool(context.Background(), "t", nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "null", res)
@@ -528,7 +531,7 @@ func TestInvokeTool_ContentProcessing_Scenarios(t *testing.T) {
 			}, nil
 		}
 
-		client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+		client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 		result, err := client.InvokeTool(context.Background(), "tool", nil, nil)
 		require.NoError(t, err)
 
@@ -552,7 +555,7 @@ func TestInvokeTool_ContentProcessing_Scenarios(t *testing.T) {
 			}, nil
 		}
 
-		client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+		client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 		result, err := client.InvokeTool(context.Background(), "tool", nil, nil)
 		require.NoError(t, err)
 
@@ -575,7 +578,7 @@ func TestInvokeTool_ContentProcessing_Scenarios(t *testing.T) {
 			}, nil
 		}
 
-		client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+		client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 		result, err := client.InvokeTool(context.Background(), "tool", nil, nil)
 		require.NoError(t, err)
 
@@ -585,7 +588,7 @@ func TestInvokeTool_ContentProcessing_Scenarios(t *testing.T) {
 }
 
 func TestEnsureInitialized_PassesHeaders(t *testing.T) {
-	tr, err := New("http://fake.com", nil, "test-client", "1.0.0")
+	tr, err := New("http://fake.com", nil, "test-client", "1.0.0", false)
 	require.NoError(t, err)
 
 	capturedHeaders := make(map[string]string)
@@ -641,7 +644,7 @@ func TestInitializeSession_PassesHeadersToWire(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	tr, err := New(ts.URL, ts.Client(), "test-client", "1.0.0")
+	tr, err := New(ts.URL, ts.Client(), "test-client", "1.0.0", false)
 	require.NoError(t, err)
 
 	testHeaders := map[string]string{"Authorization": "Bearer token"}
@@ -655,7 +658,7 @@ func TestNew_ClientVersion(t *testing.T) {
 
 	t.Run("Test with explicit version", func(t *testing.T) {
 		explicitVersion := "2.0.0"
-		tr1, err := New("http://example.com", nil, clientName, explicitVersion)
+		tr1, err := New("http://example.com", nil, clientName, explicitVersion, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -666,7 +669,7 @@ func TestNew_ClientVersion(t *testing.T) {
 	})
 
 	t.Run("Test with empty version uses SDKVersion", func(t *testing.T) {
-		tr2, err := New("http://example.com", nil, clientName, "")
+		tr2, err := New("http://example.com", nil, clientName, "", false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -675,4 +678,152 @@ func TestNew_ClientVersion(t *testing.T) {
 			t.Errorf("expected clientVersion %q, got %q", mcp.SDKVersion, tr2.clientVersion)
 		}
 	})
+}
+
+// --------------------------------------------------------------------------
+// Telemetry integration tests
+// --------------------------------------------------------------------------
+
+// setupRealTracerProvider installs a real in-memory TracerProvider as the
+// global provider for the duration of a test, then restores the previous one.
+func setupRealTracerProvider(t *testing.T) *tracetest.InMemoryExporter {
+	t.Helper()
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { otel.SetTracerProvider(prev) })
+	return exp
+}
+
+func TestListTools_WithTelemetry_PropagatesTraceparent(t *testing.T) {
+	setupRealTracerProvider(t)
+
+	server := newMockMCPServer(t)
+	defer server.Close()
+
+	server.handlers["tools/list"] = func(params json.RawMessage) (any, error) {
+		return listToolsResult{Tools: []mcpTool{}}, nil
+	}
+
+	client, err := New(server.URL, server.Client(), "client", "1.0.0", true)
+	require.NoError(t, err)
+
+	_, err = client.ListTools(context.Background(), "", nil)
+	require.NoError(t, err)
+
+	var toolsListReq *jsonRPCRequest
+	for i, r := range server.requests {
+		if r.Body.Method == "tools/list" {
+			toolsListReq = &server.requests[i].Body
+			break
+		}
+	}
+	require.NotNil(t, toolsListReq, "expected tools/list request to be captured")
+
+	paramsBytes, err := json.Marshal(toolsListReq.Params)
+	require.NoError(t, err)
+
+	var params listToolsRequestParams
+	require.NoError(t, json.Unmarshal(paramsBytes, &params))
+
+	assert.NotNil(t, params.Meta, "expected _meta to be set when telemetry is enabled")
+	if params.Meta != nil {
+		assert.NotEmpty(t, params.Meta.Traceparent, "expected traceparent to be set in _meta")
+	}
+}
+
+func TestInvokeTool_WithTelemetry_PropagatesTraceparent(t *testing.T) {
+	setupRealTracerProvider(t)
+
+	server := newMockMCPServer(t)
+	defer server.Close()
+
+	server.handlers["tools/call"] = func(params json.RawMessage) (any, error) {
+		return callToolResult{
+			Content: []textContent{{Type: "text", Text: "ok"}},
+		}, nil
+	}
+
+	client, err := New(server.URL, server.Client(), "client", "1.0.0", true)
+	require.NoError(t, err)
+
+	_, err = client.InvokeTool(context.Background(), "my_tool", nil, nil)
+	require.NoError(t, err)
+
+	var callReq *jsonRPCRequest
+	for i, r := range server.requests {
+		if r.Body.Method == "tools/call" {
+			callReq = &server.requests[i].Body
+			break
+		}
+	}
+	require.NotNil(t, callReq, "expected tools/call request to be captured")
+
+	paramsBytes, err := json.Marshal(callReq.Params)
+	require.NoError(t, err)
+
+	var params callToolRequestParams
+	require.NoError(t, json.Unmarshal(paramsBytes, &params))
+
+	assert.NotNil(t, params.Meta, "expected _meta to be set when telemetry is enabled")
+	if params.Meta != nil {
+		assert.NotEmpty(t, params.Meta.Traceparent, "expected traceparent to be set in _meta")
+	}
+}
+
+func TestInitializeSession_WithTelemetry_PropagatesTraceparent(t *testing.T) {
+	setupRealTracerProvider(t)
+
+	server := newMockMCPServer(t)
+	defer server.Close()
+
+	client, err := New(server.URL, server.Client(), "client", "1.0.0", true)
+	require.NoError(t, err)
+
+	server.handlers["tools/list"] = func(params json.RawMessage) (any, error) {
+		return listToolsResult{Tools: []mcpTool{}}, nil
+	}
+	_, err = client.ListTools(context.Background(), "", nil)
+	require.NoError(t, err)
+
+	var initReq *jsonRPCRequest
+	for i, r := range server.requests {
+		if r.Body.Method == "initialize" {
+			initReq = &server.requests[i].Body
+			break
+		}
+	}
+	require.NotNil(t, initReq, "expected initialize request to be captured")
+
+	paramsBytes, err := json.Marshal(initReq.Params)
+	require.NoError(t, err)
+
+	var params initializeRequestParams
+	require.NoError(t, json.Unmarshal(paramsBytes, &params))
+
+	assert.NotNil(t, params.Meta, "expected _meta to be set when telemetry is enabled")
+	if params.Meta != nil {
+		assert.NotEmpty(t, params.Meta.Traceparent, "expected traceparent to be set in _meta")
+	}
+}
+
+func TestClose_WithTelemetry_RecordsSessionDuration(t *testing.T) {
+	setupRealTracerProvider(t)
+
+	server := newMockMCPServer(t)
+	defer server.Close()
+
+	server.handlers["tools/list"] = func(params json.RawMessage) (any, error) {
+		return listToolsResult{Tools: []mcpTool{}}, nil
+	}
+
+	client, err := New(server.URL, server.Client(), "client", "1.0.0", true)
+	require.NoError(t, err)
+
+	_, err = client.ListTools(context.Background(), "", nil)
+	require.NoError(t, err)
+
+	err = client.Close(context.Background())
+	assert.NoError(t, err)
 }

--- a/core/transport/mcp/v20250618/types.go
+++ b/core/transport/mcp/v20250618/types.go
@@ -61,11 +61,24 @@ type serverCapabilities struct {
 	Tools   map[string]any `json:"tools,omitempty"`
 }
 
+// mcpMeta carries OpenTelemetry trace context for MCP context propagation.
+// See: https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/#context-propagation
+type mcpMeta struct {
+	Traceparent string `json:"traceparent,omitempty"`
+	Tracestate  string `json:"tracestate,omitempty"`
+}
+
 // initializeRequestParams holds the parameters for the 'initialize' handshake.
 type initializeRequestParams struct {
 	ProtocolVersion string             `json:"protocolVersion"`
 	Capabilities    clientCapabilities `json:"capabilities"`
 	ClientInfo      implementation     `json:"clientInfo"`
+	Meta            *mcpMeta           `json:"_meta,omitempty"`
+}
+
+// listToolsRequestParams holds the parameters for the 'tools/list' method.
+type listToolsRequestParams struct {
+	Meta *mcpMeta `json:"_meta,omitempty"`
 }
 
 // initializeResult holds the response from the 'initialize' handshake.
@@ -93,6 +106,7 @@ type listToolsResult struct {
 type callToolRequestParams struct {
 	Name      string         `json:"name"`
 	Arguments map[string]any `json:"arguments"`
+	Meta      *mcpMeta       `json:"_meta,omitempty"`
 }
 
 // textContent represents a single text block in a tool's output.

--- a/core/transport/mcp/v20251125/mcp.go
+++ b/core/transport/mcp/v20251125/mcp.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport"
@@ -44,8 +45,8 @@ type McpTransport struct {
 }
 
 // New creates a new version-specific transport instance.
-func New(baseURL string, client *http.Client, clientName string, clientVersion string) (*McpTransport, error) {
-	baseTransport, err := mcp.NewBaseTransport(baseURL, client)
+func New(baseURL string, client *http.Client, clientName string, clientVersion string, telemetryEnabled bool) (*McpTransport, error) {
+	baseTransport, err := mcp.NewBaseTransport(baseURL, client, telemetryEnabled)
 	if err != nil {
 		return nil, err
 	}
@@ -65,33 +66,51 @@ func New(baseURL string, client *http.Client, clientName string, clientVersion s
 }
 
 // ListTools fetches available tools
-func (t *McpTransport) ListTools(ctx context.Context, toolsetName string, headers map[string]string) (*transport.ManifestSchema, error) {
-	if err := t.EnsureInitialized(ctx, headers); err != nil {
+func (t *McpTransport) ListTools(ctx context.Context, toolsetName string, headers map[string]string) (manifest *transport.ManifestSchema, err error) {
+	if err = t.EnsureInitialized(ctx, headers); err != nil {
 		return nil, err
 	}
 
 	requestURL := t.BaseURL()
 	if toolsetName != "" {
-		var err error
 		requestURL, err = url.JoinPath(requestURL, toolsetName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to construct toolset URL: %w", err)
 		}
 	}
 
+	// Start telemetry span before the operation. In the finally-equivalent defer,
+	// record the operation duration metric and end the span.
+	var traceparent, tracestate string
+	if t.TelemetryEnabled {
+		var span mcp.SpanRef
+		operationStart := time.Now()
+		span, traceparent, tracestate = mcp.StartSpan(ctx, t.Tracer, "tools/list", t.protocolVersion, requestURL, "")
+		defer func() {
+			mcp.RecordOperationDuration(ctx, t.OperationDurationHistogram, time.Since(operationStart).Seconds(), "tools/list", t.protocolVersion, requestURL, "", err)
+			mcp.EndSpan(span, err)
+		}()
+	}
+
+	var listParams listToolsRequestParams
+	if traceparent != "" || tracestate != "" {
+		listParams.Meta = &mcpMeta{Traceparent: traceparent, Tracestate: tracestate}
+	}
+
 	var result listToolsResult
-	if err := t.sendRequest(ctx, requestURL, "tools/list", map[string]any{}, headers, &result); err != nil {
+	if err = t.sendRequest(ctx, requestURL, "tools/list", listParams, headers, &result); err != nil {
 		return nil, fmt.Errorf("failed to list tools: %w", err)
 	}
 
-	manifest := &transport.ManifestSchema{
+	manifest = &transport.ManifestSchema{
 		ServerVersion: t.ServerVersion,
 		Tools:         make(map[string]transport.ToolSchema),
 	}
 
 	for i, tool := range result.Tools {
 		if tool.Name == "" {
-			return nil, fmt.Errorf("received invalid tool definition at index %d: missing 'name' field", i)
+			err = fmt.Errorf("received invalid tool definition at index %d: missing 'name' field", i)
+			return nil, err
 		}
 
 		rawTool := map[string]any{
@@ -103,7 +122,8 @@ func (t *McpTransport) ListTools(ctx context.Context, toolsetName string, header
 			rawTool["_meta"] = tool.Meta
 		}
 
-		toolSchema, err := t.ConvertToolDefinition(rawTool)
+		var toolSchema transport.ToolSchema
+		toolSchema, err = t.ConvertToolDefinition(rawTool)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert schema for tool %s: %w", tool.Name, err)
 		}
@@ -133,22 +153,43 @@ func (t *McpTransport) GetTool(ctx context.Context, toolName string, headers map
 }
 
 // InvokeTool executes a tool
-func (t *McpTransport) InvokeTool(ctx context.Context, toolName string, payload map[string]any, headers map[string]string) (any, error) {
-	if err := t.EnsureInitialized(ctx, headers); err != nil {
+func (t *McpTransport) InvokeTool(ctx context.Context, toolName string, payload map[string]any, headers map[string]string) (output any, err error) {
+	if err = t.EnsureInitialized(ctx, headers); err != nil {
 		return "", err
 	}
+
+	// Start telemetry span before the operation. In the finally-equivalent defer,
+	// record the operation duration metric and end the span.
+	var traceparent, tracestate string
+	if t.TelemetryEnabled {
+		var span mcp.SpanRef
+		operationStart := time.Now()
+		span, traceparent, tracestate = mcp.StartSpan(ctx, t.Tracer, "tools/call", t.protocolVersion, t.BaseURL(), toolName)
+		defer func() {
+			mcp.RecordOperationDuration(ctx, t.OperationDurationHistogram, time.Since(operationStart).Seconds(), "tools/call", t.protocolVersion, t.BaseURL(), toolName, err)
+			mcp.EndSpan(span, err)
+		}()
+	}
+
+	var meta *mcpMeta
+	if traceparent != "" || tracestate != "" {
+		meta = &mcpMeta{Traceparent: traceparent, Tracestate: tracestate}
+	}
+
 	params := callToolRequestParams{
 		Name:      toolName,
 		Arguments: payload,
+		Meta:      meta,
 	}
 
 	var result callToolResult
-	if err := t.sendRequest(ctx, t.BaseURL(), "tools/call", params, headers, &result); err != nil {
+	if err = t.sendRequest(ctx, t.BaseURL(), "tools/call", params, headers, &result); err != nil {
 		return "", fmt.Errorf("failed to invoke tool '%s': %w", toolName, err)
 	}
 
 	if result.IsError {
-		return "", fmt.Errorf("tool execution resulted in error")
+		err = fmt.Errorf("tool execution resulted in error")
+		return "", err
 	}
 
 	baseContent := make([]mcp.ToolContent, len(result.Content))
@@ -159,13 +200,30 @@ func (t *McpTransport) InvokeTool(ctx context.Context, toolName string, payload 
 		}
 	}
 
-	output := t.ProcessToolResultContent(baseContent)
-
-	return output, nil
+	return t.ProcessToolResultContent(baseContent), nil
 }
 
 // initializeSession performs the initial handshake with the server.
-func (t *McpTransport) initializeSession(ctx context.Context, headers map[string]string) error {
+func (t *McpTransport) initializeSession(ctx context.Context, headers map[string]string) (err error) {
+	// Start telemetry span before the operation. In the finally-equivalent defer,
+	// record the operation duration metric and end the span.
+	var traceparent, tracestate string
+	if t.TelemetryEnabled {
+		t.StartSession(ProtocolVersion)
+		var span mcp.SpanRef
+		operationStart := time.Now()
+		span, traceparent, tracestate = mcp.StartSpan(ctx, t.Tracer, "initialize", t.protocolVersion, t.BaseURL(), "")
+		defer func() {
+			mcp.RecordOperationDuration(ctx, t.OperationDurationHistogram, time.Since(operationStart).Seconds(), "initialize", t.protocolVersion, t.BaseURL(), "", err)
+			mcp.EndSpan(span, err)
+		}()
+	}
+
+	var meta *mcpMeta
+	if traceparent != "" || tracestate != "" {
+		meta = &mcpMeta{Traceparent: traceparent, Tracestate: tracestate}
+	}
+
 	params := initializeRequestParams{
 		ProtocolVersion: t.protocolVersion,
 		Capabilities:    clientCapabilities{},
@@ -173,27 +231,31 @@ func (t *McpTransport) initializeSession(ctx context.Context, headers map[string
 			Name:    t.clientName,
 			Version: t.clientVersion,
 		},
+		Meta: meta,
 	}
 
 	var result initializeResult
-	if err := t.sendRequest(ctx, t.BaseURL(), "initialize", params, headers, &result); err != nil {
+	if err = t.sendRequest(ctx, t.BaseURL(), "initialize", params, headers, &result); err != nil {
 		return err
 	}
 
 	// Protocol Version Check
 	if result.ProtocolVersion != t.protocolVersion {
-		return fmt.Errorf("MCP version mismatch: client (%s) != server (%s)", t.protocolVersion, result.ProtocolVersion)
+		err = fmt.Errorf("MCP version mismatch: client (%s) != server (%s)", t.protocolVersion, result.ProtocolVersion)
+		return err
 	}
 
 	// Capabilities Check
 	if result.Capabilities.Tools == nil {
-		return fmt.Errorf("server does not support the 'tools' capability")
+		err = fmt.Errorf("server does not support the 'tools' capability")
+		return err
 	}
 
 	t.ServerVersion = result.ServerInfo.Version
 
 	// Confirm Handshake
-	return t.sendNotification(ctx, "notifications/initialized", map[string]any{}, headers)
+	err = t.sendNotification(ctx, "notifications/initialized", map[string]any{}, headers)
+	return err
 }
 
 // sendRequest sends a standard JSON-RPC request to the server.

--- a/core/transport/mcp/v20251125/mcp_test.go
+++ b/core/transport/mcp/v20251125/mcp_test.go
@@ -28,6 +28,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 // capturedRequest holds both the RPC body and the HTTP headers for verification
@@ -127,7 +130,7 @@ func TestHeaders_Presence(t *testing.T) {
 	server := newMockMCPServer(t)
 	defer server.Close()
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	err := client.EnsureInitialized(context.Background(), nil)
 	require.NoError(t, err)
 
@@ -166,7 +169,7 @@ func TestListTools(t *testing.T) {
 		}, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	ctx := context.Background()
 
 	t.Run("Success", func(t *testing.T) {
@@ -207,7 +210,7 @@ func TestListTools_ErrorOnEmptyName(t *testing.T) {
 		}, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	_, err := client.ListTools(context.Background(), "", nil)
 
 	assert.Error(t, err)
@@ -227,7 +230,7 @@ func TestGetTool_Success(t *testing.T) {
 		}, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	manifest, err := client.GetTool(context.Background(), "tool_a", nil)
 	require.NoError(t, err)
 	assert.Contains(t, manifest.Tools, "tool_a")
@@ -242,7 +245,7 @@ func TestGetTool_NotFound(t *testing.T) {
 		return listToolsResult{Tools: []mcpTool{}}, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	_, err := client.GetTool(context.Background(), "missing_tool", nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
@@ -269,7 +272,7 @@ func TestInvokeTool(t *testing.T) {
 		}, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	ctx := context.Background()
 
 	t.Run("Success", func(t *testing.T) {
@@ -302,7 +305,7 @@ func TestProtocolMismatch(t *testing.T) {
 		}, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 
 	_, err := client.ListTools(context.Background(), "", nil)
 	assert.Error(t, err)
@@ -321,7 +324,7 @@ func TestInitialize_MissingCapabilities(t *testing.T) {
 		}, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	_, err := client.ListTools(context.Background(), "", nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "does not support the 'tools' capability")
@@ -329,7 +332,7 @@ func TestInitialize_MissingCapabilities(t *testing.T) {
 
 func TestConvertToolSchema(t *testing.T) {
 	// Use the transport's ConvertToolDefinition which delegates to the base/helper logic
-	tr, _ := New("http://example.com", nil, "test-client", "1.0.0")
+	tr, _ := New("http://example.com", nil, "test-client", "1.0.0", false)
 
 	rawTool := map[string]any{
 		"name":        "complex_tool",
@@ -379,7 +382,7 @@ func TestListTools_WithToolset(t *testing.T) {
 		return listToolsResult{Tools: []mcpTool{}}, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	toolsetName := "my-toolset"
 
 	_, err := client.ListTools(context.Background(), toolsetName, nil)
@@ -392,7 +395,7 @@ func TestRequest_NetworkError(t *testing.T) {
 	url := server.URL
 	server.Close()
 
-	client, _ := New(url, server.Client(), "test-client", "1.0.0")
+	client, _ := New(url, server.Client(), "test-client", "1.0.0", false)
 	_, err := client.ListTools(context.Background(), "", nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "http request failed")
@@ -405,7 +408,7 @@ func TestRequest_ServerError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	_, err := client.ListTools(context.Background(), "", nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "API request failed with status 500")
@@ -418,7 +421,7 @@ func TestRequest_BadJSON(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	_, err := client.ListTools(context.Background(), "", nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "response unmarshal failed")
@@ -426,7 +429,7 @@ func TestRequest_BadJSON(t *testing.T) {
 
 func TestRequest_NewRequestError(t *testing.T) {
 	// Bad URL triggers http.NewRequest error
-	_, err := New("http://bad\nurl.com", http.DefaultClient, "test-client", "1.0.0")
+	_, err := New("http://bad\nurl.com", http.DefaultClient, "test-client", "1.0.0", false)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid control character in URL")
 }
@@ -434,7 +437,7 @@ func TestRequest_NewRequestError(t *testing.T) {
 func TestRequest_MarshalError(t *testing.T) {
 	server := newMockMCPServer(t)
 	defer server.Close()
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 
 	// Force initialization first
 	_ = client.EnsureInitialized(context.Background(), nil)
@@ -457,7 +460,7 @@ func TestInvokeTool_ErrorResult(t *testing.T) {
 		}, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	_, err := client.InvokeTool(context.Background(), "tool", nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "tool execution resulted in error")
@@ -471,7 +474,7 @@ func TestInvokeTool_RPCError(t *testing.T) {
 		return nil, errors.New("internal server error")
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	_, err := client.InvokeTool(context.Background(), "tool", nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "internal server error")
@@ -491,7 +494,7 @@ func TestInvokeTool_ComplexContent(t *testing.T) {
 		}, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	res, err := client.InvokeTool(context.Background(), "t", nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "Part 1 Part 2", res)
@@ -507,7 +510,7 @@ func TestInvokeTool_EmptyResult(t *testing.T) {
 		}, nil
 	}
 
-	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 	res, err := client.InvokeTool(context.Background(), "t", nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "null", res)
@@ -528,7 +531,7 @@ func TestInvokeTool_ContentProcessing_Scenarios(t *testing.T) {
 			}, nil
 		}
 
-		client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+		client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 		result, err := client.InvokeTool(context.Background(), "tool", nil, nil)
 		require.NoError(t, err)
 
@@ -552,7 +555,7 @@ func TestInvokeTool_ContentProcessing_Scenarios(t *testing.T) {
 			}, nil
 		}
 
-		client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+		client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 		result, err := client.InvokeTool(context.Background(), "tool", nil, nil)
 		require.NoError(t, err)
 
@@ -575,7 +578,7 @@ func TestInvokeTool_ContentProcessing_Scenarios(t *testing.T) {
 			}, nil
 		}
 
-		client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
+		client, _ := New(server.URL, server.Client(), "test-client", "1.0.0", false)
 		result, err := client.InvokeTool(context.Background(), "tool", nil, nil)
 		require.NoError(t, err)
 
@@ -585,7 +588,7 @@ func TestInvokeTool_ContentProcessing_Scenarios(t *testing.T) {
 }
 
 func TestEnsureInitialized_PassesHeaders(t *testing.T) {
-	tr, err := New("http://fake.com", nil, "test-client", "1.0.0")
+	tr, err := New("http://fake.com", nil, "test-client", "1.0.0", false)
 	require.NoError(t, err)
 
 	capturedHeaders := make(map[string]string)
@@ -641,7 +644,7 @@ func TestInitializeSession_PassesHeadersToWire(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	tr, err := New(ts.URL, ts.Client(), "test-client", "1.0.0")
+	tr, err := New(ts.URL, ts.Client(), "test-client", "1.0.0", false)
 	require.NoError(t, err)
 
 	testHeaders := map[string]string{"Authorization": "Bearer token"}
@@ -655,7 +658,7 @@ func TestNew_ClientVersion(t *testing.T) {
 
 	t.Run("Test with explicit version", func(t *testing.T) {
 		explicitVersion := "2.0.0"
-		tr1, err := New("http://example.com", nil, clientName, explicitVersion)
+		tr1, err := New("http://example.com", nil, clientName, explicitVersion, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -666,7 +669,7 @@ func TestNew_ClientVersion(t *testing.T) {
 	})
 
 	t.Run("Test with empty version uses SDKVersion", func(t *testing.T) {
-		tr2, err := New("http://example.com", nil, clientName, "")
+		tr2, err := New("http://example.com", nil, clientName, "", false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -675,4 +678,152 @@ func TestNew_ClientVersion(t *testing.T) {
 			t.Errorf("expected clientVersion %q, got %q", mcp.SDKVersion, tr2.clientVersion)
 		}
 	})
+}
+
+// --------------------------------------------------------------------------
+// Telemetry integration tests
+// --------------------------------------------------------------------------
+
+// setupRealTracerProvider installs a real in-memory TracerProvider as the
+// global provider for the duration of a test, then restores the previous one.
+func setupRealTracerProvider(t *testing.T) *tracetest.InMemoryExporter {
+	t.Helper()
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { otel.SetTracerProvider(prev) })
+	return exp
+}
+
+func TestListTools_WithTelemetry_PropagatesTraceparent(t *testing.T) {
+	setupRealTracerProvider(t)
+
+	server := newMockMCPServer(t)
+	defer server.Close()
+
+	server.handlers["tools/list"] = func(params json.RawMessage) (any, error) {
+		return listToolsResult{Tools: []mcpTool{}}, nil
+	}
+
+	client, err := New(server.URL, server.Client(), "client", "1.0.0", true)
+	require.NoError(t, err)
+
+	_, err = client.ListTools(context.Background(), "", nil)
+	require.NoError(t, err)
+
+	var toolsListReq *jsonRPCRequest
+	for i, r := range server.requests {
+		if r.Body.Method == "tools/list" {
+			toolsListReq = &server.requests[i].Body
+			break
+		}
+	}
+	require.NotNil(t, toolsListReq, "expected tools/list request to be captured")
+
+	paramsBytes, err := json.Marshal(toolsListReq.Params)
+	require.NoError(t, err)
+
+	var params listToolsRequestParams
+	require.NoError(t, json.Unmarshal(paramsBytes, &params))
+
+	assert.NotNil(t, params.Meta, "expected _meta to be set when telemetry is enabled")
+	if params.Meta != nil {
+		assert.NotEmpty(t, params.Meta.Traceparent, "expected traceparent to be set in _meta")
+	}
+}
+
+func TestInvokeTool_WithTelemetry_PropagatesTraceparent(t *testing.T) {
+	setupRealTracerProvider(t)
+
+	server := newMockMCPServer(t)
+	defer server.Close()
+
+	server.handlers["tools/call"] = func(params json.RawMessage) (any, error) {
+		return callToolResult{
+			Content: []textContent{{Type: "text", Text: "ok"}},
+		}, nil
+	}
+
+	client, err := New(server.URL, server.Client(), "client", "1.0.0", true)
+	require.NoError(t, err)
+
+	_, err = client.InvokeTool(context.Background(), "my_tool", nil, nil)
+	require.NoError(t, err)
+
+	var callReq *jsonRPCRequest
+	for i, r := range server.requests {
+		if r.Body.Method == "tools/call" {
+			callReq = &server.requests[i].Body
+			break
+		}
+	}
+	require.NotNil(t, callReq, "expected tools/call request to be captured")
+
+	paramsBytes, err := json.Marshal(callReq.Params)
+	require.NoError(t, err)
+
+	var params callToolRequestParams
+	require.NoError(t, json.Unmarshal(paramsBytes, &params))
+
+	assert.NotNil(t, params.Meta, "expected _meta to be set when telemetry is enabled")
+	if params.Meta != nil {
+		assert.NotEmpty(t, params.Meta.Traceparent, "expected traceparent to be set in _meta")
+	}
+}
+
+func TestInitializeSession_WithTelemetry_PropagatesTraceparent(t *testing.T) {
+	setupRealTracerProvider(t)
+
+	server := newMockMCPServer(t)
+	defer server.Close()
+
+	client, err := New(server.URL, server.Client(), "client", "1.0.0", true)
+	require.NoError(t, err)
+
+	server.handlers["tools/list"] = func(params json.RawMessage) (any, error) {
+		return listToolsResult{Tools: []mcpTool{}}, nil
+	}
+	_, err = client.ListTools(context.Background(), "", nil)
+	require.NoError(t, err)
+
+	var initReq *jsonRPCRequest
+	for i, r := range server.requests {
+		if r.Body.Method == "initialize" {
+			initReq = &server.requests[i].Body
+			break
+		}
+	}
+	require.NotNil(t, initReq, "expected initialize request to be captured")
+
+	paramsBytes, err := json.Marshal(initReq.Params)
+	require.NoError(t, err)
+
+	var params initializeRequestParams
+	require.NoError(t, json.Unmarshal(paramsBytes, &params))
+
+	assert.NotNil(t, params.Meta, "expected _meta to be set when telemetry is enabled")
+	if params.Meta != nil {
+		assert.NotEmpty(t, params.Meta.Traceparent, "expected traceparent to be set in _meta")
+	}
+}
+
+func TestClose_WithTelemetry_RecordsSessionDuration(t *testing.T) {
+	setupRealTracerProvider(t)
+
+	server := newMockMCPServer(t)
+	defer server.Close()
+
+	server.handlers["tools/list"] = func(params json.RawMessage) (any, error) {
+		return listToolsResult{Tools: []mcpTool{}}, nil
+	}
+
+	client, err := New(server.URL, server.Client(), "client", "1.0.0", true)
+	require.NoError(t, err)
+
+	_, err = client.ListTools(context.Background(), "", nil)
+	require.NoError(t, err)
+
+	err = client.Close(context.Background())
+	assert.NoError(t, err)
 }

--- a/core/transport/mcp/v20251125/types.go
+++ b/core/transport/mcp/v20251125/types.go
@@ -61,11 +61,24 @@ type serverCapabilities struct {
 	Tools   map[string]any `json:"tools,omitempty"`
 }
 
+// mcpMeta carries OpenTelemetry trace context for MCP context propagation.
+// See: https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/#context-propagation
+type mcpMeta struct {
+	Traceparent string `json:"traceparent,omitempty"`
+	Tracestate  string `json:"tracestate,omitempty"`
+}
+
 // initializeRequestParams holds the parameters for the 'initialize' handshake.
 type initializeRequestParams struct {
 	ProtocolVersion string             `json:"protocolVersion"`
 	Capabilities    clientCapabilities `json:"capabilities"`
 	ClientInfo      implementation     `json:"clientInfo"`
+	Meta            *mcpMeta           `json:"_meta,omitempty"`
+}
+
+// listToolsRequestParams holds the parameters for the 'tools/list' method.
+type listToolsRequestParams struct {
+	Meta *mcpMeta `json:"_meta,omitempty"`
 }
 
 // initializeResult holds the response from the 'initialize' handshake.
@@ -93,6 +106,7 @@ type listToolsResult struct {
 type callToolRequestParams struct {
 	Name      string         `json:"name"`
 	Arguments map[string]any `json:"arguments"`
+	Meta      *mcpMeta       `json:"_meta,omitempty"`
 }
 
 // textContent represents a single text block in a tool's output.


### PR DESCRIPTION
### Description: 

> Add observability to the toolbox-core Go SDK via OpenTelemetry, including tracing and metrics, and context propogation by client-server link following MCP Semantic Convention

----
### What we have covered:
- Introduce tracing spans for SDK operations following MCP Semantic Conventions.
- Add metrics to capture SDK usage and performance (mcp.client.session.duration, mcp.client.operation.duration).
- Ensure client spans are linked as parents of corresponding server spans for proper context propagation.
- Enables consistent telemetry across the Toolbox stack and OTLP-compatible backends for debugging and performance monitoring.

Issue: #207 