### PR TITLE
ci(api-docs): backfill opens a PR into gh-pages instead of deploying

### DIFF
--- a/.github/workflows/api-docs-backfill.yml
+++ b/.github/workflows/api-docs-backfill.yml
@@ -27,8 +27,12 @@ on:
         type: string
         required: true
 
+# Scope per version: each run produces an independent branch/PR, so runs for
+# different versions can proceed in parallel. A shared group with
+# cancel-in-progress: false would make GitHub cancel a pending run whenever a
+# newer one queues, silently dropping versions when several are dispatched.
 concurrency:
-  group: api-docs-deploy
+  group: api-docs-backfill-${{ github.event.inputs.package }}-${{ github.event.inputs.version }}
   cancel-in-progress: false
 
 jobs:
@@ -38,6 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       # Build from main so the archived page carries the current version picker;
       # only the package's source comes from the tag (overlaid below) so
@@ -89,10 +94,40 @@ jobs:
           chmod +x scripts/generate-api-docs.sh
           ./scripts/generate-api-docs.sh "$PKG" "$VER" "$BASE_URL"
 
-      - name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs-site/public
-          keep_files: true
-          cname: ${{ github.repository == 'googleapis/mcp-toolbox-sdk-go' && 'go.mcp-toolbox.dev' || '' }}
+      # Open a PR into gh-pages instead of deploying directly, so a human reviews
+      # before the page goes live. Overlaying the build onto a clone of the live
+      # gh-pages tree mirrors keep_files: true — existing files (other versions,
+      # CNAME, .nojekyll) are preserved and the PR diff is just this version.
+      - name: Open PR against gh-pages
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PKG: ${{ inputs.package }}
+          VER: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          BRANCH="backfill/${PKG}-${VER}"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          WORK="$(mktemp -d)"
+          git clone --depth 1 --branch gh-pages --single-branch \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$WORK"
+          cp -R "${GITHUB_WORKSPACE}/docs-site/public/." "$WORK/"
+
+          cd "$WORK"
+          git checkout -B "$BRANCH"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No documentation changes for ${PKG} ${VER}; skipping PR."
+            exit 0
+          fi
+          git commit -m "docs(api): backfill ${PKG} ${VER}"
+          git push -f origin "$BRANCH"
+
+          if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
+            echo "PR already open for ${BRANCH}; branch updated."
+          else
+            gh pr create --base gh-pages --head "$BRANCH" \
+              --title "docs(api): backfill ${PKG} ${VER}" \
+              --body "Automated API reference backfill for \`${PKG}/${VER}\`, built from main tooling with the tagged source overlaid. Merging publishes to gh-pages (additive)."
+          fi

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -154,6 +154,29 @@ Steps to backfill:
     version's directory) and **merge it into `gh-pages`** to publish. Re-running the
     workflow for the same version updates the existing PR's branch.
 
+#### Previewing a backfill PR
+
+GitHub won't render the built HTML in the PR diff. Because the PR branch *is* the
+rendered `gh-pages` tree, check it out and serve it statically — exactly what Pages
+will serve after merge:
+
+```bash
+git fetch origin backfill/<pkg>-<ver>
+# Check the branch out somewhere disposable (a detached worktree keeps your
+# current branch untouched).
+git worktree add --detach /tmp/preview-docs origin/backfill/<pkg>-<ver>
+python3 -m http.server 8099 --directory /tmp/preview-docs
+# → http://localhost:8099/<pkg>/<ver>/   e.g. http://localhost:8099/core/v0.7.0/
+```
+
+The version dropdown fetches `/<pkg>/releases.releases` at runtime, so links to
+versions not present in this branch (other backfills) will 404 locally — that's
+expected. When done, clean up:
+
+```bash
+git worktree remove /tmp/preview-docs
+```
+
 ### Building locally
 
 ```bash

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -118,15 +118,41 @@ that version.
 
 ### Backfilling old docs
 
-The **`api-docs-backfill.yml`** (API Reference Backfill) workflow runs on demand and
-builds **one historical version per run**. Use it to build any version whose docs
-are missing or whose deployment failed.
+Use the **`api-docs-backfill.yml`** (API Reference Backfill) workflow to publish docs
+for a version whose pages are missing — typically releases that predate the docs
+tooling, or a deployment that failed. It builds **one historical version per run**.
 
-Trigger it from the Actions tab, or with:
+Unlike `api-docs.yml`, this workflow does **not** deploy to production directly. Each
+run opens a **pull request into the `gh-pages` branch**, so the docs are reviewed
+before they go live. The page is published only when you merge that PR.
 
-```bash
-gh workflow run api-docs-backfill.yml -f package=core -f version=v1.0.0
-```
+How a run works:
+
+1.  It checks out `main` for the current docs tooling (layouts, scripts, version
+    picker), then overlays the requested version's package source from its release
+    tag, so `gomarkdoc` documents that version's API.
+2.  It builds `/<package>/<version>/` (plus the package's `releases`/`latest` files).
+3.  It overlays the build onto a clone of the live `gh-pages` tree — existing
+    versions, `CNAME`, and `.nojekyll` are preserved — and opens a PR from branch
+    `backfill/<pkg>-<ver>` with `gh-pages` as the base.
+
+Steps to backfill:
+
+1.  Make sure the version is listed in `docs-site/hugo.toml` (see
+    [Adding a version to the picker](#adding-a-version-to-the-picker)), so the
+    dropdown links to it.
+2.  Trigger the workflow from the Actions tab, or with:
+
+    ```bash
+    gh workflow run api-docs-backfill.yml -f package=core -f version=v1.0.0
+    ```
+
+    To catch up several versions, dispatch it once per `package`/`version`. The
+    concurrency group is scoped per version, so the runs are independent and none
+    are cancelled — each opens its own PR.
+3.  Review the resulting `backfill/<pkg>-<ver>` PR (the diff should be just that
+    version's directory) and **merge it into `gh-pages`** to publish. Re-running the
+    workflow for the same version updates the existing PR's branch.
 
 ### Building locally
 


### PR DESCRIPTION
## Summary
- The API Reference Backfill workflow (`api-docs-backfill.yml`) currently deploys built docs **straight to `gh-pages`** (prod, go.mcp-toolbox.dev) with no review step. This changes it to **open a PR into `gh-pages`** instead, so historical-version docs are reviewed before they go live.
- Replaces the `peaceiris/actions-gh-pages` deploy with a `gh` CLI step: clone the live `gh-pages` tree, overlay the freshly built `docs-site/public/` on top (mirrors `keep_files: true` — existing versions, `CNAME`, `.nojekyll` preserved), commit to a per-version branch `backfill/<pkg>-<ver>`, push, and `gh pr create --base gh-pages` (idempotent on re-run).
- Scopes the `concurrency` group **per version** instead of the shared `api-docs-deploy`. Each run now produces an independent branch/PR, so versions can run in parallel; the old shared group + `cancel-in-progress: false` would cancel a *pending* run whenever a newer one queued, silently dropping versions when several are dispatched at once.
- Adds `pull-requests: write` to the job permissions (needed for `gh pr create`).