### PR TITLE
chore(api-docs): unbreak workflow and fix stale module path

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.24.4'
+          go-version: '1.25.0'
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f # v3

--- a/docs-site/go.mod
+++ b/docs-site/go.mod
@@ -1,4 +1,4 @@
-module github.com/AnmolShukla2002/mcp-toolbox-sdk-go/docs-site
+module github.com/googleapis/mcp-toolbox-sdk-go/docs-site
 
 go 1.24.13
 


### PR DESCRIPTION
Unblocks the API Reference Deployment workflow, which has been failing on every run since 2026-04-01 due to a Go toolchain mismatch.

  ## What changed

  - **`actions/setup-go` pinned to `1.25.0`** (was `1.24.4`). The SDK modules require `go >= 1.24.13`, so every workflow run was crashing during `go
  install gomarkdoc` with:
    go: go.mod requires go >= 1.24.13 (running go 1.24.4; GOTOOLCHAIN=local)
  `1.25.0` matches the version already pinned in `lint.yaml`, keeping our CI Go versions in lockstep.

  - **`docs-site/go.mod` module path corrected** from `github.com/AnmolShukla2002/mcp-toolbox-sdk-go/docs-site` to
  `github.com/googleapis/mcp-toolbox-sdk-go/docs-site`. The fork path was left over from an earlier contribution.
  
  ## Why this matters
  
`https://go.mcp-toolbox.dev/main/` has been serving stale docs for ~8 weeks because no build has succeeded since the toolchain drifted past `1.24.4`.