### PR TITLE
docs: add API Reference links to README package table

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ within your Go applications or AI orchestration frameworks.
 This repository hosts the following Go packages. See the package-specific
 README for detailed installation and usage instructions:
 
-| Package | Target Use Case | Path | Documentation |
-| :------ | :----------| :--- | :---------- |
-| `core` | Framework-agnostic / Custom apps | `core/` | [Go SDK Core Guide](https://mcp-toolbox.dev/documentation/connect-to/toolbox-sdks/go-sdk/core/) |
-| `tbadk` | ADK Go Integration | `tbadk/` | [ADK Package Guide](https://mcp-toolbox.dev/documentation/connect-to/toolbox-sdks/go-sdk/tbadk/) |
-| `tbgenkit` | Genkit Go Integration | `tbgenkit/` | [Genkit Package Guide](https://mcp-toolbox.dev/documentation/connect-to/toolbox-sdks/go-sdk/tbgenkit/) |
+| Package | Target Use Case | Path | Documentation | API Reference |
+| :------ | :----------| :--- | :---------- | :---------- |
+| `core` | Framework-agnostic / Custom apps | `core/` | [Go SDK Core Guide](https://mcp-toolbox.dev/documentation/connect-to/toolbox-sdks/go-sdk/core/) | [API Reference](https://go.mcp-toolbox.dev/core/latest/) |
+| `tbadk` | ADK Go Integration | `tbadk/` | [ADK Package Guide](https://mcp-toolbox.dev/documentation/connect-to/toolbox-sdks/go-sdk/tbadk/) | [API Reference](https://go.mcp-toolbox.dev/tbadk/latest/) |
+| `tbgenkit` | Genkit Go Integration | `tbgenkit/` | [Genkit Package Guide](https://mcp-toolbox.dev/documentation/connect-to/toolbox-sdks/go-sdk/tbgenkit/) | [API Reference](https://go.mcp-toolbox.dev/tbgenkit/latest/) |
 
 ## Quick Start
 


### PR DESCRIPTION
Adds an **API Reference** column to the *Available Packages* table, linking each package to its hosted reference docs:

| Package | API Reference |
|---------|---------------|
| `core` | https://go.mcp-toolbox.dev/core/latest/ |
| `tbadk` | https://go.mcp-toolbox.dev/tbadk/latest/ |
| `tbgenkit` | https://go.mcp-toolbox.dev/tbgenkit/latest/ |

Absolute URLs so the links work both on GitHub and on the rendered docs landing page (the landing is the rendered README). This gives the site root a working path into the per-package API docs once `/main/` is retired.