### PR TITLE
feat(core): implement SEP-2243 routing headers for HTTP transport

### DIFF
--- a/core/transport/mcp/v20260618/mcp.go
+++ b/core/transport/mcp/v20260618/mcp.go
@@ -104,7 +104,7 @@ func (t *McpTransport) ListTools(ctx context.Context, toolsetName string, header
 	}
 
 	var result ListToolsResult
-	if err := t.sendRequest(ctx, targetURL, reqPayload, &result, headers, ""); err != nil {
+	if err := t.sendRequest(ctx, targetURL, reqPayload, &result, headers, "tools/list", ""); err != nil {
 		return nil, err
 	}
 
@@ -151,7 +151,7 @@ func (t *McpTransport) InvokeTool(ctx context.Context, toolName string, payload 
 	}
 
 	var result CallToolResult
-	if err := t.sendRequest(ctx, t.BaseURL(), reqPayload, &result, headers, toolName); err != nil {
+	if err := t.sendRequest(ctx, t.BaseURL(), reqPayload, &result, headers, "tools/call", toolName); err != nil {
 		return nil, err
 	}
 
@@ -195,7 +195,7 @@ func checkRPCError(rpcErr *jsonRPCError) error {
 	return fmt.Errorf("MCP request failed with code %d: %s", rpcErr.Code, rpcErr.Message)
 }
 
-func (t *McpTransport) sendRequest(ctx context.Context, reqURL string, bodyPayload any, dest any, headers map[string]string, mcpName string) error {
+func (t *McpTransport) sendRequest(ctx context.Context, reqURL string, bodyPayload any, dest any, headers map[string]string, method string, mcpName string) error {
 	jsonBytes, err := json.Marshal(bodyPayload)
 	if err != nil {
 		return fmt.Errorf("failed to marshal request payload: %w", err)
@@ -208,6 +208,12 @@ func (t *McpTransport) sendRequest(ctx context.Context, reqURL string, bodyPaylo
 
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("MCP-Protocol-Version", t.protocolVersion)
+	if method != "" {
+		httpReq.Header.Set("Mcp-Method", method)
+	}
+	if mcpName != "" {
+		httpReq.Header.Set("Mcp-Name", mcpName)
+	}
 	for k, v := range headers {
 		httpReq.Header.Set(k, v)
 	}

--- a/core/transport/mcp/v20260618/mcp_test.go
+++ b/core/transport/mcp/v20260618/mcp_test.go
@@ -17,11 +17,13 @@ package v20260618
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -96,4 +98,210 @@ func TestInvokeToolAndHeaders(t *testing.T) {
 	res, err := tr.InvokeTool(context.Background(), "test_tool", nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "hello", res)
+}
+
+func TestInvokeTool_NilArgumentsSerializedAsObject(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		var req map[string]any
+		require.NoError(t, json.Unmarshal(body, &req))
+		params, ok := req["params"].(map[string]any)
+		require.True(t, ok)
+		args, exists := params["arguments"]
+		require.True(t, exists, "params.arguments should exist")
+		require.NotNil(t, args, "params.arguments must not be null")
+		_, isMap := args.(map[string]any)
+		require.True(t, isMap, "params.arguments must be an object map")
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"jsonrpc": "2.0",
+			"id": "1",
+			"result": {
+				"content": [{"type": "text", "text": "ok"}]
+			}
+		}`))
+	}))
+	defer ts.Close()
+
+	tr, err := New(ts.URL, ts.Client(), "test-client", "1.0.0")
+	require.NoError(t, err)
+
+	res, err := tr.InvokeTool(context.Background(), "test_tool", nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "ok", res)
+}
+
+func TestPrepareHeadersMcpName(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DRAFT-2026-v1", r.Header.Get("MCP-Protocol-Version"))
+		assert.Equal(t, "tools/call", r.Header.Get("Mcp-Method"))
+		assert.Equal(t, "my_tool", r.Header.Get("Mcp-Name"))
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"jsonrpc": "2.0",
+			"id": "1",
+			"result": {
+				"content": [
+					{"type": "text", "text": "ok"}
+				]
+			}
+		}`))
+	}))
+	defer ts.Close()
+
+	tr, err := New(ts.URL, ts.Client(), "test-client", "1.0.0")
+	require.NoError(t, err)
+
+	res, err := tr.InvokeTool(context.Background(), "my_tool", nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "ok", res)
+}
+
+func TestResultTypeParsingAndFallback(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"jsonrpc": "2.0",
+			"id": "1",
+			"result": {
+				"content": [{"type": "text", "text": "test output"}]
+			}
+		}`))
+	}))
+	defer ts.Close()
+
+	tr, err := New(ts.URL, ts.Client(), "test-client", "1.0.0")
+	require.NoError(t, err)
+
+	res, err := tr.InvokeTool(context.Background(), "test_tool", nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "test output", res)
+}
+
+func TestListTools_ParsesInputSchemaParameters(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"jsonrpc": "2.0",
+			"id": "1",
+			"result": {
+				"tools": [
+					{
+						"name": "param_tool",
+						"description": "Tool with params",
+						"inputSchema": {
+							"type": "object",
+							"properties": {
+								"location": {
+									"type": "string",
+									"description": "City name"
+								}
+							},
+							"required": ["location"]
+						}
+					}
+				]
+			}
+		}`))
+	}))
+	defer ts.Close()
+
+	tr, err := New(ts.URL, ts.Client(), "test-client", "1.0.0")
+	require.NoError(t, err)
+
+	manifest, err := tr.ListTools(context.Background(), "", nil)
+	require.NoError(t, err)
+	require.Contains(t, manifest.Tools, "param_tool")
+
+	toolSchema := manifest.Tools["param_tool"]
+	require.NotEmpty(t, toolSchema.Parameters, "expected parameters to be parsed from inputSchema, but got empty slice")
+	assert.Equal(t, "location", toolSchema.Parameters[0].Name)
+	assert.Equal(t, "string", toolSchema.Parameters[0].Type)
+	assert.True(t, toolSchema.Parameters[0].Required)
+}
+
+func TestJSONRPCError_HTTP200_ProtocolNegotiation(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"jsonrpc": "2.0",
+			"id": "1",
+			"error": {
+				"code": -32022,
+				"message": "unsupported protocol version",
+				"data": {
+					"supported": ["2025-11-25"]
+				}
+			}
+		}`))
+	}))
+	defer ts.Close()
+
+	tr, err := New(ts.URL, ts.Client(), "test-client", "1.0.0")
+	require.NoError(t, err)
+
+	_, err = tr.ListTools(context.Background(), "", nil)
+	require.Error(t, err)
+
+	var negErr *transport.ProtocolNegotiationError
+	require.True(t, errors.As(err, &negErr), "expected ProtocolNegotiationError for HTTP 200 RPC error -32022")
+	assert.Equal(t, "2025-11-25", negErr.FallbackVersion)
+}
+
+func TestSendRequest_AddsMcpNameHeaderForPromptsGet(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DRAFT-2026-v1", r.Header.Get("MCP-Protocol-Version"))
+		assert.Equal(t, "prompts/get", r.Header.Get("Mcp-Method"))
+		assert.Equal(t, "test_prompt", r.Header.Get("Mcp-Name"))
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"1","result":{}}`))
+	}))
+	defer ts.Close()
+
+	tr, err := New(ts.URL, ts.Client(), "test-client", "1.0.0")
+	require.NoError(t, err)
+
+	reqPayload := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "1",
+		"method":  "prompts/get",
+		"params": map[string]any{
+			"name": "test_prompt",
+		},
+	}
+
+	err = tr.sendRequest(context.Background(), ts.URL, reqPayload, nil, nil, "prompts/get", "test_prompt")
+	require.NoError(t, err)
+}
+
+func TestSendRequest_AddsMcpNameHeaderForResourcesRead(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DRAFT-2026-v1", r.Header.Get("MCP-Protocol-Version"))
+		assert.Equal(t, "resources/read", r.Header.Get("Mcp-Method"))
+		assert.Equal(t, "file:///test.txt", r.Header.Get("Mcp-Name"))
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"1","result":{}}`))
+	}))
+	defer ts.Close()
+
+	tr, err := New(ts.URL, ts.Client(), "test-client", "1.0.0")
+	require.NoError(t, err)
+
+	reqPayload := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "1",
+		"method":  "resources/read",
+		"params": map[string]any{
+			"uri": "file:///test.txt",
+		},
+	}
+
+	err = tr.sendRequest(context.Background(), ts.URL, reqPayload, nil, nil, "resources/read", "file:///test.txt")
+	require.NoError(t, err)
 }


### PR DESCRIPTION
## Overview
Adds support for SEP-2243 HTTP routing headers (`Mcp-Method` and `Mcp-Name`) to the Stateless MCP HTTP transport (`v20260618`). By exposing protocol method names (`tools/list`, `tools/call`) and target entity names directly in standard HTTP headers, downstream HTTP infrastructure can perform routing, authorization, and metrics collection without parsing JSON-RPC request bodies.

##Changes
- Updated `sendRequest` signature to accept `method string` and `mcpName string`.
- Added header assignment logic: sets `Mcp-Method` and `Mcp-Name` when non-empty.
- Updated `ListTools` to pass `"tools/list"` and `InvokeTool` to pass `"tools/call"` with `toolName`.
  - Added `TestPrepareHeadersMcpName` to verify HTTP header propagation.
  - Added `TestInvokeTool_NilArgumentsSerializedAsObject` to test map serialization for empty parameters.

#### Rationale & Technical Details
Standardizing MCP HTTP transport headers enables reverse proxies and gateways to inspect and route MCP operations at L7 without expensive JSON-RPC payload parsing or buffering.
