### PR TITLE
test: isolate auth and generic integration test environments

### DIFF
--- a/core/e2e_mcp_test.go
+++ b/core/e2e_mcp_test.go
@@ -66,18 +66,22 @@ func TestMain(m *testing.M) {
 	defer os.Remove(toolsFilePath) // Ensure cleanup
 
 	// Download and start the toolbox server
-	cmd := setupAndStartToolboxServer(ctx, toolboxVersion, toolsFilePath)
+	cmd1, cmd2 := setupAndStartToolboxServers(ctx, toolboxVersion, toolsFilePath)
 
 	// Run Tests
 	log.Println("Setup complete. Running tests...")
 	exitCode := m.Run()
 
 	// Teardown Phase
-	log.Println("Tearing down toolbox server...")
-	if err := cmd.Process.Kill(); err != nil {
-		log.Printf("Failed to kill toolbox server process: %v", err)
+	log.Println("Tearing down toolbox servers...")
+	if err := cmd1.Process.Kill(); err != nil {
+		log.Printf("Failed to kill toolbox server 1 process: %v", err)
 	}
-	_ = cmd.Wait() // Clean up the process resources
+	if err := cmd2.Process.Kill(); err != nil {
+		log.Printf("Failed to kill toolbox server 2 process: %v", err)
+	}
+	_ = cmd1.Wait() // Clean up the process resources
+	_ = cmd2.Wait()
 
 	os.Exit(exitCode)
 }
@@ -134,8 +138,16 @@ func (c *CapturingTransport) CapturedHeaders() http.Header {
 	return c.lastHeaders
 }
 
+func runAgainstBothServers(t *testing.T, fn func(t *testing.T, testBaseUrl string)) {
+	for _, url := range []string{"http://localhost:5000", "http://localhost:5001"} {
+		t.Run(url, func(t *testing.T) {
+			fn(t, url)
+		})
+	}
+}
+
 // helper factory to create a client with a specific protocol
-func getNewMCPToolboxClient(t *testing.T, tc protocolTestCase) *core.ToolboxClient {
+func getNewMCPToolboxClient(t *testing.T, testBaseUrl string, tc protocolTestCase) *core.ToolboxClient {
 	opts := []core.ClientOption{}
 
 	// Only add WithProtocol if it's NOT the default test case
@@ -143,17 +155,18 @@ func getNewMCPToolboxClient(t *testing.T, tc protocolTestCase) *core.ToolboxClie
 		opts = append(opts, core.WithProtocol(tc.protocol))
 	}
 
-	client, err := core.NewToolboxClient("http://localhost:5000", opts...)
+	client, err := core.NewToolboxClient(testBaseUrl, opts...)
 	require.NoError(t, err, "Failed to create MCP ToolboxClient for %s", tc.name)
 	return client
 }
 
 func TestMCP_Basic(t *testing.T) {
+	runAgainstBothServers(t, func(t *testing.T, testBaseUrl string) {
 	for _, proto := range protocolsToTest {
 		t.Run(proto.name, func(t *testing.T) {
 			// Helper to create a new client for each sub-test
 			newClient := func(t *testing.T) *core.ToolboxClient {
-				return getNewMCPToolboxClient(t, proto)
+				return getNewMCPToolboxClient(t, testBaseUrl, proto)
 			}
 
 			// Helper to load the get-n-rows tool
@@ -182,7 +195,7 @@ func TestMCP_Basic(t *testing.T) {
 				}
 
 				// Inject Transport into Client
-				client, err := core.NewToolboxClient("http://localhost:5000", opts...)
+				client, err := core.NewToolboxClient(testBaseUrl, opts...)
 				require.NoError(t, err)
 
 				// Trigger a request
@@ -195,7 +208,7 @@ func TestMCP_Basic(t *testing.T) {
 				// Determine which protocol to check against
 				protocolToCheck := proto.protocol
 				if proto.isDefault {
-					protocolToCheck = core.MCPv20250618 // Default should match latest
+					protocolToCheck = core.MCPv20251125 // Default should match latest stable
 				}
 
 				switch protocolToCheck {
@@ -311,13 +324,15 @@ func TestMCP_Basic(t *testing.T) {
 			})
 		})
 	}
+	})
 }
 
 func TestMCP_LoadErrors(t *testing.T) {
+	runAgainstBothServers(t, func(t *testing.T, testBaseUrl string) {
 	for _, proto := range protocolsToTest {
 		t.Run(proto.name, func(t *testing.T) {
 			newClient := func(t *testing.T) *core.ToolboxClient {
-				return getNewMCPToolboxClient(t, proto)
+				return getNewMCPToolboxClient(t, testBaseUrl, proto)
 			}
 
 			t.Run("test_load_non_existent_tool", func(t *testing.T) {
@@ -336,24 +351,26 @@ func TestMCP_LoadErrors(t *testing.T) {
 	}
 
 	t.Run("test_new_client_with_nil_option", func(t *testing.T) {
-		_, err := core.NewToolboxClient("http://localhost:5000", nil)
+		_, err := core.NewToolboxClient(testBaseUrl, nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "received a nil ClientOption")
 	})
 
 	t.Run("test_load_tool_with_nil_option", func(t *testing.T) {
-		client := getNewMCPToolboxClient(t, protocolsToTest[0])
+		client := getNewMCPToolboxClient(t, testBaseUrl, protocolsToTest[0])
 		_, err := client.LoadTool("get-n-rows", context.Background(), nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "received a nil ToolOption")
 	})
+	})
 }
 
 func TestMCP_BindParams(t *testing.T) {
+	runAgainstBothServers(t, func(t *testing.T, testBaseUrl string) {
 	for _, proto := range protocolsToTest {
 		t.Run(proto.name, func(t *testing.T) {
 			newClient := func(t *testing.T) *core.ToolboxClient {
-				return getNewMCPToolboxClient(t, proto)
+				return getNewMCPToolboxClient(t, testBaseUrl, proto)
 			}
 			getNRowsTool := func(t *testing.T, client *core.ToolboxClient) *core.ToolboxTool {
 				tool, err := client.LoadTool("get-n-rows", context.Background())
@@ -402,12 +419,14 @@ func TestMCP_BindParams(t *testing.T) {
 			})
 		})
 	}
+	})
 }
 
 func TestMCP_BindParamErrors(t *testing.T) {
+	runAgainstBothServers(t, func(t *testing.T, testBaseUrl string) {
 	for _, proto := range protocolsToTest {
 		t.Run(proto.name, func(t *testing.T) {
-			client := getNewMCPToolboxClient(t, proto)
+			client := getNewMCPToolboxClient(t, testBaseUrl, proto)
 			tool, err := client.LoadTool("get-n-rows", context.Background())
 			require.NoError(t, err)
 
@@ -427,9 +446,11 @@ func TestMCP_BindParamErrors(t *testing.T) {
 			})
 		})
 	}
+	})
 }
 
 func TestMCP_Auth(t *testing.T) {
+	runAgainstBothServers(t, func(t *testing.T, testBaseUrl string) {
 	// Helper to create a static token source from a string token
 	staticTokenSource := func(token string) oauth2.TokenSource {
 		return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
@@ -438,7 +459,7 @@ func TestMCP_Auth(t *testing.T) {
 	for _, proto := range protocolsToTest {
 		t.Run(proto.name, func(t *testing.T) {
 			newClient := func(t *testing.T) *core.ToolboxClient {
-				return getNewMCPToolboxClient(t, proto)
+				return getNewMCPToolboxClient(t, testBaseUrl, proto)
 			}
 
 			t.Run("test_run_tool_unauth_with_auth", func(t *testing.T) {
@@ -543,13 +564,15 @@ func TestMCP_Auth(t *testing.T) {
 			})
 		})
 	}
+	})
 }
 
 func TestMCP_OptionalParams(t *testing.T) {
+	runAgainstBothServers(t, func(t *testing.T, testBaseUrl string) {
 	for _, proto := range protocolsToTest {
 		t.Run(proto.name, func(t *testing.T) {
 			newClient := func(t *testing.T) *core.ToolboxClient {
-				return getNewMCPToolboxClient(t, proto)
+				return getNewMCPToolboxClient(t, testBaseUrl, proto)
 			}
 			searchRowsTool := func(t *testing.T, client *core.ToolboxClient) *core.ToolboxTool {
 				tool, err := client.LoadTool("search-rows", context.Background())
@@ -721,13 +744,15 @@ func TestMCP_OptionalParams(t *testing.T) {
 			})
 		})
 	}
+	})
 }
 
 func TestMCP_MapParams(t *testing.T) {
+	runAgainstBothServers(t, func(t *testing.T, testBaseUrl string) {
 	for _, proto := range protocolsToTest {
 		t.Run(proto.name, func(t *testing.T) {
 			newClient := func(t *testing.T) *core.ToolboxClient {
-				return getNewMCPToolboxClient(t, proto)
+				return getNewMCPToolboxClient(t, testBaseUrl, proto)
 			}
 			processDataTool := func(t *testing.T, client *core.ToolboxClient) *core.ToolboxTool {
 				tool, err := client.LoadTool("process-data", context.Background())
@@ -821,13 +846,15 @@ func TestMCP_MapParams(t *testing.T) {
 			})
 		})
 	}
+	})
 }
 
 func TestMCP_ContextHandling(t *testing.T) {
+	runAgainstBothServers(t, func(t *testing.T, testBaseUrl string) {
 	for _, proto := range protocolsToTest {
 		t.Run(proto.name, func(t *testing.T) {
 			newClient := func(t *testing.T) *core.ToolboxClient {
-				return getNewMCPToolboxClient(t, proto)
+				return getNewMCPToolboxClient(t, testBaseUrl, proto)
 			}
 
 			t.Run("test_load_tool_with_cancelled_context", func(t *testing.T) {
@@ -855,4 +882,6 @@ func TestMCP_ContextHandling(t *testing.T) {
 			})
 		})
 	}
+	})
 }
+

--- a/core/e2e_setup_test.go
+++ b/core/e2e_setup_test.go
@@ -89,7 +89,7 @@ func downloadBlob(ctx context.Context, bucketName, sourceBlobName, destinationFi
 func getToolboxBinaryURL(toolboxVersion string) string {
 	osSystem := runtime.GOOS
 	arch := runtime.GOARCH
-	return fmt.Sprintf("v%s/%s/%s/toolbox", toolboxVersion, osSystem, arch)
+	return fmt.Sprintf("%s/%s/%s/toolbox", toolboxVersion, osSystem, arch)
 }
 
 func getAuthToken(ctx context.Context, clientID string) string {
@@ -104,11 +104,15 @@ func getAuthToken(ctx context.Context, clientID string) string {
 	return token.AccessToken
 }
 
-func setupAndStartToolboxServer(ctx context.Context, version, toolsFilePath string) *exec.Cmd {
+func setupAndStartToolboxServers(ctx context.Context, version, toolsFilePath string) (*exec.Cmd, *exec.Cmd) {
 	log.Println("Downloading toolbox binary from GCS bucket...")
 	binaryURL := getToolboxBinaryURL(version)
 	binaryPath := "toolbox"
-	downloadBlob(ctx, "mcp-toolbox-for-databases", binaryURL, binaryPath)
+	bucketName := "mcp-toolbox-for-databases"
+	if version == "main" || version == "mcp-v202606" {
+		bucketName = "mcp-toolbox-for-databases-dev"
+	}
+	downloadBlob(ctx, bucketName, binaryURL, binaryPath)
 	log.Println("Toolbox binary downloaded successfully.")
 
 	if err := os.Chmod(binaryPath, 0755); err != nil {
@@ -120,24 +124,34 @@ func setupAndStartToolboxServer(ctx context.Context, version, toolsFilePath stri
 		log.Fatalf("Failed to get absolute path for toolbox binary: %v", err)
 	}
 
-	log.Println("Starting toolbox server process...")
-	cmd := exec.Command(absBinaryPath, "--tools-file", toolsFilePath)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	log.Println("Starting toolbox server 1 process on port 5000...")
+	cmd1 := exec.Command(absBinaryPath, "--port", "5000", "--tools-file", toolsFilePath)
+	cmd1.Stdout = os.Stdout
+	cmd1.Stderr = os.Stderr
 
-	if err := cmd.Start(); err != nil {
-		log.Fatalf("Failed to start toolbox server: %v", err)
+	if err := cmd1.Start(); err != nil {
+		log.Fatalf("Failed to start toolbox server 1: %v", err)
 	}
 
-	log.Println("Waiting for server to initialize...")
-	// A more robust way to check for server readiness is to poll the health endpoint.
-	// For now, Sleep is a simple way to wait.
+	log.Println("Starting toolbox server 2 process on port 5001...")
+	cmd2 := exec.Command(absBinaryPath, "--port", "5001", "--tools-file", toolsFilePath, "--enable-draft-specs")
+	cmd2.Stdout = os.Stdout
+	cmd2.Stderr = os.Stderr
+
+	if err := cmd2.Start(); err != nil {
+		log.Fatalf("Failed to start toolbox server 2: %v", err)
+	}
+
+	log.Println("Waiting for servers to initialize...")
 	time.Sleep(5 * time.Second)
 
-	if cmd.ProcessState != nil && cmd.ProcessState.Exited() {
-		log.Fatalf("Toolbox server failed to start and exited with code: %d", cmd.ProcessState.ExitCode())
+	if cmd1.ProcessState != nil && cmd1.ProcessState.Exited() {
+		log.Fatalf("Toolbox server 1 failed to start and exited with code: %d", cmd1.ProcessState.ExitCode())
+	}
+	if cmd2.ProcessState != nil && cmd2.ProcessState.Exited() {
+		log.Fatalf("Toolbox server 2 failed to start and exited with code: %d", cmd2.ProcessState.ExitCode())
 	}
 
-	log.Println("Toolbox server started successfully.")
-	return cmd
+	log.Println("Toolbox servers started successfully.")
+	return cmd1, cmd2
 }

--- a/core/integration.cloudbuild.yaml
+++ b/core/integration.cloudbuild.yaml
@@ -137,5 +137,5 @@ steps:
 options:
   logging: CLOUD_LOGGING_ONLY
 substitutions:
-  _TOOLBOX_VERSION: '1.5.0'
+  _TOOLBOX_VERSION: 'v1.6.0'
   _TOOLBOX_MANIFEST_VERSION: '34'

--- a/tbadk/e2e_setup_test.go
+++ b/tbadk/e2e_setup_test.go
@@ -89,7 +89,7 @@ func downloadBlob(ctx context.Context, bucketName, sourceBlobName, destinationFi
 func getToolboxBinaryURL(toolboxVersion string) string {
 	osSystem := runtime.GOOS
 	arch := runtime.GOARCH
-	return fmt.Sprintf("v%s/%s/%s/toolbox", toolboxVersion, osSystem, arch)
+	return fmt.Sprintf("%s/%s/%s/toolbox", toolboxVersion, osSystem, arch)
 }
 
 func getAuthToken(ctx context.Context, clientID string) string {
@@ -104,11 +104,15 @@ func getAuthToken(ctx context.Context, clientID string) string {
 	return token.AccessToken
 }
 
-func setupAndStartToolboxServer(ctx context.Context, version, toolsFilePath string) *exec.Cmd {
+func setupAndStartToolboxServers(ctx context.Context, version, toolsFilePath string) (*exec.Cmd, *exec.Cmd) {
 	log.Println("Downloading toolbox binary from GCS bucket...")
 	binaryURL := getToolboxBinaryURL(version)
 	binaryPath := "toolbox"
-	downloadBlob(ctx, "mcp-toolbox-for-databases", binaryURL, binaryPath)
+	bucketName := "mcp-toolbox-for-databases"
+	if version == "main" || version == "mcp-v202606" {
+		bucketName = "mcp-toolbox-for-databases-dev"
+	}
+	downloadBlob(ctx, bucketName, binaryURL, binaryPath)
 	log.Println("Toolbox binary downloaded successfully.")
 
 	if err := os.Chmod(binaryPath, 0755); err != nil {
@@ -120,24 +124,34 @@ func setupAndStartToolboxServer(ctx context.Context, version, toolsFilePath stri
 		log.Fatalf("Failed to get absolute path for toolbox binary: %v", err)
 	}
 
-	log.Println("Starting toolbox server process...")
-	cmd := exec.Command(absBinaryPath, "--tools-file", toolsFilePath)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	log.Println("Starting toolbox server 1 process on port 5000...")
+	cmd1 := exec.Command(absBinaryPath, "--port", "5000", "--tools-file", toolsFilePath)
+	cmd1.Stdout = os.Stdout
+	cmd1.Stderr = os.Stderr
 
-	if err := cmd.Start(); err != nil {
-		log.Fatalf("Failed to start toolbox server: %v", err)
+	if err := cmd1.Start(); err != nil {
+		log.Fatalf("Failed to start toolbox server 1: %v", err)
 	}
 
-	log.Println("Waiting for server to initialize...")
-	// A more robust way to check for server readiness is to poll the health endpoint.
-	// For now, Sleep is a simple way to wait.
+	log.Println("Starting toolbox server 2 process on port 5001...")
+	cmd2 := exec.Command(absBinaryPath, "--port", "5001", "--tools-file", toolsFilePath, "--enable-draft-specs")
+	cmd2.Stdout = os.Stdout
+	cmd2.Stderr = os.Stderr
+
+	if err := cmd2.Start(); err != nil {
+		log.Fatalf("Failed to start toolbox server 2: %v", err)
+	}
+
+	log.Println("Waiting for servers to initialize...")
 	time.Sleep(5 * time.Second)
 
-	if cmd.ProcessState != nil && cmd.ProcessState.Exited() {
-		log.Fatalf("Toolbox server failed to start and exited with code: %d", cmd.ProcessState.ExitCode())
+	if cmd1.ProcessState != nil && cmd1.ProcessState.Exited() {
+		log.Fatalf("Toolbox server 1 failed to start and exited with code: %d", cmd1.ProcessState.ExitCode())
+	}
+	if cmd2.ProcessState != nil && cmd2.ProcessState.Exited() {
+		log.Fatalf("Toolbox server 2 failed to start and exited with code: %d", cmd2.ProcessState.ExitCode())
 	}
 
-	log.Println("Toolbox server started successfully.")
-	return cmd
+	log.Println("Toolbox servers started successfully.")
+	return cmd1, cmd2
 }

--- a/tbadk/e2e_test.go
+++ b/tbadk/e2e_test.go
@@ -96,6 +96,7 @@ type protocolTestCase struct {
 
 var protocolsToTest = []protocolTestCase{
 	{name: "Default (Latest)", isDefault: true},
+	{name: "MCP Draft", protocol: core.MCPDraft},
 	{name: "v20241105", protocol: core.MCPv20241105},
 	{name: "v20250326", protocol: core.MCPv20250326},
 	{name: "v20250618", protocol: core.MCPv20250618},
@@ -133,6 +134,14 @@ func (c *BodyCapturingTransport) RoundTrip(req *http.Request) (*http.Response, e
 	return base.RoundTrip(req)
 }
 
+func runAgainstBothServers(t *testing.T, fn func(t *testing.T, testBaseUrl string)) {
+	for _, url := range []string{"http://localhost:5000", "http://localhost:5001"} {
+		t.Run(url, func(t *testing.T) {
+			fn(t, url)
+		})
+	}
+}
+
 func TestMain(m *testing.M) {
 	ctx := context.Background()
 	log.Println("Starting E2E test setup...")
@@ -158,23 +167,28 @@ func TestMain(m *testing.M) {
 	defer os.Remove(toolsFilePath) // Ensure cleanup
 
 	// Download and start the toolbox server
-	cmd := setupAndStartToolboxServer(ctx, toolboxVersion, toolsFilePath)
+	cmd1, cmd2 := setupAndStartToolboxServers(ctx, toolboxVersion, toolsFilePath)
 
 	// Run Tests ---
 	log.Println("Setup complete. Running tests...")
 	exitCode := m.Run()
 
 	// Teardown Phase ---
-	log.Println("Tearing down toolbox server...")
-	if err := cmd.Process.Kill(); err != nil {
-		log.Printf("Failed to kill toolbox server process: %v", err)
+	log.Println("Tearing down toolbox servers...")
+	if err := cmd1.Process.Kill(); err != nil {
+		log.Printf("Failed to kill toolbox server 1 process: %v", err)
 	}
-	_ = cmd.Wait() // Clean up the process resources
+	if err := cmd2.Process.Kill(); err != nil {
+		log.Printf("Failed to kill toolbox server 2 process: %v", err)
+	}
+	_ = cmd1.Wait() // Clean up the process resources
+	_ = cmd2.Wait()
 
 	os.Exit(exitCode)
 }
 
 func TestE2E_Basic(t *testing.T) {
+	runAgainstBothServers(t, func(t *testing.T, testBaseUrl string) {
 	for _, proto := range protocolsToTest {
 		t.Run(proto.name, func(t *testing.T) {
 			// Helper to create a new client for each sub-test, like a function-scoped fixture
@@ -183,7 +197,7 @@ func TestE2E_Basic(t *testing.T) {
 				if !proto.isDefault {
 					opts = append(opts, core.WithProtocol(proto.protocol))
 				}
-				client, err := tbadk.NewToolboxClient("http://localhost:5000", opts...)
+				client, err := tbadk.NewToolboxClient(testBaseUrl, opts...)
 				require.NoError(t, err, "Failed to create ToolboxClient")
 				return client
 			}
@@ -215,7 +229,7 @@ func TestE2E_Basic(t *testing.T) {
 					opts = append(opts, core.WithProtocol(proto.protocol))
 				}
 
-				client, err := tbadk.NewToolboxClient("http://localhost:5000", opts...)
+				client, err := tbadk.NewToolboxClient(testBaseUrl, opts...)
 				require.NoError(t, err)
 
 				// Trigger the handshake by loading a tool
@@ -332,9 +346,11 @@ func TestE2E_Basic(t *testing.T) {
 			})
 		})
 	}
+	})
 }
 
 func TestE2E_LoadErrors(t *testing.T) {
+	runAgainstBothServers(t, func(t *testing.T, testBaseUrl string) {
 	for _, proto := range protocolsToTest {
 		t.Run(proto.name, func(t *testing.T) {
 			newClient := func(t *testing.T) tbadk.ToolboxClient {
@@ -342,7 +358,7 @@ func TestE2E_LoadErrors(t *testing.T) {
 				if !proto.isDefault {
 					opts = append(opts, core.WithProtocol(proto.protocol))
 				}
-				client, err := tbadk.NewToolboxClient("http://localhost:5000", opts...)
+				client, err := tbadk.NewToolboxClient(testBaseUrl, opts...)
 				require.NoError(t, err, "Failed to create ToolboxClient")
 				return client
 			}
@@ -375,9 +391,11 @@ func TestE2E_LoadErrors(t *testing.T) {
 			})
 		})
 	}
+	})
 }
 
 func TestE2E_BindParams(t *testing.T) {
+	runAgainstBothServers(t, func(t *testing.T, testBaseUrl string) {
 	for _, proto := range protocolsToTest {
 		t.Run(proto.name, func(t *testing.T) {
 			newClient := func(t *testing.T) tbadk.ToolboxClient {
@@ -385,7 +403,7 @@ func TestE2E_BindParams(t *testing.T) {
 				if !proto.isDefault {
 					opts = append(opts, core.WithProtocol(proto.protocol))
 				}
-				client, err := tbadk.NewToolboxClient("http://localhost:5000", opts...)
+				client, err := tbadk.NewToolboxClient(testBaseUrl, opts...)
 				require.NoError(t, err)
 				return client
 			}
@@ -444,16 +462,18 @@ func TestE2E_BindParams(t *testing.T) {
 			})
 		})
 	}
+	})
 }
 
 func TestE2E_BindParamErrors(t *testing.T) {
+	runAgainstBothServers(t, func(t *testing.T, testBaseUrl string) {
 	for _, proto := range protocolsToTest {
 		t.Run(proto.name, func(t *testing.T) {
 			opts := []core.ClientOption{}
 			if !proto.isDefault {
 				opts = append(opts, core.WithProtocol(proto.protocol))
 			}
-			client, err := tbadk.NewToolboxClient("http://localhost:5000", opts...)
+			client, err := tbadk.NewToolboxClient(testBaseUrl, opts...)
 			require.NoError(t, err)
 			tool, err := client.LoadTool("get-n-rows", context.Background())
 			require.NoError(t, err)
@@ -474,9 +494,11 @@ func TestE2E_BindParamErrors(t *testing.T) {
 			})
 		})
 	}
+	})
 }
 
 func TestE2E_Auth(t *testing.T) {
+	runAgainstBothServers(t, func(t *testing.T, testBaseUrl string) {
 	for _, proto := range protocolsToTest {
 		t.Run(proto.name, func(t *testing.T) {
 			newClient := func(t *testing.T) tbadk.ToolboxClient {
@@ -484,7 +506,7 @@ func TestE2E_Auth(t *testing.T) {
 				if !proto.isDefault {
 					opts = append(opts, core.WithProtocol(proto.protocol))
 				}
-				client, err := tbadk.NewToolboxClient("http://localhost:5000", opts...)
+				client, err := tbadk.NewToolboxClient(testBaseUrl, opts...)
 				require.NoError(t, err)
 				return client
 			}
@@ -605,9 +627,11 @@ func TestE2E_Auth(t *testing.T) {
 			})
 		})
 	}
+	})
 }
 
 func TestE2E_OptionalParams(t *testing.T) {
+	runAgainstBothServers(t, func(t *testing.T, testBaseUrl string) {
 	for _, proto := range protocolsToTest {
 		t.Run(proto.name, func(t *testing.T) {
 			// Helper to create a new client
@@ -616,7 +640,7 @@ func TestE2E_OptionalParams(t *testing.T) {
 				if !proto.isDefault {
 					opts = append(opts, core.WithProtocol(proto.protocol))
 				}
-				client, err := tbadk.NewToolboxClient("http://localhost:5000", opts...)
+				client, err := tbadk.NewToolboxClient(testBaseUrl, opts...)
 				require.NoError(t, err, "Failed to create ToolboxClient")
 				return client
 			}
@@ -807,9 +831,11 @@ func TestE2E_OptionalParams(t *testing.T) {
 			})
 		})
 	}
+	})
 }
 
 func TestE2E_MapParams(t *testing.T) {
+	runAgainstBothServers(t, func(t *testing.T, testBaseUrl string) {
 	for _, proto := range protocolsToTest {
 		t.Run(proto.name, func(t *testing.T) {
 			// Helper to create a new client
@@ -818,7 +844,7 @@ func TestE2E_MapParams(t *testing.T) {
 				if !proto.isDefault {
 					opts = append(opts, core.WithProtocol(proto.protocol))
 				}
-				client, err := tbadk.NewToolboxClient("http://localhost:5000", opts...)
+				client, err := tbadk.NewToolboxClient(testBaseUrl, opts...)
 				require.NoError(t, err, "Failed to create ToolboxClient")
 				return client
 			}
@@ -933,4 +959,5 @@ func TestE2E_MapParams(t *testing.T) {
 			})
 		})
 	}
+	})
 }

--- a/tbadk/integration.cloudbuild.yaml
+++ b/tbadk/integration.cloudbuild.yaml
@@ -98,5 +98,5 @@ steps:
 options:
   logging: CLOUD_LOGGING_ONLY
 substitutions:
-  _TOOLBOX_VERSION: '1.5.0'
+  _TOOLBOX_VERSION: 'v1.6.0'
   _TOOLBOX_MANIFEST_VERSION: '34'

--- a/tbgenkit/integration.cloudbuild.yaml
+++ b/tbgenkit/integration.cloudbuild.yaml
@@ -44,5 +44,5 @@ steps:
 options:
   logging: CLOUD_LOGGING_ONLY
 substitutions:
-  _TOOLBOX_VERSION: '1.5.0'
+  _TOOLBOX_VERSION: 'v1.6.0'
   _TOOLBOX_MANIFEST_VERSION: '34'

--- a/tbgenkit/tbgenkit_setup_test.go
+++ b/tbgenkit/tbgenkit_setup_test.go
@@ -89,7 +89,7 @@ func downloadBlob(ctx context.Context, bucketName, sourceBlobName, destinationFi
 func getToolboxBinaryURL(toolboxVersion string) string {
 	osSystem := runtime.GOOS
 	arch := runtime.GOARCH
-	return fmt.Sprintf("v%s/%s/%s/toolbox", toolboxVersion, osSystem, arch)
+	return fmt.Sprintf("%s/%s/%s/toolbox", toolboxVersion, osSystem, arch)
 }
 
 func getAuthToken(ctx context.Context, clientID string) string {
@@ -104,11 +104,15 @@ func getAuthToken(ctx context.Context, clientID string) string {
 	return token.AccessToken
 }
 
-func setupAndStartToolboxServer(ctx context.Context, version, toolsFilePath string) *exec.Cmd {
+func setupAndStartToolboxServers(ctx context.Context, version, toolsFilePath string) (*exec.Cmd, *exec.Cmd) {
 	log.Println("Downloading toolbox binary from GCS bucket...")
 	binaryURL := getToolboxBinaryURL(version)
 	binaryPath := "toolbox"
-	downloadBlob(ctx, "mcp-toolbox-for-databases", binaryURL, binaryPath)
+	bucketName := "mcp-toolbox-for-databases"
+	if version == "main" || version == "mcp-v202606" {
+		bucketName = "mcp-toolbox-for-databases-dev"
+	}
+	downloadBlob(ctx, bucketName, binaryURL, binaryPath)
 	log.Println("Toolbox binary downloaded successfully.")
 
 	if err := os.Chmod(binaryPath, 0755); err != nil {
@@ -120,24 +124,34 @@ func setupAndStartToolboxServer(ctx context.Context, version, toolsFilePath stri
 		log.Fatalf("Failed to get absolute path for toolbox binary: %v", err)
 	}
 
-	log.Println("Starting toolbox server process...")
-	cmd := exec.Command(absBinaryPath, "--tools-file", toolsFilePath)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	log.Println("Starting toolbox server 1 process on port 5000...")
+	cmd1 := exec.Command(absBinaryPath, "--port", "5000", "--tools-file", toolsFilePath)
+	cmd1.Stdout = os.Stdout
+	cmd1.Stderr = os.Stderr
 
-	if err := cmd.Start(); err != nil {
-		log.Fatalf("Failed to start toolbox server: %v", err)
+	if err := cmd1.Start(); err != nil {
+		log.Fatalf("Failed to start toolbox server 1: %v", err)
 	}
 
-	log.Println("Waiting for server to initialize...")
-	// A more robust way to check for server readiness is to poll the health endpoint.
-	// For now, Sleep is a simple way to wait.
+	log.Println("Starting toolbox server 2 process on port 5001...")
+	cmd2 := exec.Command(absBinaryPath, "--port", "5001", "--tools-file", toolsFilePath, "--enable-draft-specs")
+	cmd2.Stdout = os.Stdout
+	cmd2.Stderr = os.Stderr
+
+	if err := cmd2.Start(); err != nil {
+		log.Fatalf("Failed to start toolbox server 2: %v", err)
+	}
+
+	log.Println("Waiting for servers to initialize...")
 	time.Sleep(5 * time.Second)
 
-	if cmd.ProcessState != nil && cmd.ProcessState.Exited() {
-		log.Fatalf("Toolbox server failed to start and exited with code: %d", cmd.ProcessState.ExitCode())
+	if cmd1.ProcessState != nil && cmd1.ProcessState.Exited() {
+		log.Fatalf("Toolbox server 1 failed to start and exited with code: %d", cmd1.ProcessState.ExitCode())
+	}
+	if cmd2.ProcessState != nil && cmd2.ProcessState.Exited() {
+		log.Fatalf("Toolbox server 2 failed to start and exited with code: %d", cmd2.ProcessState.ExitCode())
 	}
 
-	log.Println("Toolbox server started successfully.")
-	return cmd
+	log.Println("Toolbox servers started successfully.")
+	return cmd1, cmd2
 }

--- a/tbgenkit/tbgenkit_test.go
+++ b/tbgenkit/tbgenkit_test.go
@@ -55,11 +55,20 @@ type protocolTestCase struct {
 
 var protocolsToTest = []protocolTestCase{
 	{name: "Default (Latest)", isDefault: true},
+	{name: "MCP Draft", protocol: core.MCPDraft},
 	{name: "v20241105", protocol: core.MCPv20241105},
 	{name: "v20250326", protocol: core.MCPv20250326},
 	{name: "v20250618", protocol: core.MCPv20250618},
 	{name: "v20251125", protocol: core.MCPv20251125},
 	{name: "MCP Alias (Latest)", protocol: core.MCP},
+}
+
+func runAgainstBothServers(t *testing.T, fn func(t *testing.T, testBaseUrl string)) {
+	for _, url := range []string{"http://localhost:5000", "http://localhost:5001"} {
+		t.Run(url, func(t *testing.T) {
+			fn(t, url)
+		})
+	}
 }
 
 func TestMain(m *testing.M) {
@@ -87,23 +96,28 @@ func TestMain(m *testing.M) {
 	defer os.Remove(toolsFilePath) // Ensure cleanup
 
 	// Download and start the toolbox server
-	cmd := setupAndStartToolboxServer(ctx, toolboxVersion, toolsFilePath)
+	cmd1, cmd2 := setupAndStartToolboxServers(ctx, toolboxVersion, toolsFilePath)
 
 	// --- 2. Run Tests ---
 	log.Println("Setup complete. Running tests...")
 	exitCode := m.Run()
 
 	// --- 3. Teardown Phase ---
-	log.Println("Tearing down toolbox server...")
-	if err := cmd.Process.Kill(); err != nil {
-		log.Printf("Failed to kill toolbox server process: %v", err)
+	log.Println("Tearing down toolbox servers...")
+	if err := cmd1.Process.Kill(); err != nil {
+		log.Printf("Failed to kill toolbox server 1 process: %v", err)
 	}
-	_ = cmd.Wait() // Clean up the process resources
+	if err := cmd2.Process.Kill(); err != nil {
+		log.Printf("Failed to kill toolbox server 2 process: %v", err)
+	}
+	_ = cmd1.Wait() // Clean up the process resources
+	_ = cmd2.Wait()
 
 	os.Exit(exitCode)
 }
 
 func TestToGenkitTool(t *testing.T) {
+	runAgainstBothServers(t, func(t *testing.T, testBaseUrl string) {
 	for _, proto := range protocolsToTest {
 		t.Run(proto.name, func(t *testing.T) {
 			// Helper to create a new client for each sub-test, like a function-scoped fixture
@@ -112,7 +126,7 @@ func TestToGenkitTool(t *testing.T) {
 				if !proto.isDefault {
 					opts = append(opts, core.WithProtocol(proto.protocol))
 				}
-				client, err := core.NewToolboxClient("http://localhost:5000", opts...)
+				client, err := core.NewToolboxClient(testBaseUrl, opts...)
 				require.NoError(t, err, "Failed to create ToolboxClient")
 				return client
 			}
@@ -198,9 +212,11 @@ func TestToGenkitTool(t *testing.T) {
 
 		})
 	}
+	})
 }
 
 func TestToGenkitTool_BoundParams(t *testing.T) {
+	runAgainstBothServers(t, func(t *testing.T, testBaseUrl string) {
 	for _, proto := range protocolsToTest {
 		t.Run(proto.name, func(t *testing.T) {
 			// Helper to create a new client for each sub-test, like a function-scoped fixture
@@ -209,7 +225,7 @@ func TestToGenkitTool_BoundParams(t *testing.T) {
 				if !proto.isDefault {
 					opts = append(opts, core.WithProtocol(proto.protocol))
 				}
-				client, err := core.NewToolboxClient("http://localhost:5000", opts...)
+				client, err := core.NewToolboxClient(testBaseUrl, opts...)
 				require.NoError(t, err, "Failed to create ToolboxClient")
 				return client
 			}
@@ -303,9 +319,11 @@ func TestToGenkitTool_BoundParams(t *testing.T) {
 			})
 		})
 	}
+	})
 }
 
 func TestToGenkitTool_Auth(t *testing.T) {
+	runAgainstBothServers(t, func(t *testing.T, testBaseUrl string) {
 	for _, proto := range protocolsToTest {
 		t.Run(proto.name, func(t *testing.T) {
 			// Helper to create a new client for each sub-test, like a function-scoped fixture
@@ -314,7 +332,7 @@ func TestToGenkitTool_Auth(t *testing.T) {
 				if !proto.isDefault {
 					opts = append(opts, core.WithProtocol(proto.protocol))
 				}
-				client, err := core.NewToolboxClient("http://localhost:5000", opts...)
+				client, err := core.NewToolboxClient(testBaseUrl, opts...)
 				require.NoError(t, err, "Failed to create ToolboxClient")
 				return client
 			}
@@ -466,9 +484,11 @@ func TestToGenkitTool_Auth(t *testing.T) {
 			})
 		})
 	}
+	})
 }
 
 func TestToGenkitTool_OptionalParams(t *testing.T) {
+	runAgainstBothServers(t, func(t *testing.T, testBaseUrl string) {
 	for _, proto := range protocolsToTest {
 		t.Run(proto.name, func(t *testing.T) {
 			// Helper to create a new client for each sub-test, like a function-scoped fixture
@@ -477,7 +497,7 @@ func TestToGenkitTool_OptionalParams(t *testing.T) {
 				if !proto.isDefault {
 					opts = append(opts, core.WithProtocol(proto.protocol))
 				}
-				client, err := core.NewToolboxClient("http://localhost:5000", opts...)
+				client, err := core.NewToolboxClient(testBaseUrl, opts...)
 				require.NoError(t, err, "Failed to create ToolboxClient")
 				return client
 			}
@@ -717,9 +737,11 @@ func TestToGenkitTool_OptionalParams(t *testing.T) {
 			})
 		})
 	}
+	})
 }
 
 func TestToGenkitTool_MapParams(t *testing.T) {
+	runAgainstBothServers(t, func(t *testing.T, testBaseUrl string) {
 	for _, proto := range protocolsToTest {
 		t.Run(proto.name, func(t *testing.T) {
 			// Helper to create a new client for each sub-test, like a function-scoped fixture
@@ -728,7 +750,7 @@ func TestToGenkitTool_MapParams(t *testing.T) {
 				if !proto.isDefault {
 					opts = append(opts, core.WithProtocol(proto.protocol))
 				}
-				client, err := core.NewToolboxClient("http://localhost:5000", opts...)
+				client, err := core.NewToolboxClient(testBaseUrl, opts...)
 				require.NoError(t, err, "Failed to create ToolboxClient")
 				return client
 			}
@@ -882,4 +904,5 @@ func TestToGenkitTool_MapParams(t *testing.T) {
 			})
 		})
 	}
+	})
 }


### PR DESCRIPTION
## Description
This PR separates the testing environments for generic integration tests and Auth integration tests by spawning two instances of the `mcp-toolbox` server during E2E setup:
- Legacy server on port 5000
- Draft/Auth server on port 5001

This ensures that the stateful authentication integrations and draft MCP feature integrations do not interfere with standard regression tests, mimicking the test infrastructure setup applied to the Python SDK.