### PR TITLE
docs(api): fix root landing layout and restore cross-package nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ Logo](https://raw.githubusercontent.com/googleapis/mcp-toolbox/main/logo.png)
 **Core Module :**
 [![Go Report Card](https://goreportcard.com/badge/github.com/googleapis/mcp-toolbox-sdk-go/core)](https://goreportcard.com/report/github.com/googleapis/mcp-toolbox-sdk-go/core)
 [![Module Version](https://img.shields.io/github/v/release/googleapis/mcp-toolbox-sdk-go?filter=core/v*)](https://img.shields.io/github/v/release/googleapis/mcp-toolbox-sdk-go?filter=core/v*)
-[![Go Version](https://img.shields.io/github/go-mod/go-version/googleapis/mcp-toolbox-sdk-go?filename=core/go.mod)]([https://img.shields.io/github/go-mod/go-version/googleapis/mcp-toolbox-sdk-go](https://img.shields.io/github/go-mod/go-version/googleapis/mcp-toolbox-sdk-go?filename=core/go.mod))
+[![Go Version](https://img.shields.io/github/go-mod/go-version/googleapis/mcp-toolbox-sdk-go?filename=core/go.mod)](https://img.shields.io/github/go-mod/go-version/googleapis/mcp-toolbox-sdk-go?filename=core/go.mod)
 
 **TBADK Module :**
 [![Go Report Card](https://goreportcard.com/badge/github.com/googleapis/mcp-toolbox-sdk-go/tbadk)](https://goreportcard.com/report/github.com/googleapis/mcp-toolbox-sdk-go/tbadk)
 [![Module Version](https://img.shields.io/github/v/release/googleapis/mcp-toolbox-sdk-go?filter=tbadk/v*)](https://img.shields.io/github/v/release/googleapis/mcp-toolbox-sdk-go?filter=tbadk/v*)
-[![Go Version](https://img.shields.io/github/go-mod/go-version/googleapis/mcp-toolbox-sdk-go?filename=tbadk/go.mod)]([https://img.shields.io/github/go-mod/go-version/googleapis/mcp-toolbox-sdk-go](https://img.shields.io/github/go-mod/go-version/googleapis/mcp-toolbox-sdk-go?filename=tbadk/go.mod))
+[![Go Version](https://img.shields.io/github/go-mod/go-version/googleapis/mcp-toolbox-sdk-go?filename=tbadk/go.mod)](https://img.shields.io/github/go-mod/go-version/googleapis/mcp-toolbox-sdk-go?filename=tbadk/go.mod)
 
 **TBGenkit Module :**
 [![Go Report Card](https://goreportcard.com/badge/github.com/googleapis/mcp-toolbox-sdk-go/tbgenkit)](https://goreportcard.com/report/github.com/googleapis/mcp-toolbox-sdk-go/tbgenkit)

--- a/docs-site/hugo.toml
+++ b/docs-site/hugo.toml
@@ -2,8 +2,6 @@ title = "MCP Toolbox Go API"
 
 [params]
   offlineSearch = true
-  # Author only — Docsy's footer prepends the current year, so including a year
-  # here would render a doubled "© 2026 2026 Google LLC".
   copyright = "Google LLC"
 
 # Hand-edited version lists, one per package. Newest first — the order is

--- a/docs-site/hugo.toml
+++ b/docs-site/hugo.toml
@@ -2,7 +2,9 @@ title = "MCP Toolbox Go API"
 
 [params]
   offlineSearch = true
-  copyright = "2026 Google LLC"
+  # Author only — Docsy's footer prepends the current year, so including a year
+  # here would render a doubled "© 2026 2026 Google LLC".
+  copyright = "Google LLC"
 
 # Hand-edited version lists, one per package. Newest first — the order is
 # mirrored into the dropdown. Add a block before tagging a release, and only

--- a/docs-site/layouts/_partials/navbar-version-selector.html
+++ b/docs-site/layouts/_partials/navbar-version-selector.html
@@ -1,4 +1,6 @@
-{{ if .Site.Params.versions -}}
+{{/* Require a package context: on the rootless landing $pkg is empty, which
+     would emit a broken //releases.releases include and a meaningless picker. */ -}}
+{{ if and .Site.Params.versions .Site.Params.package -}}
 {{ $pkg := .Site.Params.package | default "" -}}
 <div class="dropdown">
   <a class="nav-link dropdown-toggle" href="#" role="button"

--- a/docs-site/layouts/_partials/sidebar-tree.html
+++ b/docs-site/layouts/_partials/sidebar-tree.html
@@ -1,0 +1,201 @@
+{{ $context := .context -}}
+{{ $sidebarRoot := .sidebarRoot -}}
+{{ $sidebarRootID := .sidebarRootID -}}
+{{ $cacheSidebar := .cacheSidebar -}}
+
+{{ with $context -}}
+
+{{/* When the sidebar is cached, "active" class is set client side. */ -}}
+{{ $shouldDelayActive := $cacheSidebar -}}
+
+<div id="td-sidebar-menu" class="td-sidebar__inner{{ if $shouldDelayActive }} d-none{{ end }}">
+  {{ if not .Site.Params.ui.sidebar_search_disable -}}
+
+  <form class="td-sidebar__search d-flex align-items-center">
+    {{ partial "search-input.html" . }}
+    <button class="btn btn-link td-sidebar__toggle" type="button" {{/**/ -}}
+      data-bs-toggle="collapse" data-bs-target="#td-section-nav" {{/**/ -}}
+      aria-controls="td-section-nav" aria-expanded="false" aria-label="Toggle section navigation">
+    </button>
+  </form>
+
+  {{- else -}}
+
+  <div id="content-mobile">
+  <form class="td-sidebar__search d-flex align-items-center">
+    {{ partial "search-input.html" . }}
+    <button class="btn btn-link td-sidebar__toggle" type="button" {{/**/ -}}
+      data-bs-toggle="collapse" data-bs-target="#td-section-nav" {{/**/ -}}
+      aria-controls="td-section-nav" aria-expanded="false" aria-label="Toggle section navigation">
+    </button>
+  </form>
+  </div>
+  <div id="content-desktop"></div>
+
+  {{- end }}
+  {{/* */ -}}
+
+  <nav class="td-sidebar-nav collapse
+        {{- if .Site.Params.ui.sidebar_search_disable }} td-sidebar-nav--search-disabled{{ end -}}
+        {{- if .Site.Params.ui.sidebar_menu_foldable }} foldable-nav{{ end }}" {{/**/ -}}
+      id="td-section-nav"
+      {{- if .Site.Params.ui.sidebar_root_enabled }} data-sidebar-root-id="{{ $sidebarRootID }}"{{ end -}}
+    >
+    {{ if and .Site.Params.ui.sidebar_lang_menu (gt (len .Site.Home.Translations) 0) -}}
+    <div class="td-sidebar-nav__section nav-item d-block d-lg-none">
+      {{ partial "navbar-lang-selector.html" . }}
+    </div>
+    {{ end -}}
+    {{/* Cross-package links: literal hrefs (not menu/relref), so they resolve
+         verbatim from any per-package subdirectory baseURL without relURL
+         rewriting them into broken /core/dev/core/latest/ style paths. */ -}}
+    {{ $pkg := .Site.Params.package | default "" -}}
+    <ul class="td-sidebar-nav__section pe-md-3 ul-0">
+      <li class="td-sidebar-nav__section-title td-sidebar-nav__section without-child">
+        <a class="align-left ps-0 td-sidebar-link td-sidebar-link__section{{ if eq $pkg "core" }} active{{ end }}" href="/core/latest/"><span{{ if eq $pkg "core" }} class="td-sidebar-nav-active-item"{{ end }}>Core</span></a>
+      </li>
+      <li class="td-sidebar-nav__section-title td-sidebar-nav__section without-child">
+        <a class="align-left ps-0 td-sidebar-link td-sidebar-link__section{{ if eq $pkg "tbadk" }} active{{ end }}" href="/tbadk/latest/"><span{{ if eq $pkg "tbadk" }} class="td-sidebar-nav-active-item"{{ end }}>tbadk</span></a>
+      </li>
+      <li class="td-sidebar-nav__section-title td-sidebar-nav__section without-child">
+        <a class="align-left ps-0 td-sidebar-link td-sidebar-link__section{{ if eq $pkg "tbgenkit" }} active{{ end }}" href="/tbgenkit/latest/"><span{{ if eq $pkg "tbgenkit" }} class="td-sidebar-nav-active-item"{{ end }}>tbgenkit</span></a>
+      </li>
+    </ul>
+    {{ $navRoot := cond (and (ne .Params.toc_root true) (eq .Site.Home.Type "docs")) .Site.Home .FirstSection -}}
+    {{ if $sidebarRoot -}}
+      {{ $navRoot = $sidebarRoot -}}
+    {{ end -}}
+    {{ $ulNr := 0 -}}
+    {{ $ulShow := .Site.Params.ui.ul_show | default 1 -}}
+    {{ $sidebarMenuTruncate := .Site.Params.ui.sidebar_menu_truncate | default 100 -}}
+    <ul class="td-sidebar-nav__section pe-md-3 ul-{{ $ulNr }}">
+      {{ template "section-tree-nav-section" (dict "page" . "section" $navRoot "shouldDelayActive" $shouldDelayActive "sidebarMenuTruncate" $sidebarMenuTruncate "ulNr" $ulNr "ulShow" (add $ulShow 1)) }}
+    </ul>
+  </nav>
+</div>
+
+{{- end }}{{/* with $context */ -}}
+
+{{ define "section-tree-nav-section" -}}
+  {{/* cSpell:ignore manuallink manuallinkrelref manuallinktitle */ -}}
+  {{ $s := .section -}}
+  {{ $p := .page -}}
+  {{ $shouldDelayActive := .shouldDelayActive -}}
+  {{ $sidebarMenuTruncate := .sidebarMenuTruncate -}}
+  {{ $treeRoot := cond (eq .ulNr 0) true false -}}
+  {{ $ulNr := .ulNr -}}
+  {{ $ulShow := .ulShow -}}
+  {{ $active := and (not $shouldDelayActive) (eq $s $p) -}}
+  {{ $activePath := and (not $shouldDelayActive) (or (eq $p $s) ($p.IsDescendant $s)) -}}
+  {{ $show := cond
+        (or
+          (lt $ulNr $ulShow)
+          $activePath
+          (and (not $shouldDelayActive) (eq $s.Parent $p.Parent))
+          (and (not $shouldDelayActive) (eq $s.Parent $p))
+          (not $p.Site.Params.ui.sidebar_menu_compact)
+          (and (not $shouldDelayActive) ($p.IsDescendant $s.Parent))
+        )
+        true false
+  -}}
+  {{ $mid := printf "m-%s" ($s.RelPermalink | anchorize) -}}
+  {{ $pages_tmp := where (union $s.Pages $s.Sections).ByWeight ".Params.toc_hide" "!=" true -}}
+  {{ $pages := $pages_tmp | first $sidebarMenuTruncate -}}
+  {{ $truncatedEntryCount := sub (len $pages_tmp) $sidebarMenuTruncate -}}
+
+  {{ if gt $truncatedEntryCount 0 -}}
+    {{ warnf "WARNING: %d sidebar entries have been truncated. To avoid this, increase `params.ui.sidebar_menu_truncate` to at least %d (from %d) in your config file. Section: %s"
+        $truncatedEntryCount (len $pages_tmp) $sidebarMenuTruncate  $s.Path -}}
+  {{ end -}}
+
+  {{ $withChild := gt (len $pages) 0 -}}
+  {{ $manualLink :=
+      cond
+        (isset $s.Params "manuallink")
+        $s.Params.manualLink
+        (cond
+          (isset $s.Params "manuallinkrelref")
+          (relref $s $s.Params.manualLinkRelref)
+          $s.RelPermalink
+        )
+  -}}
+  {{ $manualLinkTitle :=
+      cond
+        (isset $s.Params "manuallinktitle")
+        $s.Params.manualLinkTitle
+        $s.Title
+  -}}
+  {{ if and $treeRoot (eq $s.Params.sidebar_root_for "self") -}}
+    {{ with $s.Parent -}}
+      {{ $manualLink = .RelPermalink -}}
+    {{ end -}}
+  {{ end -}}
+  <li class="td-sidebar-nav__section-title td-sidebar-nav__section
+        {{- if $withChild }} with-child{{ else }} without-child{{ end -}}
+        {{ if $activePath }} active-path{{ end -}}
+        {{ if (not (or $show $p.Site.Params.ui.sidebar_menu_foldable )) }} collapse{{ end -}}
+      " {{/**/ -}}
+      id="{{ $mid }}-li" {{- /**/ -}}
+    >
+    {{ if (and $p.Site.Params.ui.sidebar_menu_foldable (ge $ulNr 1)) -}}
+    <input type="checkbox" id="{{ $mid }}-check"{{ if $activePath}} checked{{ end }}/>
+    <label for="{{ $mid }}-check">{{/**/ -}}
+      <a href="{{ $manualLink }}"
+        {{- if ne $s.LinkTitle $manualLinkTitle }} {{/**/ -}}
+          title="{{ $manualLinkTitle }}"
+        {{- end -}}
+        {{ with $s.Params.manualLinkTarget }} {{/**/ -}}
+          target="{{ . }}"
+          {{- if eq . "_blank" }} rel="noopener"{{ end -}}
+        {{ end }} {{/**/ -}}
+        class="align-left ps-0 {{ if $active}} active{{ end }} td-sidebar-link
+          {{- if $s.IsPage }} td-sidebar-link__page
+          {{- else }} td-sidebar-link__section
+          {{- end }}
+          {{- if $treeRoot }} tree-root{{ end }}" {{/**/ -}}
+        id="{{ $mid }}" {{- /**/ -}}
+      >
+        {{- with $s.Params.Icon -}}
+          <i class="{{ . }}"></i>
+        {{- end -}}
+        <span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}">
+          {{- $s.LinkTitle -}}
+        </span> {{- /**/ -}}
+      </a> {{- /**/ -}}
+    </label>
+    {{ else -}}
+      <a href="{{ $manualLink }}"
+        {{- if ne $s.LinkTitle $manualLinkTitle }} title="{{ $manualLinkTitle }}"{{ end -}}
+        {{ with $s.Params.manualLinkTarget }} {{/**/ -}}
+          target="{{ . }}"
+          {{- if eq . "_blank" }} rel="noopener"{{ end -}}
+        {{ end }} {{/**/ -}}
+        class="align-left ps-0
+          {{- if $active}} active{{ end }} {{/**/ -}}
+          td-sidebar-link
+          {{- if $s.IsPage }} td-sidebar-link__page{{ else }} td-sidebar-link__section{{ end }}
+          {{- if $treeRoot }} tree-root{{ end }}" {{/**/ -}}
+        id="{{ $mid }}" {{- /**/ -}}
+      >
+      {{- with $s.Params.Icon -}}
+        <i class="{{ . }}"></i>
+      {{- end -}}
+      <span class="
+        {{- if $active }}td-sidebar-nav-active-item{{ end -}}
+        {{- if and $treeRoot $s.Params.sidebar_root_for site.Params.ui.sidebar_root_enabled }} td-sidebar-root-up-icon{{ end -}}
+      ">
+        {{- $s.LinkTitle -}}
+      </span></a>
+    {{- end -}}
+    {{ if $withChild -}}
+    {{ $ulNr := add $ulNr 1 }}
+    <ul class="ul-{{ $ulNr }}{{ if (gt $ulNr 1)}} foldable{{end}}">
+      {{ range $pages -}}
+        {{ if (not (and (eq $s $p.Site.Home) (eq .Params.toc_root true))) -}}
+          {{ template "section-tree-nav-section" (dict "page" $p "section" . "shouldDelayActive" $shouldDelayActive "sidebarMenuTruncate" $sidebarMenuTruncate "ulNr" $ulNr "ulShow" $ulShow) }}
+        {{- end }}
+      {{- end }}
+    </ul>
+    {{- end }}
+  </li>
+{{- end -}}

--- a/docs-site/layouts/_partials/sidebar-tree.html
+++ b/docs-site/layouts/_partials/sidebar-tree.html
@@ -46,9 +46,20 @@
       {{ partial "navbar-lang-selector.html" . }}
     </div>
     {{ end -}}
+    {{ $navRoot := cond (and (ne .Params.toc_root true) (eq .Site.Home.Type "docs")) .Site.Home .FirstSection -}}
+    {{ if $sidebarRoot -}}
+      {{ $navRoot = $sidebarRoot -}}
+    {{ end -}}
+    {{ $ulNr := 0 -}}
+    {{ $ulShow := .Site.Params.ui.ul_show | default 1 -}}
+    {{ $sidebarMenuTruncate := .Site.Params.ui.sidebar_menu_truncate | default 100 -}}
+    <ul class="td-sidebar-nav__section pe-md-3 ul-{{ $ulNr }}">
+      {{ template "section-tree-nav-section" (dict "page" . "section" $navRoot "shouldDelayActive" $shouldDelayActive "sidebarMenuTruncate" $sidebarMenuTruncate "ulNr" $ulNr "ulShow" (add $ulShow 1)) }}
+    </ul>
     {{/* Cross-package links: literal hrefs (not menu/relref), so they resolve
          verbatim from any per-package subdirectory baseURL without relURL
-         rewriting them into broken /core/dev/core/latest/ style paths. */ -}}
+         rewriting them into broken /core/dev/core/latest/ style paths. Placed
+         after the page's own tree so the current page's heading comes first. */ -}}
     {{ $pkg := .Site.Params.package | default "" -}}
     <ul class="td-sidebar-nav__section pe-md-3 ul-0">
       <li class="td-sidebar-nav__section-title td-sidebar-nav__section without-child">
@@ -60,16 +71,6 @@
       <li class="td-sidebar-nav__section-title td-sidebar-nav__section without-child">
         <a class="align-left ps-0 td-sidebar-link td-sidebar-link__section{{ if eq $pkg "tbgenkit" }} active{{ end }}" href="/tbgenkit/latest/"><span{{ if eq $pkg "tbgenkit" }} class="td-sidebar-nav-active-item"{{ end }}>tbgenkit</span></a>
       </li>
-    </ul>
-    {{ $navRoot := cond (and (ne .Params.toc_root true) (eq .Site.Home.Type "docs")) .Site.Home .FirstSection -}}
-    {{ if $sidebarRoot -}}
-      {{ $navRoot = $sidebarRoot -}}
-    {{ end -}}
-    {{ $ulNr := 0 -}}
-    {{ $ulShow := .Site.Params.ui.ul_show | default 1 -}}
-    {{ $sidebarMenuTruncate := .Site.Params.ui.sidebar_menu_truncate | default 100 -}}
-    <ul class="td-sidebar-nav__section pe-md-3 ul-{{ $ulNr }}">
-      {{ template "section-tree-nav-section" (dict "page" . "section" $navRoot "shouldDelayActive" $shouldDelayActive "sidebarMenuTruncate" $sidebarMenuTruncate "ulNr" $ulNr "ulShow" (add $ulShow 1)) }}
     </ul>
   </nav>
 </div>

--- a/scripts/generate-root.sh
+++ b/scripts/generate-root.sh
@@ -15,7 +15,17 @@ title: "MCP Toolbox Go SDK"
 type: docs
 ---
 EOF
-cat README.md >> "$CONTENT_DIR/_index.md"
+# Strip the README's leading H1 and its hand-maintained TOC block before
+# appending: Docsy already renders the page title as an H1 and an "On this page"
+# TOC, so leaving them in would duplicate both on the landing page. awk (not
+# `sed -e '0,/re/'`, which is GNU-only and silently no-ops on BSD/macOS sed)
+# drops only the first `# ` heading, leaving `# ` comments in later code blocks.
+awk '
+  /<!-- TOC -->/ { intoc = 1 }
+  intoc { if (/<!-- \/TOC -->/) intoc = 0; next }
+  !h1done && /^# / { h1done = 1; next }
+  { print }
+' README.md >> "$CONTENT_DIR/_index.md"
 
 cd docs-site
 hugo \

--- a/scripts/generate-root.sh
+++ b/scripts/generate-root.sh
@@ -17,9 +17,7 @@ type: docs
 EOF
 # Strip the README's leading H1 and its hand-maintained TOC block before
 # appending: Docsy already renders the page title as an H1 and an "On this page"
-# TOC, so leaving them in would duplicate both on the landing page. awk (not
-# `sed -e '0,/re/'`, which is GNU-only and silently no-ops on BSD/macOS sed)
-# drops only the first `# ` heading, leaving `# ` comments in later code blocks.
+# TOC, so leaving them in would duplicate both on the landing page.
 awk '
   /<!-- TOC -->/ { intoc = 1 }
   intoc { if (/<!-- \/TOC -->/) intoc = 0; next }


### PR DESCRIPTION
## Summary

Fixes layout defects on the root API-reference landing page (the README installed at the bare domain by #260) and restores cross-package navigation (lost when #259 was closed).

**Root landing fixes**
- Strip the README's duplicate H1 and its manual `<!-- TOC -->` block in `generate-root.sh` (Docsy already renders both).
- Fix the doubled copyright year — Docsy v0.14.3 prepends the year, so `copyright` drops it.
- Fix malformed `core`/`tbadk` Go Version badge links.

**Navigation**
- Add Core / tbadk / tbgenkit links to the left sidebar (`sidebar-tree.html`), below the page heading.
- Hide the version picker on the rootless landing.

## Test plan
- Built root + `core dev` locally; verified single H1/TOC, correct copyright, fixed badges, sidebar links, and dropdown only on package pages.
- These changes are already deployed to the live site at https://go.mcp-toolbox.dev/

