### PR TITLE
feat(core): update default protocol alias to 2025-11-25 and update E2E test harness

### DIFF
--- a/core/e2e_mcp_test.go
+++ b/core/e2e_mcp_test.go
@@ -195,7 +195,7 @@ func TestMCP_Basic(t *testing.T) {
 				// Determine which protocol to check against
 				protocolToCheck := proto.protocol
 				if proto.isDefault {
-					protocolToCheck = core.MCPv20250618 // Default should match latest
+					protocolToCheck = core.MCPLatest // Default should match latest
 				}
 
 				switch protocolToCheck {

--- a/core/protocol.go
+++ b/core/protocol.go
@@ -28,7 +28,7 @@ const (
 	MCPv20241105 Protocol = "2024-11-05"
 
 	// MCP is the default alias pointing to the newest supported version.
-	MCP = MCPv20250618
+	MCP = MCPv20251125
 
 	MCPLatest Protocol = MCPv20251125
 	MCPDraft  Protocol = MCPv20260618
@@ -37,6 +37,7 @@ const (
 // GetSupportedMcpVersions returns a list of supported MCP protocol versions.
 func GetSupportedMcpVersions() []string {
 	return []string{
+		string(MCPv20260618),
 		string(MCPv20251125),
 		string(MCPv20250618),
 		string(MCPv20250326),

--- a/core/protocol_test.go
+++ b/core/protocol_test.go
@@ -21,13 +21,14 @@ import "testing"
 func TestGetSupportedMcpVersions(t *testing.T) {
 	versions := GetSupportedMcpVersions()
 
-	// Verify we get exactly 4 versions
-	if len(versions) != 4 {
-		t.Errorf("Expected 4 supported versions, got %d", len(versions))
+	// Verify we get exactly 5 versions
+	if len(versions) != 5 {
+		t.Errorf("Expected 5 supported versions, got %d", len(versions))
 	}
 
 	// Verify the content matches our constants
 	expected := []string{
+		string(MCPv20260618),
 		string(MCPv20251125),
 		string(MCPv20250618),
 		string(MCPv20250326),


### PR DESCRIPTION
## Description

This PR updates protocol version aliases to set `2025-11-25` as the baseline stable release, updates the E2E test harness to check against `MCPLatest`, and introduces `MCPDraft` to support incoming experimental protocol features in stacked PRs.

> [!NOTE]
> * At the time this PR was created `2025-11-25` was the active latest stable MCP release, and `2026-07-28` was still an unfinalized draft (`DRAFT-2026-v1`).
> * Current state is that although MCP has since officially released `2026-07-28`, this commit represents Step 1 of our stacked PR branch chain.
> * https://github.com/googleapis/mcp-toolbox-sdk-go/pull/309 promotes `MCPLatest`, `MCP`, and `MCPDraft` directly to the official `2026-07-28` version string.

## Changes

   * Bumps `Protocol.MCP` and `Protocol.MCPLatest` to `2025-11-25`.
   * Introduces `Protocol.MCPDraft` (`DRAFT-2026-v1` / `v20260618`) to establish an entry point for draft 2026 features.
   * Adds `MCPDraft` to `GetSupportedMcpVersions()`.
   * Updates default integration test checks to evaluate against `core.MCPLatest`.
   * Updates supported protocol count assertions to account for `MCPDraft`.
