### PR TITLE
chore(ci): Harden workflows from Zizmor findings

### DIFF
--- a/.github/workflows/api-docs-backfill.yml
+++ b/.github/workflows/api-docs-backfill.yml
@@ -67,6 +67,7 @@ jobs:
           ref: refs/tags/${{ inputs.package }}/${{ inputs.version }}
           submodules: recursive
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -37,11 +37,13 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: '1.25.0'
+          cache: false
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@2752ce1d29631191ea3f27c23495fa06139a5b78 # v3
@@ -77,9 +79,12 @@ jobs:
         if: steps.resolve.outputs.packages != ''
         run: |
           chmod +x scripts/generate-api-docs.sh
-          for PKG in ${{ steps.resolve.outputs.packages }}; do
-            ./scripts/generate-api-docs.sh "$PKG" "${{ steps.resolve.outputs.version }}" "$BASE_URL"
+          for PKG in ${STEPS_RESOLVE_OUTPUTS_PACKAGES}; do
+            ./scripts/generate-api-docs.sh "$PKG" "${STEPS_RESOLVE_OUTPUTS_VERSION}" "$BASE_URL"
           done
+        env:
+          STEPS_RESOLVE_OUTPUTS_PACKAGES: ${{ steps.resolve.outputs.packages }}
+          STEPS_RESOLVE_OUTPUTS_VERSION: ${{ steps.resolve.outputs.version }}
 
       - name: Build root page
         if: steps.resolve.outputs.packages != '' && startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/cloud_build_failure_reporter.yml
+++ b/.github/workflows/cloud_build_failure_reporter.yml
@@ -38,10 +38,12 @@ jobs:
 
     steps:
       - uses: 'actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3' # v9
+        env:
+          TRIGGER_NAMES: ${{ inputs.trigger_names }}
         with:
           script: |-
                   // parse test names
-                  const testNameSubstring = '${{ inputs.trigger_names }}';
+                  const testNameSubstring = process.env.TRIGGER_NAMES;
                   const testNameFound = new Map(); //keeps track of whether each test is found
                   testNameSubstring.split(',').forEach(testName => {
                     testNameFound.set(testName, false);
@@ -171,8 +173,8 @@ jobs:
                   const noTestFound = Array.from(testNameFound.values()).every(value => value === false);
                   if (noTestFound){
                     createOrCommentIssue(
-                      'Missing periodic tests: ${{ inputs.trigger_names }}',
-                      `No periodic test is found for triggers: ${{ inputs.trigger_names }}. Last checked from ${
+                      `Missing periodic tests: ${process.env.TRIGGER_NAMES}`,
+                      `No periodic test is found for triggers: ${process.env.TRIGGER_NAMES}. Last checked from ${
                         commits[0].html_url
                       } to ${commits[commits.length - 1].html_url}.`
                     );

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 name: lint
+# pull_request_target only fires on `labeled`; running fork code is gated
+# behind the maintainer-applied 'tests: run' label
 on: # zizmor: ignore[dangerous-triggers] 
   pull_request:
   pull_request_target:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: lint
-on:
+on: # zizmor: ignore[dangerous-triggers]
   pull_request:
   pull_request_target:
     types: [labeled]

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: lint
-on: # zizmor: ignore[dangerous-triggers]
+on: # zizmor: ignore[dangerous-triggers] 
   pull_request:
   pull_request_target:
     types: [labeled]

--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -30,6 +30,8 @@ jobs:
       pull-requests: 'write'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c # v1.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR addresses several security warnings flagged by zizmor, autofixed by the tool and manual fixes

**Changes Included**

- api-docs.yml: Refactored the `generate-api-docs.sh` step to pass dynamic outputs `(steps.resolve.outputs.packages and version)` via environment variables rather than expanding them directly into the bash script.
- cloud_build_failure_reporter.yml: Mitigated a JavaScript template injection vulnerability in `actions/github-script` by passing the `inputs.trigger_names` through an environment variable `(process.env.TRIGGER_NAMES)`.
- added persist-credentials: false to `actions/checkout steps` in `api-docs.yml`, `api-docs-backfill.yml`, and `sync-labels.yaml`
- lint.yaml: Added a `# zizmor: ignore[dangerous-triggers] to suppress a false-positive warning regarding the pull_request_target trigger. Since this execution is strictly gated by a maintainer applying the tests: run label, it is protected against arbitrary code execution from untrusted PRs.
- Disabled the cache for `actions/setup-go` in `api-docs.yml`