### PR TITLE
chore: give mcp-toolbox server its own renovate group

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -34,6 +34,7 @@
       matchManagers: [
         'custom.regex',
       ],
+      groupName: 'mcp-toolbox server',
       commitMessageTopic: 'MCP Toolbox server for integration tests',
       matchUpdateTypes: [
         'minor',


### PR DESCRIPTION
## Summary
Renovate was already updating the toolbox server version, but it folded the bump into PR #153 (`update all non-major dependencies`) via the `group:allNonMajor` preset. That PR is blocked — it also bundles several `gomod` updates and never merges — so the bump stays stuck and gets done by hand (#267).

This gives the toolbox `packageRule` its own `groupName` so it gets a dedicated, mergeable PR. Single-line change.

## Note
After merge, if Renovate doesn't re-split #153 on its own, tick "rebase all open PRs" on the Dependency Dashboard (#14).
