### PR TITLE
ci(api-docs): trigger deployment on tag pushes

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -17,7 +17,8 @@ name: "API Reference Deployment"
 on:
   push:
     branches: [ 'main', 'ref-docs' ]
-  workflow_dispatch: 
+    tags: [ '**' ]
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
Adds tags:['**'] so the API Reference Deployment workflow fires on tag pushes, not just main. Inert until a tag is pushed; per-package routing and root-redirect handling follow in subsequent PRs.