### PR TITLE
feat: add support for protocol negotiation fallback with custom arrays

### DIFF
--- a/core/client.go
+++ b/core/client.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 
@@ -44,6 +45,7 @@ type ToolboxClient struct {
 	defaultOptionsSet   bool
 	clientName          string
 	clientVersion       string
+	supportedProtocols  []Protocol
 }
 
 // NewToolboxClient creates and configures a new, immutable client for interacting with a
@@ -467,13 +469,47 @@ func (tc *ToolboxClient) executeWithFallback(fn func(tr transport.Transport) (an
 		if errors.As(err, &negErr) {
 			fallbackVersion := Protocol(negErr.FallbackVersion)
 
-			if fallbackVersion == tc.protocol {
+			supportedVersions := GetSupportedMcpVersions()
+			serverIdx := -1
+			for i, v := range supportedVersions {
+				if Protocol(v) == fallbackVersion {
+					serverIdx = i
+					break
+				}
+			}
+
+			if serverIdx == -1 {
+				return nil, fmt.Errorf("server returned unknown protocol version: %s", fallbackVersion)
+			}
+
+			var serverSupported []Protocol
+			for _, v := range supportedVersions[serverIdx:] {
+				serverSupported = append(serverSupported, Protocol(v))
+			}
+
+			var fallbackProtocol Protocol
+			if len(tc.supportedProtocols) > 0 {
+				var mutuallySupported []Protocol
+				for _, v := range tc.supportedProtocols {
+					if slices.Contains(serverSupported, v) {
+						mutuallySupported = append(mutuallySupported, v)
+					}
+				}
+				if len(mutuallySupported) == 0 {
+					return nil, fmt.Errorf("no mutually supported protocol version. Client supports: %v, Server supports: %s", tc.supportedProtocols, fallbackVersion)
+				}
+				fallbackProtocol = mutuallySupported[0]
+			} else {
+				fallbackProtocol = fallbackVersion
+			}
+
+			if fallbackProtocol == tc.protocol {
 				return nil, err
 			}
 
 			var fallbackTransport transport.Transport
 			var createErr error
-			switch fallbackVersion {
+			switch fallbackProtocol {
 			case MCPv20260618:
 				fallbackTransport, createErr = mcp20260618.New(tc.baseURL, tc.httpClient, tc.clientName, tc.clientVersion)
 			case MCPv20251125:
@@ -485,14 +521,14 @@ func (tc *ToolboxClient) executeWithFallback(fn func(tr transport.Transport) (an
 			case MCPv20241105:
 				fallbackTransport, createErr = mcp20241105.New(tc.baseURL, tc.httpClient, tc.clientName, tc.clientVersion)
 			default:
-				return nil, fmt.Errorf("unsupported fallback protocol: %s", fallbackVersion)
+				return nil, fmt.Errorf("unsupported fallback protocol: %s", fallbackProtocol)
 			}
 
 			if createErr != nil {
-				return nil, fmt.Errorf("failed to create transport for fallback version %s: %w", fallbackVersion, createErr)
+				return nil, fmt.Errorf("failed to create transport for fallback version %s: %w", fallbackProtocol, createErr)
 			}
 
-			tc.protocol = fallbackVersion
+			tc.protocol = fallbackProtocol
 			tc.transport = fallbackTransport
 		} else {
 			return nil, err

--- a/core/client_test.go
+++ b/core/client_test.go
@@ -1093,6 +1093,128 @@ func TestExecuteWithFallback_EdgeCases(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, MCPv20251125, client.GetProtocol())
 	})
+
+	t.Run("Artificial Array Test", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("MCP-Protocol-Version") == "DRAFT-2026-v1" {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"1","error":{"code":-32600,"message":"invalid protocol version"}}`))
+				return
+			}
+			body, _ := io.ReadAll(r.Body)
+			var req mcpRPCRequest
+			_ = json.Unmarshal(body, &req)
+
+			var result any
+			switch req.Method {
+			case "initialize":
+				paramsMap, _ := req.Params.(map[string]any)
+				reqVersion, _ := paramsMap["protocolVersion"].(string)
+				result = map[string]any{
+					"protocolVersion": reqVersion,
+					"capabilities":    map[string]any{"tools": map[string]any{}},
+					"serverInfo":      map[string]any{"name": "mock-server", "version": "1.0.0"},
+				}
+			case "notifications/initialized":
+				w.WriteHeader(http.StatusOK)
+				return
+			case "tools/list":
+				result = map[string]any{
+					"tools": []mcpTool{{Name: "art_tool", Description: "tool"}},
+				}
+			}
+			resBytes, _ := json.Marshal(result)
+			resp := mcpRPCResponse{
+				JSONRPC: "2.0",
+				ID:      req.ID,
+				Result:  resBytes,
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+		}))
+		defer ts.Close()
+
+		client, err := NewToolboxClient(ts.URL,
+			WithHTTPClient(ts.Client()),
+			WithSupportedProtocols([]Protocol{MCPDraft, MCPv20241105}),
+		)
+		require.NoError(t, err)
+
+		tool, err := client.LoadTool("art_tool", context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, "art_tool", tool.Name())
+		assert.Equal(t, MCPv20241105, client.GetProtocol())
+	})
+
+	t.Run("Strict Constraint Test", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"1","error":{"code":-32600,"message":"invalid protocol version"}}`))
+		}))
+		defer ts.Close()
+
+		client, err := NewToolboxClient(ts.URL,
+			WithHTTPClient(ts.Client()),
+			WithSupportedProtocols([]Protocol{MCPDraft, MCPv20251125}),
+		)
+		require.NoError(t, err)
+
+		_, err = client.LoadTool("strict_tool", context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no mutually supported protocol version")
+	})
+
+	t.Run("Modern Smart Fallback Test", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("MCP-Protocol-Version") == "DRAFT-2026-v1" {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"1","error":{"code":-32022,"message":"Unsupported","data":{"supported":["2024-11-05"]}}}`))
+				return
+			}
+			body, _ := io.ReadAll(r.Body)
+			var req mcpRPCRequest
+			_ = json.Unmarshal(body, &req)
+
+			var result any
+			switch req.Method {
+			case "initialize":
+				paramsMap, _ := req.Params.(map[string]any)
+				reqVersion, _ := paramsMap["protocolVersion"].(string)
+				result = map[string]any{
+					"protocolVersion": reqVersion,
+					"capabilities":    map[string]any{"tools": map[string]any{}},
+					"serverInfo":      map[string]any{"name": "mock-server", "version": "1.0.0"},
+				}
+			case "notifications/initialized":
+				w.WriteHeader(http.StatusOK)
+				return
+			case "tools/list":
+				result = map[string]any{
+					"tools": []mcpTool{{Name: "modern_tool", Description: "tool"}},
+				}
+			}
+			resBytes, _ := json.Marshal(result)
+			resp := mcpRPCResponse{
+				JSONRPC: "2.0",
+				ID:      req.ID,
+				Result:  resBytes,
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+		}))
+		defer ts.Close()
+
+		client, err := NewToolboxClient(ts.URL,
+			WithHTTPClient(ts.Client()),
+			WithSupportedProtocols([]Protocol{MCPDraft, MCPv20241105}),
+		)
+		require.NoError(t, err)
+
+		tool, err := client.LoadTool("modern_tool", context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, "modern_tool", tool.Name())
+		assert.Equal(t, MCPv20241105, client.GetProtocol())
+	})
 }
 
 func TestExecuteWithFallback_NoInfiniteLoop(t *testing.T) {

--- a/core/options.go
+++ b/core/options.go
@@ -17,6 +17,7 @@ package core
 import (
 	"fmt"
 	"net/http"
+	"slices"
 
 	"golang.org/x/oauth2"
 )
@@ -25,6 +26,37 @@ import (
 
 // ClientOption configures a ToolboxClient at creation time.
 type ClientOption func(*ToolboxClient) error
+
+// WithSupportedProtocols configures a user-defined list of supported protocols for auto-negotiation.
+// The provided protocols are prioritized from newest to oldest version.
+func WithSupportedProtocols(protocols []Protocol) ClientOption {
+	return func(tc *ToolboxClient) error {
+		if len(protocols) == 0 {
+			return fmt.Errorf("WithSupportedProtocols: protocols slice cannot be empty")
+		}
+		if tc.protocolSet {
+			return fmt.Errorf("protocol is already set and cannot be overridden")
+		}
+
+		allVersions := GetSupportedMcpVersions()
+		for _, p := range protocols {
+			if !slices.Contains(allVersions, string(p)) {
+				return fmt.Errorf("invalid protocol version '%s'. Must be one of: %v", p, allVersions)
+			}
+		}
+
+		var sorted []Protocol
+		for _, verStr := range allVersions {
+			p := Protocol(verStr)
+			if slices.Contains(protocols, p) {
+				sorted = append(sorted, p)
+			}
+		}
+		tc.supportedProtocols = sorted
+		tc.protocol = sorted[0]
+		return nil
+	}
+}
 
 // Constructor for a newToolConfig which initializes the maps for auth token sources and bound parameters
 func newToolConfig() *ToolConfig {

--- a/core/options_test.go
+++ b/core/options_test.go
@@ -17,6 +17,7 @@
 package core
 
 import (
+	"fmt"
 	"net/http"
 	"reflect"
 	"strings"
@@ -634,4 +635,57 @@ func TestNewToolConfig(t *testing.T) {
 	if config.Strict != false {
 		t.Errorf("Expected Strict to be false, but got %t", config.Strict)
 	}
+}
+
+func TestWithSupportedProtocols(t *testing.T) {
+	t.Run("Success case", func(t *testing.T) {
+		client := newTestClient()
+		opt := WithSupportedProtocols([]Protocol{MCPv20250618, MCPv20251125})
+		err := opt(client)
+
+		if err != nil {
+			t.Fatalf("Expected no error, but got: %v", err)
+		}
+		if len(client.supportedProtocols) != 2 {
+			t.Fatalf("Expected 2 supported protocols, got %d", len(client.supportedProtocols))
+		}
+		if client.protocol != MCPv20251125 {
+			t.Errorf("Expected highest priority protocol %s, got %s", MCPv20251125, client.protocol)
+		}
+	})
+
+	t.Run("Empty slice error", func(t *testing.T) {
+		client := newTestClient()
+		opt := WithSupportedProtocols([]Protocol{})
+		err := opt(client)
+		if err == nil {
+			t.Error("Expected error for empty protocols slice, got nil")
+		}
+	})
+
+	t.Run("Invalid protocol element error", func(t *testing.T) {
+		client := newTestClient()
+		opt := WithSupportedProtocols([]Protocol{MCPv20251125, Protocol("invalid-version")})
+		err := opt(client)
+		if err == nil {
+			t.Error("Expected error for invalid protocol version element, got nil")
+		}
+		expectedErr := fmt.Sprintf("invalid protocol version 'invalid-version'. Must be one of: %v", GetSupportedMcpVersions())
+		if err.Error() != expectedErr {
+			t.Errorf("Expected error message %q, got %q", expectedErr, err.Error())
+		}
+	})
+
+	t.Run("Protocol already set error", func(t *testing.T) {
+		client := newTestClient()
+		client.protocolSet = true
+		opt := WithSupportedProtocols([]Protocol{MCPv20251125})
+		err := opt(client)
+		if err == nil {
+			t.Error("Expected error when protocol is already set, got nil")
+		}
+		if !strings.Contains(err.Error(), "protocol is already set and cannot be overridden") {
+			t.Errorf("Unexpected error message: %v", err)
+		}
+	})
 }

--- a/core/transport/mcp/v20241105/mcp.go
+++ b/core/transport/mcp/v20241105/mcp.go
@@ -247,6 +247,10 @@ func (t *McpTransport) doRPC(ctx context.Context, url string, reqBody any, heade
 	}
 	defer resp.Body.Close()
 
+	supportedVersionsPriority := []string{
+		ProtocolVersion,
+	}
+
 	checkRPCError := func(rpcErr *jsonRPCError) error {
 		if rpcErr == nil {
 			return nil
@@ -254,8 +258,16 @@ func (t *McpTransport) doRPC(ctx context.Context, url string, reqBody any, heade
 		if rpcErr.Code == -32004 || rpcErr.Code == -32022 {
 			if data, ok := rpcErr.Data.(map[string]any); ok {
 				if supported, ok := data["supported"].([]any); ok && len(supported) > 0 {
-					if fallbackStr, ok := supported[0].(string); ok {
-						return &transport.ProtocolNegotiationError{FallbackVersion: fallbackStr}
+					supportedSet := make(map[string]struct{})
+					for _, s := range supported {
+						if str, ok := s.(string); ok {
+							supportedSet[str] = struct{}{}
+						}
+					}
+					for _, v := range supportedVersionsPriority {
+						if _, exists := supportedSet[v]; exists {
+							return &transport.ProtocolNegotiationError{FallbackVersion: v}
+						}
 					}
 				}
 			}

--- a/core/transport/mcp/v20250326/mcp.go
+++ b/core/transport/mcp/v20250326/mcp.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport"
 	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport/mcp"
+	mcp20241105 "github.com/googleapis/mcp-toolbox-sdk-go/core/transport/mcp/v20241105"
 )
 
 const (
@@ -292,6 +293,11 @@ func (t *McpTransport) doRPC(ctx context.Context, url string, reqBody any, heade
 	}
 	defer resp.Body.Close()
 
+	supportedVersionsPriority := []string{
+		ProtocolVersion,
+		mcp20241105.ProtocolVersion,
+	}
+
 	checkRPCError := func(rpcErr *jsonRPCError) error {
 		if rpcErr == nil {
 			return nil
@@ -299,8 +305,16 @@ func (t *McpTransport) doRPC(ctx context.Context, url string, reqBody any, heade
 		if rpcErr.Code == -32004 || rpcErr.Code == -32022 {
 			if data, ok := rpcErr.Data.(map[string]any); ok {
 				if supported, ok := data["supported"].([]any); ok && len(supported) > 0 {
-					if fallbackStr, ok := supported[0].(string); ok {
-						return &transport.ProtocolNegotiationError{FallbackVersion: fallbackStr}
+					supportedSet := make(map[string]struct{})
+					for _, s := range supported {
+						if str, ok := s.(string); ok {
+							supportedSet[str] = struct{}{}
+						}
+					}
+					for _, v := range supportedVersionsPriority {
+						if _, exists := supportedSet[v]; exists {
+							return &transport.ProtocolNegotiationError{FallbackVersion: v}
+						}
 					}
 				}
 			}

--- a/core/transport/mcp/v20250618/mcp.go
+++ b/core/transport/mcp/v20250618/mcp.go
@@ -27,6 +27,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport"
 	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport/mcp"
+	mcp20241105 "github.com/googleapis/mcp-toolbox-sdk-go/core/transport/mcp/v20241105"
+	mcp20250326 "github.com/googleapis/mcp-toolbox-sdk-go/core/transport/mcp/v20250326"
 )
 
 const (
@@ -250,6 +252,12 @@ func (t *McpTransport) doRPC(ctx context.Context, url string, reqBody any, heade
 	}
 	defer resp.Body.Close()
 
+	supportedVersionsPriority := []string{
+		ProtocolVersion,
+		mcp20250326.ProtocolVersion,
+		mcp20241105.ProtocolVersion,
+	}
+
 	checkRPCError := func(rpcErr *jsonRPCError) error {
 		if rpcErr == nil {
 			return nil
@@ -257,8 +265,16 @@ func (t *McpTransport) doRPC(ctx context.Context, url string, reqBody any, heade
 		if rpcErr.Code == -32004 || rpcErr.Code == -32022 {
 			if data, ok := rpcErr.Data.(map[string]any); ok {
 				if supported, ok := data["supported"].([]any); ok && len(supported) > 0 {
-					if fallbackStr, ok := supported[0].(string); ok {
-						return &transport.ProtocolNegotiationError{FallbackVersion: fallbackStr}
+					supportedSet := make(map[string]struct{})
+					for _, s := range supported {
+						if str, ok := s.(string); ok {
+							supportedSet[str] = struct{}{}
+						}
+					}
+					for _, v := range supportedVersionsPriority {
+						if _, exists := supportedSet[v]; exists {
+							return &transport.ProtocolNegotiationError{FallbackVersion: v}
+						}
 					}
 				}
 			}

--- a/core/transport/mcp/v20251125/mcp.go
+++ b/core/transport/mcp/v20251125/mcp.go
@@ -27,6 +27,9 @@ import (
 	"github.com/google/uuid"
 	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport"
 	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport/mcp"
+	mcp20241105 "github.com/googleapis/mcp-toolbox-sdk-go/core/transport/mcp/v20241105"
+	mcp20250326 "github.com/googleapis/mcp-toolbox-sdk-go/core/transport/mcp/v20250326"
+	mcp20250618 "github.com/googleapis/mcp-toolbox-sdk-go/core/transport/mcp/v20250618"
 )
 
 const (
@@ -249,6 +252,13 @@ func (t *McpTransport) doRPC(ctx context.Context, url string, reqBody any, heade
 	}
 	defer resp.Body.Close()
 
+	supportedVersionsPriority := []string{
+		ProtocolVersion,
+		mcp20250618.ProtocolVersion,
+		mcp20250326.ProtocolVersion,
+		mcp20241105.ProtocolVersion,
+	}
+
 	checkRPCError := func(rpcErr *jsonRPCError) error {
 		if rpcErr == nil {
 			return nil
@@ -256,8 +266,16 @@ func (t *McpTransport) doRPC(ctx context.Context, url string, reqBody any, heade
 		if rpcErr.Code == -32004 || rpcErr.Code == -32022 {
 			if data, ok := rpcErr.Data.(map[string]any); ok {
 				if supported, ok := data["supported"].([]any); ok && len(supported) > 0 {
-					if fallbackStr, ok := supported[0].(string); ok {
-						return &transport.ProtocolNegotiationError{FallbackVersion: fallbackStr}
+					supportedSet := make(map[string]struct{})
+					for _, s := range supported {
+						if str, ok := s.(string); ok {
+							supportedSet[str] = struct{}{}
+						}
+					}
+					for _, v := range supportedVersionsPriority {
+						if _, exists := supportedSet[v]; exists {
+							return &transport.ProtocolNegotiationError{FallbackVersion: v}
+						}
 					}
 				}
 			}

--- a/core/transport/mcp/v20260618/mcp.go
+++ b/core/transport/mcp/v20260618/mcp.go
@@ -26,6 +26,9 @@ import (
 
 	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport"
 	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport/mcp"
+	mcp20241105 "github.com/googleapis/mcp-toolbox-sdk-go/core/transport/mcp/v20241105"
+	mcp20250326 "github.com/googleapis/mcp-toolbox-sdk-go/core/transport/mcp/v20250326"
+	mcp20250618 "github.com/googleapis/mcp-toolbox-sdk-go/core/transport/mcp/v20250618"
 	mcp20251125 "github.com/googleapis/mcp-toolbox-sdk-go/core/transport/mcp/v20251125"
 )
 
@@ -49,6 +52,9 @@ func New(baseURL string, client *http.Client, clientName string, clientVersion s
 	baseTransport, err := mcp.NewBaseTransport(baseURL, client)
 	if err != nil {
 		return nil, err
+	}
+	if clientVersion == "" {
+		clientVersion = mcp.SDKVersion
 	}
 
 	return &McpTransport{
@@ -174,6 +180,13 @@ func (t *McpTransport) InvokeTool(ctx context.Context, toolName string, payload 
 	return t.ProcessToolResultContent(baseContent), nil
 }
 
+var supportedVersionsPriority = []string{
+	mcp20251125.ProtocolVersion,
+	mcp20250618.ProtocolVersion,
+	mcp20250326.ProtocolVersion,
+	mcp20241105.ProtocolVersion,
+}
+
 func checkRPCError(rpcErr *jsonRPCError) error {
 	if rpcErr == nil {
 		return nil
@@ -181,8 +194,16 @@ func checkRPCError(rpcErr *jsonRPCError) error {
 	if rpcErr.Code == -32004 || rpcErr.Code == -32022 {
 		if data, ok := rpcErr.Data.(map[string]any); ok {
 			if supported, ok := data["supported"].([]any); ok && len(supported) > 0 {
-				if fallbackStr, ok := supported[0].(string); ok {
-					return &transport.ProtocolNegotiationError{FallbackVersion: fallbackStr}
+				supportedSet := make(map[string]struct{})
+				for _, s := range supported {
+					if str, ok := s.(string); ok {
+						supportedSet[str] = struct{}{}
+					}
+				}
+				for _, v := range supportedVersionsPriority {
+					if _, exists := supportedSet[v]; exists {
+						return &transport.ProtocolNegotiationError{FallbackVersion: v}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Description
This PR adds support for specifying a custom array of supported MCP protocol versions during client initialization. This enables robust protocol negotiation and fallback strategies when interacting with different versions of the Toolbox server.

## Changes
- Implemented `core.WithSupportedProtocols([]core.Protocol{})` in the client options to handle custom array fallbacks.
- Added explicit aliases for `core.MCPLatest` and `core.MCPDraft` to the core constants.
- Refactored the E2E tests to use `serverURLStable` and `serverURLDraft` constants.
- Added explicit integration tests for establishing connections with `core.MCPLatest`, and verifying that the array fallback `[]core.Protocol{core.MCPLatest, core.MCPDraft}` successfully negotiates the correct protocol version.
- Updated the SDK `README.md` to document the new custom array examples for protocol negotiation.