### PR TITLE
ci(api-docs): isolate per-package builds and stabilize root URL

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -58,15 +58,15 @@ jobs:
         id: resolve
         run: |
           # Route the git ref to the package(s) and version to build.
-          # Per-package tags build one package; bare legacy tags build all three.
+          # A per-package tag builds that one package; pushes to main (and manual
+          # dispatch) build all three as "dev". Any other tag is skipped.
           REF="${GITHUB_REF}"
           case "$REF" in
-            refs/tags/core/v*)      echo "packages=core"                >> "$GITHUB_OUTPUT"; echo "version=${REF#refs/tags/core/}"     >> "$GITHUB_OUTPUT" ;;
-            refs/tags/tbadk/v*)     echo "packages=tbadk"               >> "$GITHUB_OUTPUT"; echo "version=${REF#refs/tags/tbadk/}"    >> "$GITHUB_OUTPUT" ;;
-            refs/tags/tbgenkit/v*)  echo "packages=tbgenkit"            >> "$GITHUB_OUTPUT"; echo "version=${REF#refs/tags/tbgenkit/}" >> "$GITHUB_OUTPUT" ;;
-            refs/tags/v[0-9]*)      echo "packages=core tbadk tbgenkit" >> "$GITHUB_OUTPUT"; echo "version=${REF#refs/tags/}"          >> "$GITHUB_OUTPUT" ;;
-            refs/tags/github.com/*) echo "packages="                    >> "$GITHUB_OUTPUT"; echo "version="                          >> "$GITHUB_OUTPUT" ;;
-            *)                      echo "packages=core tbadk tbgenkit" >> "$GITHUB_OUTPUT"; echo "version=dev"                        >> "$GITHUB_OUTPUT" ;;
+            refs/tags/core/v*)     echo "packages=core"                >> "$GITHUB_OUTPUT"; echo "version=${REF#refs/tags/core/}"     >> "$GITHUB_OUTPUT" ;;
+            refs/tags/tbadk/v*)    echo "packages=tbadk"               >> "$GITHUB_OUTPUT"; echo "version=${REF#refs/tags/tbadk/}"    >> "$GITHUB_OUTPUT" ;;
+            refs/tags/tbgenkit/v*) echo "packages=tbgenkit"            >> "$GITHUB_OUTPUT"; echo "version=${REF#refs/tags/tbgenkit/}" >> "$GITHUB_OUTPUT" ;;
+            refs/tags/*)           echo "packages="                    >> "$GITHUB_OUTPUT"; echo "version="                          >> "$GITHUB_OUTPUT" ;;
+            *)                     echo "packages=core tbadk tbgenkit" >> "$GITHUB_OUTPUT"; echo "version=dev"                        >> "$GITHUB_OUTPUT" ;;
           esac
 
           # Deploys only run upstream (see job-level guard), so always use the
@@ -78,11 +78,6 @@ jobs:
         run: |
           chmod +x scripts/generate-api-docs.sh
           for PKG in ${{ steps.resolve.outputs.packages }}; do
-            # Legacy bare tags predate some packages; skip any absent at this ref.
-            if [[ "${{ steps.resolve.outputs.version }}" != "dev" ]] && [ ! -d "$PKG" ]; then
-              echo "Package $PKG absent at this ref; skipping." >&2
-              continue
-            fi
             ./scripts/generate-api-docs.sh "$PKG" "${{ steps.resolve.outputs.version }}" "$BASE_URL"
           done
 

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -16,7 +16,7 @@
 name: "API Reference Deployment"
 on:
   push:
-    branches: [ 'main', 'ref-docs' ]
+    branches: [ 'main' ]
     tags: [ '**' ]
   workflow_dispatch:
 
@@ -26,6 +26,8 @@ concurrency:
 
 jobs:
   deploy:
+    # Never run on forks; docs deploy only from the upstream repository.
+    if: github.repository == 'googleapis/mcp-toolbox-sdk-go'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -67,13 +69,9 @@ jobs:
             *)                      echo "packages=core tbadk tbgenkit" >> "$GITHUB_OUTPUT"; echo "version=dev"                        >> "$GITHUB_OUTPUT" ;;
           esac
 
-          # Upstream serves from the custom domain; forks fall back to their
-          # GitHub Pages URL so external contributors can preview docsite changes.
-          if [[ "${{ github.repository }}" == "googleapis/mcp-toolbox-sdk-go" ]]; then
-            echo "BASE_URL=https://go.mcp-toolbox.dev/" >> "$GITHUB_ENV"
-          else
-            echo "BASE_URL=https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/" >> "$GITHUB_ENV"
-          fi
+          # Deploys only run upstream (see job-level guard), so always use the
+          # production domain.
+          echo "BASE_URL=https://go.mcp-toolbox.dev/" >> "$GITHUB_ENV"
 
       - name: Build per-package docs
         if: steps.resolve.outputs.packages != ''

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -20,6 +20,10 @@ on:
     tags: [ '**' ]
   workflow_dispatch:
 
+concurrency:
+  group: api-docs-deploy
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -48,32 +52,50 @@ jobs:
           cd docs-site
           npm install postcss postcss-cli autoprefixer
 
-      - name: Build API Reference
+      - name: Resolve build target
+        id: resolve
+        run: |
+          # Route the git ref to the package(s) and version to build.
+          # Per-package tags build one package; bare legacy tags build all three.
+          REF="${GITHUB_REF}"
+          case "$REF" in
+            refs/tags/core/v*)      echo "packages=core"                >> "$GITHUB_OUTPUT"; echo "version=${REF#refs/tags/core/}"     >> "$GITHUB_OUTPUT" ;;
+            refs/tags/tbadk/v*)     echo "packages=tbadk"               >> "$GITHUB_OUTPUT"; echo "version=${REF#refs/tags/tbadk/}"    >> "$GITHUB_OUTPUT" ;;
+            refs/tags/tbgenkit/v*)  echo "packages=tbgenkit"            >> "$GITHUB_OUTPUT"; echo "version=${REF#refs/tags/tbgenkit/}" >> "$GITHUB_OUTPUT" ;;
+            refs/tags/v[0-9]*)      echo "packages=core tbadk tbgenkit" >> "$GITHUB_OUTPUT"; echo "version=${REF#refs/tags/}"          >> "$GITHUB_OUTPUT" ;;
+            refs/tags/github.com/*) echo "packages="                    >> "$GITHUB_OUTPUT"; echo "version="                          >> "$GITHUB_OUTPUT" ;;
+            *)                      echo "packages=core tbadk tbgenkit" >> "$GITHUB_OUTPUT"; echo "version=dev"                        >> "$GITHUB_OUTPUT" ;;
+          esac
+
+          # Upstream serves from the custom domain; forks fall back to their
+          # GitHub Pages URL so external contributors can preview docsite changes.
+          if [[ "${{ github.repository }}" == "googleapis/mcp-toolbox-sdk-go" ]]; then
+            echo "BASE_URL=https://go.mcp-toolbox.dev/" >> "$GITHUB_ENV"
+          else
+            echo "BASE_URL=https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/" >> "$GITHUB_ENV"
+          fi
+
+      - name: Build per-package docs
+        if: steps.resolve.outputs.packages != ''
         run: |
           chmod +x scripts/generate-api-docs.sh
-          
-          # If the Action is running in the official upstream repository, 
-          # strictly route all assets and links to the production custom domain.
-          if [[ "${{ github.repository }}" == "googleapis/mcp-toolbox-sdk-go" ]]; then
-            BASE_URL="https://go.mcp-toolbox.dev/"
-          
-          # If the Action is running in an external contributor's fork, 
-          # dynamically fallback to their personal GitHub Pages URL.
-          # This ensures external contributors can successfully build and preview 
-          # docsite changes on their own forks without encountering broken links.
-          else
-            BASE_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/"
-          fi
-          
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/}
-          else
-            VERSION="main"
-          fi
-          
-          ./scripts/generate-api-docs.sh "$VERSION" "$BASE_URL"
+          for PKG in ${{ steps.resolve.outputs.packages }}; do
+            # Legacy bare tags predate some packages; skip any absent at this ref.
+            if [[ "${{ steps.resolve.outputs.version }}" != "dev" ]] && [ ! -d "$PKG" ]; then
+              echo "Package $PKG absent at this ref; skipping." >&2
+              continue
+            fi
+            ./scripts/generate-api-docs.sh "$PKG" "${{ steps.resolve.outputs.version }}" "$BASE_URL"
+          done
+
+      - name: Build root page
+        if: steps.resolve.outputs.packages != '' && startsWith(github.ref, 'refs/tags/')
+        run: |
+          chmod +x scripts/generate-root.sh
+          ./scripts/generate-root.sh "$BASE_URL"
 
       - name: Deploy to gh-pages
+        if: steps.resolve.outputs.packages != ''
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -17,7 +17,8 @@ name: "API Reference Deployment"
 on:
   push:
     branches: [ 'main', 'ref-docs' ]
-  workflow_dispatch: 
+    tags: [ '**' ]
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/docs-site/hugo.toml
+++ b/docs-site/hugo.toml
@@ -1,4 +1,3 @@
-baseURL = "PLACEHOLDER_BASE_URL"
 title = "MCP Toolbox Go API"
 
 [params]

--- a/scripts/generate-api-docs.sh
+++ b/scripts/generate-api-docs.sh
@@ -1,87 +1,61 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
-export PATH=$PATH:$(go env GOPATH)/bin
+export PATH="$PATH:$(go env GOPATH)/bin"
 
-VERSION=${1:-"main"}
-BASE_URL=${2:-"/"}
+PACKAGE="${1:?package required (core|tbadk|tbgenkit)}"
+VERSION="${2:?version required (e.g. v1.0.0 or dev)}"
+BASE_URL="${3:-/}"
+
+case "$PACKAGE" in
+  core)     TITLE="Core" ;;
+  tbadk)    TITLE="Tbadk" ;;
+  tbgenkit) TITLE="Tbgenkit" ;;
+  *)        echo "Unknown package: $PACKAGE" >&2; exit 1 ;;
+esac
 
 go install github.com/princjef/gomarkdoc/cmd/gomarkdoc@latest
 
-rm -rf docs-site/content/*
-mkdir -p docs-site/content/docs
+# Per-build content tree in a temp dir, kept out of the checked-in
+# docs-site/content so concurrent package builds never trample each other.
+CONTENT_DIR="$(mktemp -d)"
+trap 'rm -rf "$CONTENT_DIR"' EXIT
+mkdir -p "$CONTENT_DIR/docs"
 
-cat <<EOF > docs-site/content/_index.md
+cat > "$CONTENT_DIR/_index.md" <<EOF
 ---
-title: "MCP Toolbox Go SDK"
+title: "MCP Toolbox Go SDK — ${TITLE} (${VERSION})"
 type: docs
 ---
-
 EOF
+cat README.md >> "$CONTENT_DIR/_index.md"
 
-cat README.md >> docs-site/content/_index.md
-
-cat <<EOF > docs-site/content/docs/_index.md
+cat > "$CONTENT_DIR/docs/_index.md" <<EOF
 ---
 title: "Packages"
 type: docs
 weight: 1
 alwaysopen: true
 ---
-Select a framework to view its public variables, functions, and structs.
+Public variables, functions, and structs for the ${TITLE} package.
 EOF
 
-generate_package() {
-  local PKG_DIR=$1
-  local TITLE=$2
-  local WEIGHT=$3
-  local MANUAL_VERSIONS=$4
-  local MD_FILE="docs-site/content/docs/${PKG_DIR}.md"
+MD_FILE="$CONTENT_DIR/docs/${PACKAGE}.md"
+cat > "$MD_FILE" <<EOF
+---
+title: "${TITLE}"
+type: docs
+weight: 10
+---
 
-  printf -- "---\ntitle: \"%s\"\ntype: docs\nweight: %s\n---\n\n" "$TITLE" "$WEIGHT" > "$MD_FILE"
+Viewing \`${VERSION}\`.
 
-  cat <<EOF >> "$MD_FILE"
-<div style="margin-bottom: 2rem; padding: 1rem; background-color: #f8f9fa; border-radius: 8px; border: 1px solid #e9ecef; display: inline-block;">
-  <label for="${PKG_DIR}-version" style="font-weight: bold; margin-right: 10px; color: #4a4a4a;">Package Version:</label>
-  
-  <select id="${PKG_DIR}-version" onchange="if (this.value) window.location.href=this.value;" style="padding: 5px 10px; border-radius: 4px; border: 1px solid #ccc; background-color: white; color: #333333; cursor: pointer;">
-    <option value="${BASE_URL}main/docs/${PKG_DIR}/">main (latest)</option>
 EOF
-
-  for VER in $MANUAL_VERSIONS; do
-    echo "    <option value=\"${BASE_URL}${VER}/docs/${PKG_DIR}/\">${VER}</option>" >> "$MD_FILE"
-  done
-
-  cat <<EOF >> "$MD_FILE"
-  </select>
-</div>
-EOF
-
-  gomarkdoc ./${PKG_DIR}/... | sed '/^# /d' >> "$MD_FILE"
-}
-
-# --- EXECUTE GENERATOR (UPDATE THESE BEFORE RELEASING!) ---
-# To add a version to the dropdown, just type it inside the quotes separated by a space.
-# Example: generate_package "core" "Core" "10" "v1.0.0 v0.9.0"
-
-generate_package "core" "Core" "10" ""
-generate_package "tbadk" "Tbadk" "20" ""
-generate_package "tbgenkit" "Tbgenkit" "30" ""
+gomarkdoc "./${PACKAGE}/..." | sed '/^# /d' >> "$MD_FILE"
 
 cd docs-site
-sed -i "s|PLACEHOLDER_BASE_URL|${BASE_URL}|g" hugo.toml
-
-HUGO_PARAMS_VERSION="${VERSION}" hugo --minify --baseURL "${BASE_URL}${VERSION}/" --destination "public/${VERSION}"
-
-cat <<EOF > public/index.html
-<!DOCTYPE html>
-<html>
-<head>
-  <meta http-equiv="refresh" content="0; url=${BASE_URL}${VERSION}/" />
-</head>
-<body style="background-color: rgb(64, 63, 76); color: white; text-align: center; padding-top: 50px; font-family: sans-serif;">
-  <p>Redirecting to the latest API version (${VERSION})...</p>
-  <script>window.location.replace('${BASE_URL}${VERSION}/');</script>
-</body>
-</html>
-EOF
+HUGO_PARAMS_VERSION="${VERSION}" hugo \
+  --minify \
+  --contentDir "${CONTENT_DIR}" \
+  --baseURL "${BASE_URL}${PACKAGE}/${VERSION}/" \
+  --destination "public/${PACKAGE}/${VERSION}"

--- a/scripts/generate-api-docs.sh
+++ b/scripts/generate-api-docs.sh
@@ -18,40 +18,21 @@ go install github.com/princjef/gomarkdoc/cmd/gomarkdoc@latest
 
 # Per-build content tree in a temp dir, kept out of the checked-in
 # docs-site/content so concurrent package builds never trample each other.
+# The package's API reference is the home page, so /<pkg>/<version>/ lands
+# directly on the docs (the repo README lives only at the site root).
 CONTENT_DIR="$(mktemp -d)"
 trap 'rm -rf "$CONTENT_DIR"' EXIT
-mkdir -p "$CONTENT_DIR/docs"
 
 cat > "$CONTENT_DIR/_index.md" <<EOF
 ---
 title: "MCP Toolbox Go SDK — ${TITLE} (${VERSION})"
 type: docs
 ---
-EOF
-cat README.md >> "$CONTENT_DIR/_index.md"
-
-cat > "$CONTENT_DIR/docs/_index.md" <<EOF
----
-title: "Packages"
-type: docs
-weight: 1
-alwaysopen: true
----
-Public variables, functions, and structs for the ${TITLE} package.
-EOF
-
-MD_FILE="$CONTENT_DIR/docs/${PACKAGE}.md"
-cat > "$MD_FILE" <<EOF
----
-title: "${TITLE}"
-type: docs
-weight: 10
----
 
 Viewing \`${VERSION}\`.
 
 EOF
-gomarkdoc "./${PACKAGE}/..." | sed '/^# /d' >> "$MD_FILE"
+gomarkdoc "./${PACKAGE}/..." | sed '/^# /d' >> "$CONTENT_DIR/_index.md"
 
 cd docs-site
 HUGO_PARAMS_VERSION="${VERSION}" hugo \

--- a/scripts/generate-root.sh
+++ b/scripts/generate-root.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+BASE_URL="${1:-/}"
+
+# Render the repo README (from the checked-out tag) as the root landing page.
+# Built only on tag pushes so the root URL tracks the latest release and stays
+# stable between main-branch dev builds.
+CONTENT_DIR="$(mktemp -d)"
+trap 'rm -rf "$CONTENT_DIR"' EXIT
+
+cat > "$CONTENT_DIR/_index.md" <<EOF
+---
+title: "MCP Toolbox Go SDK"
+type: docs
+---
+EOF
+cat README.md >> "$CONTENT_DIR/_index.md"
+
+cd docs-site
+hugo \
+  --minify \
+  --contentDir "${CONTENT_DIR}" \
+  --baseURL "${BASE_URL}" \
+  --destination "public"


### PR DESCRIPTION
# Summary

Fixes two defects in the API reference docs pipeline (go.mcp-toolbox.dev) and cleans up the generation scripts:
  
  - Cross-package coupling: a single tag rebuilt all three packages into one shared folder, even though core, tbadk, and tbgenkit release on independent cadences. Now each per-package tag (core/v*, tbadk/v*, tbgenkit/v*) builds only that package at `/<pkg>/<version>/` pushes to main build all three as /<pkg>/dev/.
  - Root URL flapping: the root index.html was regenerated on every run, so `/` ping-ponged between dev and the latest tagged version. The root (repo README) is now rebuilt only on tag pushes, so it tracks the latest release and stays stable between dev builds.

#  URL model after this PR
 
| Ref pushed | Builds | Root / |
| :--- | :--- | :--- |
| push to main | /core/dev/, /tbadk/dev/, /tbgenkit/dev/ | untouched |
| tag core/v1.0.0 | /core/v1.0.0/ only | rebuilt from that tag's README |
| any other tag | nothing (skipped) | untouched |

 
#  How it was tested

Tested locally against the **exact CI Hugo version** (`0.152.2` extended). 

**1. Install the CI Hugo and lint the workflow**

```bash
cd /tmp && rm -rf hugo-test && mkdir hugo-test && cd hugo-test
curl -sSL -o hugo.tar.gz \
  https://github.com/gohugoio/hugo/releases/download/v0.152.2/hugo_extended_0.152.2_darwin-universal.tar.gz
tar xzf hugo.tar.gz && ./hugo version
export PATH="/tmp/hugo-test:$PATH"

cd /Users/twishabansal/mcp-toolbox-sdk-go
go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/api-docs.yml   # passes clean
```

**2. Replay the two workflow scenarios into one shared `public/` tree** (mimics deploying a tag on top of the existing dev site, which is how isolation gets verified)

```bash
export PATH="/tmp/hugo-test:$PATH"
rm -rf docs-site/public

# SCENARIO 1: push to main -> all three packages at dev, no root rebuild
for pkg in core tbadk tbgenkit; do
  ./scripts/generate-api-docs.sh "$pkg" dev "http://localhost:8080/"
done

# SCENARIO 2: push tag core/v1.0.0 -> only core, plus root rebuild
./scripts/generate-api-docs.sh core v1.0.0 "http://localhost:8080/"
./scripts/generate-root.sh "http://localhost:8080/"
```

**3. Assert isolation, stable root, and content**

```bash
echo "core/v1.0.0 added?       $([ -d docs-site/public/core/v1.0.0 ] && echo YES || echo NO)"
echo "core/dev still intact?   $([ -d docs-site/public/core/dev ] && echo YES || echo NO)"
echo "tbadk/dev untouched?     $([ -d docs-site/public/tbadk/dev ] && echo YES || echo NO)"
echo "tbgenkit/dev untouched?  $([ -d docs-site/public/tbgenkit/dev ] && echo YES || echo NO)"
echo "root is README?          $(grep -qiE 'Quickstart|go get' docs-site/public/index.html && echo YES || echo NO)"
echo "root NOT a redirect?     $(grep -qi 'http-equiv.*refresh' docs-site/public/index.html && echo NO || echo YES)"
echo "v1.0.0 shows 'Viewing'?  $(grep -qiE 'Viewing' docs-site/public/core/v1.0.0/index.html && echo YES || echo NO)"
echo "v1.0.0 has API symbols?  $(grep -qE 'NewToolboxClient' docs-site/public/core/v1.0.0/index.html && echo YES || echo NO)"
echo "checked-in content kept? $([ -d docs-site/content/en ] && echo YES || echo NO)"
```

All assertions returned the expected values (isolation preserved, root is the README with **0** meta-refresh redirects, tag page shows `Viewing v1.0.0` + gomarkdoc API symbols, `docs-site/content` not wiped).

**4. Visual spot-check**

```bash
cd docs-site/public && python3 -m http.server 8080
# browse http://localhost:8080/ , /core/dev/ , /core/v1.0.0/ , /tbadk/dev/ , /tbgenkit/dev/
```