### PR TITLE
feat(core): add support for MCP 2026 stateless draft and auto-negotiation fallback

### DIFF
--- a/core/client.go
+++ b/core/client.go
@@ -16,9 +16,11 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 
 	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport"
 	mcp20241105 "github.com/googleapis/mcp-toolbox-sdk-go/core/transport/mcp/v20241105"
@@ -31,6 +33,7 @@ import (
 
 // The synchronous interface for a Toolbox service client.
 type ToolboxClient struct {
+	mu                  sync.RWMutex
 	baseURL             string
 	httpClient          *http.Client
 	protocol            Protocol
@@ -200,6 +203,8 @@ func (tc *ToolboxClient) newToolboxTool(
 		requiredAuthnParams: remainingAuthnParams,
 		requiredAuthzTokens: remainingAuthzTokens,
 		clientHeaderSources: tc.clientHeaderSources,
+		clientName:          tc.clientName,
+		clientVersion:       tc.clientVersion,
 	}
 
 	return tt, usedAuthKeys, usedBoundKeys, nil
@@ -245,11 +250,15 @@ func (tc *ToolboxClient) LoadTool(name string, ctx context.Context, opts ...Tool
 	}
 
 	// Fetch the manifest for the specified tool.
-	manifest, err := tc.transport.GetTool(ctx, name, resolvedHeaders)
+	var manifest *transport.ManifestSchema
+	res, err := tc.executeWithFallback(func(tr transport.Transport) (any, error) {
+		return tr.GetTool(ctx, name, resolvedHeaders)
+	})
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to load tool manifest for '%s': %w", name, err)
 	}
+	manifest = res.(*transport.ManifestSchema)
 	if manifest.Tools == nil {
 		return nil, fmt.Errorf("tool '%s' not found (manifest contains no tools)", name)
 	}
@@ -259,7 +268,11 @@ func (tc *ToolboxClient) LoadTool(name string, ctx context.Context, opts ...Tool
 	}
 
 	// Construct the tool from its schema and the final configuration.
-	tool, usedAuthKeys, usedBoundKeys, err := tc.newToolboxTool(name, schema, finalConfig, true, tc.transport)
+	tc.mu.RLock()
+	activeTransport := tc.transport
+	tc.mu.RUnlock()
+
+	tool, usedAuthKeys, usedBoundKeys, err := tc.newToolboxTool(name, schema, finalConfig, true, activeTransport)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create toolbox tool from schema for '%s': %w", name, err)
 	}
@@ -340,10 +353,14 @@ func (tc *ToolboxClient) LoadToolset(name string, ctx context.Context, opts ...T
 	}
 
 	// Fetch Manifest via Transport
-	manifest, err := tc.transport.ListTools(ctx, name, resolvedHeaders)
+	var manifest *transport.ManifestSchema
+	res, err := tc.executeWithFallback(func(tr transport.Transport) (any, error) {
+		return tr.ListTools(ctx, name, resolvedHeaders)
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to load toolset manifest for '%s': %w", name, err)
 	}
+	manifest = res.(*transport.ManifestSchema)
 	if manifest.Tools == nil {
 		return nil, fmt.Errorf("toolset '%s' not found (manifest contains no tools)", name)
 	}
@@ -361,9 +378,13 @@ func (tc *ToolboxClient) LoadToolset(name string, ctx context.Context, opts ...T
 		providedBoundKeys[k] = struct{}{}
 	}
 
+	tc.mu.RLock()
+	activeTransport := tc.transport
+	tc.mu.RUnlock()
+
 	for toolName, schema := range manifest.Tools {
 		// Construct each tool from its schema and the shared configuration.
-		tool, usedAuthKeys, usedBoundKeys, err := tc.newToolboxTool(toolName, schema, finalConfig, finalConfig.Strict, tc.transport)
+		tool, usedAuthKeys, usedBoundKeys, err := tc.newToolboxTool(toolName, schema, finalConfig, finalConfig.Strict, activeTransport)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create tool '%s': %w", toolName, err)
 		}
@@ -428,4 +449,53 @@ func (tc *ToolboxClient) LoadToolset(name string, ctx context.Context, opts ...T
 	}
 
 	return tools, nil
+}
+
+// GetProtocol returns the active protocol version for the client.
+func (tc *ToolboxClient) GetProtocol() Protocol {
+	return tc.protocol
+}
+
+func (tc *ToolboxClient) executeWithFallback(fn func(tr transport.Transport) (any, error)) (any, error) {
+	for {
+		result, err := fn(tc.transport)
+		if err == nil {
+			return result, nil
+		}
+
+		var negErr *transport.ProtocolNegotiationError
+		if errors.As(err, &negErr) {
+			fallbackVersion := Protocol(negErr.FallbackVersion)
+
+			if fallbackVersion == tc.protocol {
+				return nil, err
+			}
+
+			var fallbackTransport transport.Transport
+			var createErr error
+			switch fallbackVersion {
+			case MCPv20260618:
+				fallbackTransport, createErr = mcp20260618.New(tc.baseURL, tc.httpClient, tc.clientName, tc.clientVersion)
+			case MCPv20251125:
+				fallbackTransport, createErr = mcp20251125.New(tc.baseURL, tc.httpClient, tc.clientName, tc.clientVersion)
+			case MCPv20250618:
+				fallbackTransport, createErr = mcp20250618.New(tc.baseURL, tc.httpClient, tc.clientName, tc.clientVersion)
+			case MCPv20250326:
+				fallbackTransport, createErr = mcp20250326.New(tc.baseURL, tc.httpClient, tc.clientName, tc.clientVersion)
+			case MCPv20241105:
+				fallbackTransport, createErr = mcp20241105.New(tc.baseURL, tc.httpClient, tc.clientName, tc.clientVersion)
+			default:
+				return nil, fmt.Errorf("unsupported fallback protocol: %s", fallbackVersion)
+			}
+
+			if createErr != nil {
+				return nil, fmt.Errorf("failed to create transport for fallback version %s: %w", fallbackVersion, createErr)
+			}
+
+			tc.protocol = fallbackVersion
+			tc.transport = fallbackTransport
+		} else {
+			return nil, err
+		}
+	}
 }

--- a/core/client_test.go
+++ b/core/client_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
+
 	"io"
 	"log"
 	"net/http"
@@ -103,13 +103,6 @@ func newMockMCPServer(t *testing.T, tools []mcpTool) *httptest.Server {
 }
 
 // Test Helpers & Mocks
-
-// failingTokenSource is a token source that always returns an error, for testing failure paths.
-type failingTokenSource struct{}
-
-func (f *failingTokenSource) Token() (*oauth2.Token, error) {
-	return nil, errors.New("token source failed as designed")
-}
 
 func getMyToken() string {
 	return "dynamic-token-from-func"
@@ -528,7 +521,7 @@ func TestLoadToolAndLoadToolset(t *testing.T) {
 
 		isToolBError := strings.Contains(errStr, "no parameter named 'param1' found on tool 'toolB'")
 
-		if !(isToolAError || isToolBError) {
+		if !isToolAError && !isToolBError {
 			t.Errorf("Incorrect error for unused auth token in strict mode. Got: %v", err)
 		}
 	})
@@ -913,4 +906,215 @@ func TestLoadToolAndLoadToolset_ErrorPaths(t *testing.T) {
 			t.Errorf("Incorrect error for completely unused param. Got: %v", err)
 		}
 	})
+}
+
+func TestExecuteWithFallback_EdgeCases(t *testing.T) {
+	t.Run("Infinite Loop Prevention", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"1","error":{"code":-32022,"message":"Unsupported protocol version","data":{"supported":["DRAFT-2026-v1"]}}}`))
+		}))
+		defer ts.Close()
+
+		client, err := NewToolboxClient(ts.URL, WithHTTPClient(ts.Client()))
+		require.NoError(t, err)
+
+		_, err = client.LoadTool("test-tool", context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "server requested protocol fallback")
+	})
+
+	t.Run("MultiStep Cascading Fallback", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("MCP-Protocol-Version") == "DRAFT-2026-v1" {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"1","error":{"code":-32022,"message":"Unsupported","data":{"supported":["2025-06-18","2024-11-05"]}}}`))
+				return
+			}
+			body, _ := io.ReadAll(r.Body)
+			var req mcpRPCRequest
+			_ = json.Unmarshal(body, &req)
+
+			var result any
+			switch req.Method {
+			case "initialize":
+				result = map[string]any{
+					"protocolVersion": "2025-06-18",
+					"capabilities":    map[string]any{"tools": map[string]any{}},
+					"serverInfo":      map[string]any{"name": "mock-server", "version": "1.0.0"},
+				}
+			case "notifications/initialized":
+				w.WriteHeader(http.StatusOK)
+				return
+			case "tools/list":
+				result = map[string]any{
+					"tools": []mcpTool{{Name: "cascaded_tool", Description: "tool"}},
+				}
+			}
+			resBytes, _ := json.Marshal(result)
+			resp := mcpRPCResponse{
+				JSONRPC: "2.0",
+				ID:      req.ID,
+				Result:  resBytes,
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+		}))
+		defer ts.Close()
+
+		client, err := NewToolboxClient(ts.URL, WithHTTPClient(ts.Client()))
+		require.NoError(t, err)
+
+		tool, err := client.LoadTool("cascaded_tool", context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, "cascaded_tool", tool.Name())
+	})
+
+	t.Run("Sequential Step-by-Step Fallback", func(t *testing.T) {
+		tests := []struct {
+			name             string
+			initialProtocol  Protocol
+			serverSupported  []string
+			expectedProtocol Protocol
+		}{
+			{
+				name:             "Fallback from DRAFT-2026-v1 to 2025-11-25",
+				initialProtocol:  MCPv20260618,
+				serverSupported:  []string{"2025-11-25", "2025-06-18"},
+				expectedProtocol: MCPv20251125,
+			},
+			{
+				name:             "Fallback from 2025-11-25 to 2025-06-18",
+				initialProtocol:  MCPv20251125,
+				serverSupported:  []string{"2025-06-18", "2025-03-26"},
+				expectedProtocol: MCPv20250618,
+			},
+			{
+				name:             "Fallback from 2025-06-18 to 2025-03-26",
+				initialProtocol:  MCPv20250618,
+				serverSupported:  []string{"2025-03-26", "2024-11-05"},
+				expectedProtocol: MCPv20250326,
+			},
+			{
+				name:             "Fallback from 2025-03-26 to 2024-11-05",
+				initialProtocol:  MCPv20250326,
+				serverSupported:  []string{"2024-11-05"},
+				expectedProtocol: MCPv20241105,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if tt.initialProtocol == MCPv20260618 && r.Header.Get("MCP-Protocol-Version") == "DRAFT-2026-v1" {
+						w.WriteHeader(http.StatusBadRequest)
+						respErr, _ := json.Marshal(map[string]any{
+							"jsonrpc": "2.0",
+							"id":      "1",
+							"error": map[string]any{
+								"code":    -32022,
+								"message": "Unsupported protocol version",
+								"data":    map[string]any{"supported": tt.serverSupported},
+							},
+						})
+						_, _ = w.Write(respErr)
+						return
+					}
+
+					body, _ := io.ReadAll(r.Body)
+					var req mcpRPCRequest
+					_ = json.Unmarshal(body, &req)
+
+					switch req.Method {
+					case "initialize":
+						paramsMap, _ := req.Params.(map[string]any)
+						reqVersion, _ := paramsMap["protocolVersion"].(string)
+						if reqVersion != string(tt.expectedProtocol) {
+							w.WriteHeader(http.StatusBadRequest)
+							respErr, _ := json.Marshal(map[string]any{
+								"jsonrpc": "2.0",
+								"id":      req.ID,
+								"error": map[string]any{
+									"code":    -32004,
+									"message": "Version mismatch",
+									"data":    map[string]any{"supported": tt.serverSupported},
+								},
+							})
+							_, _ = w.Write(respErr)
+							return
+						}
+						resp := mcpRPCResponse{
+							JSONRPC: "2.0",
+							ID:      req.ID,
+							Result: func() json.RawMessage {
+								b, _ := json.Marshal(map[string]any{
+									"protocolVersion": string(tt.expectedProtocol),
+									"capabilities":    map[string]any{"tools": map[string]any{}},
+									"serverInfo":      map[string]any{"name": "mock-server", "version": "1.0.0"},
+								})
+								return b
+							}(),
+						}
+						w.Header().Set("Content-Type", "application/json")
+						w.Header().Set("Mcp-Session-Id", "session-123")
+						_ = json.NewEncoder(w).Encode(resp)
+					case "notifications/initialized":
+						w.WriteHeader(http.StatusOK)
+					case "tools/list":
+						resp := mcpRPCResponse{
+							JSONRPC: "2.0",
+							ID:      req.ID,
+							Result: func() json.RawMessage {
+								b, _ := json.Marshal(map[string]any{
+									"tools": []mcpTool{{Name: "step_tool", Description: "tool"}},
+								})
+								return b
+							}(),
+						}
+						w.Header().Set("Content-Type", "application/json")
+						_ = json.NewEncoder(w).Encode(resp)
+					}
+				}))
+				defer ts.Close()
+
+				client, err := NewToolboxClient(ts.URL, WithHTTPClient(ts.Client()), WithProtocol(tt.initialProtocol))
+				require.NoError(t, err)
+
+				tool, err := client.LoadTool("step_tool", context.Background())
+				require.NoError(t, err)
+				assert.Equal(t, "step_tool", tool.Name())
+				assert.Equal(t, tt.expectedProtocol, client.GetProtocol())
+			})
+		}
+	})
+
+	t.Run("GetProtocol returns active protocol", func(t *testing.T) {
+		client, err := NewToolboxClient("http://localhost:5000", WithProtocol(MCPv20251125))
+		require.NoError(t, err)
+		assert.Equal(t, MCPv20251125, client.GetProtocol())
+	})
+}
+
+func TestExecuteWithFallback_NoInfiniteLoop(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"1","error":{"code":-32022,"message":"Unsupported","data":{"supported":["DRAFT-2026-v1"]}}}`))
+	}))
+	defer ts.Close()
+
+	client, err := NewToolboxClient(ts.URL, WithHTTPClient(ts.Client()))
+	require.NoError(t, err)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := client.LoadTool("test_tool", context.Background())
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err, "expected error when server demands current protocol version as fallback")
+	case <-time.After(2 * time.Second):
+		t.Fatal("executeWithFallback hung in an infinite loop")
+	}
 }

--- a/core/tool.go
+++ b/core/tool.go
@@ -39,6 +39,9 @@ type ToolboxTool struct {
 	requiredAuthnParams map[string][]string
 	requiredAuthzTokens []string
 	clientHeaderSources map[string]oauth2.TokenSource
+	clientName          string
+	clientVersion       string
+	supportedProtocols  []string
 }
 
 // Name returns the tool's name.
@@ -206,6 +209,13 @@ func (tt *ToolboxTool) cloneToolboxTool() *ToolboxTool {
 		requiredAuthnParams: make(map[string][]string, len(tt.requiredAuthnParams)),
 		requiredAuthzTokens: make([]string, len(tt.requiredAuthzTokens)),
 		clientHeaderSources: make(map[string]oauth2.TokenSource, len(tt.clientHeaderSources)),
+		clientName:          tt.clientName,
+		clientVersion:       tt.clientVersion,
+	}
+
+	if tt.supportedProtocols != nil {
+		newTt.supportedProtocols = make([]string, len(tt.supportedProtocols))
+		copy(newTt.supportedProtocols, tt.supportedProtocols)
 	}
 
 	if tt.boundParamSchemas != nil {

--- a/core/transport/mcp/v20241105/mcp.go
+++ b/core/transport/mcp/v20241105/mcp.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport"
@@ -185,7 +186,7 @@ func (t *McpTransport) initializeSession(ctx context.Context, headers map[string
 
 	// Protocol Version Check
 	if result.ProtocolVersion != t.protocolVersion {
-		return fmt.Errorf("MCP version mismatch: client (%s) != server (%s)", t.protocolVersion, result.ProtocolVersion)
+		return &transport.ProtocolNegotiationError{FallbackVersion: result.ProtocolVersion}
 	}
 
 	// Capabilities Check
@@ -246,13 +247,42 @@ func (t *McpTransport) doRPC(ctx context.Context, url string, reqBody any, heade
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusOK {
-		// Continue to body parsing
-	} else if (resp.StatusCode == http.StatusAccepted || resp.StatusCode == http.StatusNoContent) && dest == nil {
+	checkRPCError := func(rpcErr *jsonRPCError) error {
+		if rpcErr == nil {
+			return nil
+		}
+		if rpcErr.Code == -32004 || rpcErr.Code == -32022 {
+			if data, ok := rpcErr.Data.(map[string]any); ok {
+				if supported, ok := data["supported"].([]any); ok && len(supported) > 0 {
+					if fallbackStr, ok := supported[0].(string); ok {
+						return &transport.ProtocolNegotiationError{FallbackVersion: fallbackStr}
+					}
+				}
+			}
+			return &transport.ProtocolNegotiationError{FallbackVersion: "2024-11-05"}
+		}
+		errMsgLower := strings.ToLower(rpcErr.Message)
+		if strings.Contains(errMsgLower, "invalid protocol version") || strings.Contains(errMsgLower, "unsupported protocol version") {
+			return &transport.ProtocolNegotiationError{FallbackVersion: "2024-11-05"}
+		}
+		return fmt.Errorf("MCP request failed with code %d: %s", rpcErr.Code, rpcErr.Message)
+	}
+
+	if (resp.StatusCode == http.StatusAccepted || resp.StatusCode == http.StatusNoContent) && dest == nil {
 		return nil // Valid notification success
-	} else {
-		// Any other code, OR a 202/204 when we expected a result, is a failure.
+	}
+	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+		var rpcResp jsonRPCResponse
+		if err := json.Unmarshal(body, &rpcResp); err == nil && rpcResp.Error != nil {
+			if err := checkRPCError(rpcResp.Error); err != nil {
+				return err
+			}
+		}
+		bodyStrLower := strings.ToLower(string(body))
+		if strings.Contains(bodyStrLower, "invalid protocol version") || strings.Contains(bodyStrLower, "unsupported protocol version") {
+			return &transport.ProtocolNegotiationError{FallbackVersion: "2024-11-05"}
+		}
 		return fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -273,7 +303,9 @@ func (t *McpTransport) doRPC(ctx context.Context, url string, reqBody any, heade
 
 	// Check RPC Error
 	if rpcResp.Error != nil {
-		return fmt.Errorf("MCP request failed with code %d: %s", rpcResp.Error.Code, rpcResp.Error.Message)
+		if err := checkRPCError(rpcResp.Error); err != nil {
+			return err
+		}
 	}
 
 	// Decode Result into specific struct

--- a/core/transport/mcp/v20241105/mcp_test.go
+++ b/core/transport/mcp/v20241105/mcp_test.go
@@ -23,8 +23,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport/mcp"
 	"testing"
+
+	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport"
+	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport/mcp"
 
 	"maps"
 
@@ -267,8 +269,9 @@ func TestProtocolMismatch(t *testing.T) {
 	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0")
 
 	_, err := client.ListTools(context.Background(), "", nil)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "MCP version mismatch")
+	var negErr *transport.ProtocolNegotiationError
+	require.True(t, errors.As(err, &negErr))
+	assert.Equal(t, "2099-01-01", negErr.FallbackVersion)
 }
 
 func TestInitialize_MissingCapabilities(t *testing.T) {
@@ -363,7 +366,7 @@ func TestRequest_NetworkError(t *testing.T) {
 func TestRequest_ServerError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte("Internal Error"))
+		_, _ = w.Write([]byte("Internal Error"))
 	}))
 	defer server.Close()
 
@@ -376,8 +379,9 @@ func TestRequest_ServerError(t *testing.T) {
 func TestRequest_BadJSON(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{ broken json `))
+		_, _ = w.Write([]byte(`{ broken json `))
 	}))
+
 	defer server.Close()
 
 	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0")
@@ -553,7 +557,7 @@ func TestEnsureInitialized_PassesHeaders(t *testing.T) {
 	require.NoError(t, err)
 
 	capturedHeaders := make(map[string]string)
-	tr.BaseMcpTransport.HandshakeHook = func(ctx context.Context, headers map[string]string) error {
+	tr.HandshakeHook = func(ctx context.Context, headers map[string]string) error {
 		maps.Copy(capturedHeaders, headers)
 		return nil
 	}
@@ -582,7 +586,8 @@ func TestInitializeSession_PassesHeadersToWire(t *testing.T) {
 			return
 		}
 
-		if req.Method == "initialize" {
+		switch req.Method {
+		case "initialize":
 			resp := map[string]any{
 				"jsonrpc": "2.0",
 				"id":      "123",
@@ -592,11 +597,13 @@ func TestInitializeSession_PassesHeadersToWire(t *testing.T) {
 					"serverInfo":      map[string]any{"name": "test", "version": "1.0"},
 				},
 			}
-			json.NewEncoder(w).Encode(resp)
-		} else if req.Method == "notifications/initialized" {
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case "notifications/initialized":
 			w.WriteHeader(http.StatusNoContent)
-		} else {
-			w.WriteHeader(http.StatusNotFound)
+		default:
+			t.Errorf("Unexpected RPC method called: %q", req.Method)
+			w.WriteHeader(http.StatusBadRequest)
 		}
 	}))
 	defer ts.Close()
@@ -635,4 +642,44 @@ func TestNew_ClientVersion(t *testing.T) {
 			t.Errorf("expected clientVersion %q, got %q", mcp.SDKVersion, tr2.clientVersion)
 		}
 	})
+}
+
+func TestJSONRPCError_ProtocolNegotiation(t *testing.T) {
+	testCases := []struct {
+		name    string
+		code    int
+		message string
+	}{
+		{"Code -32022", -32022, "version mismatch"},
+		{"Code -32004", -32004, "version mismatch"},
+		{"Message invalid protocol version", -32000, "invalid protocol version"},
+		{"Message unsupported protocol version", -32000, "unsupported protocol version"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				resp := jsonRPCResponse{
+					JSONRPC: "2.0",
+					ID:      "1",
+					Error: &jsonRPCError{
+						Code:    tc.code,
+						Message: tc.message,
+					},
+				}
+				_ = json.NewEncoder(w).Encode(resp)
+			}))
+			defer server.Close()
+
+			tr, err := New(server.URL, server.Client(), "custom-client", "1.0.0")
+			require.NoError(t, err)
+
+			_, err = tr.ListTools(context.Background(), "", nil)
+			require.Error(t, err)
+			var negErr *transport.ProtocolNegotiationError
+			require.True(t, errors.As(err, &negErr))
+			assert.Equal(t, "2024-11-05", negErr.FallbackVersion)
+		})
+	}
 }

--- a/core/transport/mcp/v20250326/mcp.go
+++ b/core/transport/mcp/v20250326/mcp.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport"
@@ -191,7 +192,7 @@ func (t *McpTransport) initializeSession(ctx context.Context, headers map[string
 
 	// Protocol Version Check
 	if result.ProtocolVersion != t.protocolVersion {
-		return fmt.Errorf("MCP version mismatch: client (%s) != server (%s)", t.protocolVersion, result.ProtocolVersion)
+		return &transport.ProtocolNegotiationError{FallbackVersion: result.ProtocolVersion}
 	}
 
 	// Capabilities Check
@@ -291,13 +292,42 @@ func (t *McpTransport) doRPC(ctx context.Context, url string, reqBody any, heade
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusOK {
-		// Continue to body parsing
-	} else if (resp.StatusCode == http.StatusAccepted || resp.StatusCode == http.StatusNoContent) && dest == nil {
+	checkRPCError := func(rpcErr *jsonRPCError) error {
+		if rpcErr == nil {
+			return nil
+		}
+		if rpcErr.Code == -32004 || rpcErr.Code == -32022 {
+			if data, ok := rpcErr.Data.(map[string]any); ok {
+				if supported, ok := data["supported"].([]any); ok && len(supported) > 0 {
+					if fallbackStr, ok := supported[0].(string); ok {
+						return &transport.ProtocolNegotiationError{FallbackVersion: fallbackStr}
+					}
+				}
+			}
+			return &transport.ProtocolNegotiationError{FallbackVersion: "2024-11-05"}
+		}
+		errMsgLower := strings.ToLower(rpcErr.Message)
+		if strings.Contains(errMsgLower, "invalid protocol version") || strings.Contains(errMsgLower, "unsupported protocol version") {
+			return &transport.ProtocolNegotiationError{FallbackVersion: "2024-11-05"}
+		}
+		return fmt.Errorf("MCP request failed with code %d: %s", rpcErr.Code, rpcErr.Message)
+	}
+
+	if (resp.StatusCode == http.StatusAccepted || resp.StatusCode == http.StatusNoContent) && dest == nil {
 		return resp.Header, nil // Valid notification success
-	} else {
-		// Any other code, OR a 202/204 when we expected a result, is a failure.
+	}
+	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+		var rpcResp jsonRPCResponse
+		if err := json.Unmarshal(body, &rpcResp); err == nil && rpcResp.Error != nil {
+			if err := checkRPCError(rpcResp.Error); err != nil {
+				return nil, err
+			}
+		}
+		bodyStrLower := strings.ToLower(string(body))
+		if strings.Contains(bodyStrLower, "invalid protocol version") || strings.Contains(bodyStrLower, "unsupported protocol version") {
+			return nil, &transport.ProtocolNegotiationError{FallbackVersion: "2024-11-05"}
+		}
 		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -316,7 +346,9 @@ func (t *McpTransport) doRPC(ctx context.Context, url string, reqBody any, heade
 
 	// Check RPC Error
 	if rpcResp.Error != nil {
-		return nil, fmt.Errorf("MCP request failed with code %d: %s", rpcResp.Error.Code, rpcResp.Error.Message)
+		if err := checkRPCError(rpcResp.Error); err != nil {
+			return nil, err
+		}
 	}
 
 	// Decode Result into specific struct

--- a/core/transport/mcp/v20250326/mcp_test.go
+++ b/core/transport/mcp/v20250326/mcp_test.go
@@ -23,8 +23,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport/mcp"
 	"testing"
+
+	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport"
+	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport/mcp"
 
 	"maps"
 
@@ -104,10 +106,8 @@ func newMockMCPServer() *mockMCPServer {
 
 		w.Header().Set("Content-Type", "application/json")
 
-		if headers != nil {
-			for k, v := range headers {
-				w.Header().Set(k, v)
-			}
+		for k, v := range headers {
+			w.Header().Set(k, v)
 		}
 
 		_ = json.NewEncoder(w).Encode(resp)
@@ -338,8 +338,9 @@ func TestProtocolVersionMismatch(t *testing.T) {
 
 	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
 	err := client.EnsureInitialized(context.Background(), nil)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "MCP version mismatch")
+	var negErr *transport.ProtocolNegotiationError
+	require.True(t, errors.As(err, &negErr))
+	assert.Equal(t, "2099-01-01", negErr.FallbackVersion)
 }
 
 func TestInitialization_MissingCapabilities(t *testing.T) {
@@ -375,7 +376,7 @@ func TestRequest_NetworkError(t *testing.T) {
 func TestRequest_ServerError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte("Internal Error"))
+		_, _ = w.Write([]byte("Internal Error"))
 	}))
 	defer server.Close()
 
@@ -388,7 +389,7 @@ func TestRequest_ServerError(t *testing.T) {
 func TestRequest_BadJSON(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{ broken json `))
+		_, _ = w.Write([]byte(`{ broken json `))
 	}))
 	defer server.Close()
 
@@ -448,7 +449,7 @@ func TestInit_NotificationFailure(t *testing.T) {
 		var req jsonRPCRequest
 		// Read body to clear buffer, though we just check fields
 		body, _ := io.ReadAll(r.Body)
-		json.Unmarshal(body, &req)
+		_ = json.Unmarshal(body, &req)
 
 		if req.Method == "initialize" {
 			// Success
@@ -458,16 +459,18 @@ func TestInit_NotificationFailure(t *testing.T) {
 				Result:  json.RawMessage(`{"protocolVersion":"2025-03-26","capabilities":{"tools":{}},"serverInfo":{"name":"mock","version":"1"},"Mcp-Session-Id":"s1"}`),
 			}
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(resp)
+			_ = json.NewEncoder(w).Encode(resp)
 			return
 		}
+
 		if req.Method == "notifications/initialized" {
 			// Fail
 			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte("Server Error"))
+			_, _ = w.Write([]byte("Server Error"))
 			return
 		}
 	}))
+
 	defer server.Close()
 
 	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
@@ -623,7 +626,7 @@ func TestEnsureInitialized_PassesHeaders(t *testing.T) {
 
 	capturedHeaders := make(map[string]string)
 
-	tr.BaseMcpTransport.HandshakeHook = func(ctx context.Context, headers map[string]string) error {
+	tr.HandshakeHook = func(ctx context.Context, headers map[string]string) error {
 		maps.Copy(capturedHeaders, headers)
 		return nil
 	}
@@ -653,7 +656,8 @@ func TestInitializeSession_PassesHeadersToWire(t *testing.T) {
 			return
 		}
 
-		if req.Method == "initialize" {
+		switch req.Method {
+		case "initialize":
 			resp := map[string]any{
 				"jsonrpc": "2.0",
 				"id":      "123",
@@ -665,12 +669,14 @@ func TestInitializeSession_PassesHeadersToWire(t *testing.T) {
 			}
 			// Set Session ID header required for this version
 			w.Header().Set("Mcp-Session-Id", "session-123")
-			json.NewEncoder(w).Encode(resp)
-		} else if req.Method == "notifications/initialized" {
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case "notifications/initialized":
 			// Verify notification success
 			w.WriteHeader(http.StatusNoContent)
-		} else {
-			w.WriteHeader(http.StatusNotFound)
+		default:
+			t.Errorf("Unexpected RPC method called: %q", req.Method)
+			w.WriteHeader(http.StatusBadRequest)
 		}
 	}))
 	defer ts.Close()

--- a/core/transport/mcp/v20250618/mcp.go
+++ b/core/transport/mcp/v20250618/mcp.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport"
@@ -182,7 +183,7 @@ func (t *McpTransport) initializeSession(ctx context.Context, headers map[string
 
 	// Protocol Version Check
 	if result.ProtocolVersion != t.protocolVersion {
-		return fmt.Errorf("MCP version mismatch: client (%s) != server (%s)", t.protocolVersion, result.ProtocolVersion)
+		return &transport.ProtocolNegotiationError{FallbackVersion: result.ProtocolVersion}
 	}
 
 	// Capabilities Check
@@ -249,13 +250,42 @@ func (t *McpTransport) doRPC(ctx context.Context, url string, reqBody any, heade
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusOK {
-		// Continue to body parsing
-	} else if (resp.StatusCode == http.StatusAccepted || resp.StatusCode == http.StatusNoContent) && dest == nil {
+	checkRPCError := func(rpcErr *jsonRPCError) error {
+		if rpcErr == nil {
+			return nil
+		}
+		if rpcErr.Code == -32004 || rpcErr.Code == -32022 {
+			if data, ok := rpcErr.Data.(map[string]any); ok {
+				if supported, ok := data["supported"].([]any); ok && len(supported) > 0 {
+					if fallbackStr, ok := supported[0].(string); ok {
+						return &transport.ProtocolNegotiationError{FallbackVersion: fallbackStr}
+					}
+				}
+			}
+			return &transport.ProtocolNegotiationError{FallbackVersion: "2025-03-26"}
+		}
+		errMsgLower := strings.ToLower(rpcErr.Message)
+		if strings.Contains(errMsgLower, "invalid protocol version") || strings.Contains(errMsgLower, "unsupported protocol version") {
+			return &transport.ProtocolNegotiationError{FallbackVersion: "2025-03-26"}
+		}
+		return fmt.Errorf("MCP request failed with code %d: %s", rpcErr.Code, rpcErr.Message)
+	}
+
+	if (resp.StatusCode == http.StatusAccepted || resp.StatusCode == http.StatusNoContent) && dest == nil {
 		return nil // Valid notification success
-	} else {
-		// Any other code, OR a 202/204 when we expected a result, is a failure.
+	}
+	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+		var rpcResp jsonRPCResponse
+		if err := json.Unmarshal(body, &rpcResp); err == nil && rpcResp.Error != nil {
+			if err := checkRPCError(rpcResp.Error); err != nil {
+				return err
+			}
+		}
+		bodyStrLower := strings.ToLower(string(body))
+		if strings.Contains(bodyStrLower, "invalid protocol version") || strings.Contains(bodyStrLower, "unsupported protocol version") {
+			return &transport.ProtocolNegotiationError{FallbackVersion: "2025-03-26"}
+		}
 		return fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -276,7 +306,9 @@ func (t *McpTransport) doRPC(ctx context.Context, url string, reqBody any, heade
 
 	// Check RPC Error
 	if rpcResp.Error != nil {
-		return fmt.Errorf("MCP request failed with code %d: %s", rpcResp.Error.Code, rpcResp.Error.Message)
+		if err := checkRPCError(rpcResp.Error); err != nil {
+			return err
+		}
 	}
 
 	// Decode Result into specific struct

--- a/core/transport/mcp/v20250618/mcp_test.go
+++ b/core/transport/mcp/v20250618/mcp_test.go
@@ -23,8 +23,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport/mcp"
 	"testing"
+
+	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport"
+	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport/mcp"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -305,8 +307,9 @@ func TestProtocolMismatch(t *testing.T) {
 	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
 
 	_, err := client.ListTools(context.Background(), "", nil)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "MCP version mismatch")
+	var negErr *transport.ProtocolNegotiationError
+	require.True(t, errors.As(err, &negErr))
+	assert.Equal(t, "2099-01-01", negErr.FallbackVersion)
 }
 
 func TestInitialize_MissingCapabilities(t *testing.T) {
@@ -401,7 +404,8 @@ func TestRequest_NetworkError(t *testing.T) {
 func TestRequest_ServerError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte("Internal Error"))
+		_, _ = w.Write([]byte("Internal Error"))
+
 	}))
 	defer server.Close()
 
@@ -414,8 +418,9 @@ func TestRequest_ServerError(t *testing.T) {
 func TestRequest_BadJSON(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{ broken json `))
+		_, _ = w.Write([]byte(`{ broken json `))
 	}))
+
 	defer server.Close()
 
 	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
@@ -589,7 +594,7 @@ func TestEnsureInitialized_PassesHeaders(t *testing.T) {
 	require.NoError(t, err)
 
 	capturedHeaders := make(map[string]string)
-	tr.BaseMcpTransport.HandshakeHook = func(ctx context.Context, headers map[string]string) error {
+	tr.HandshakeHook = func(ctx context.Context, headers map[string]string) error {
 		for k, v := range headers {
 			capturedHeaders[k] = v
 		}
@@ -621,7 +626,8 @@ func TestInitializeSession_PassesHeadersToWire(t *testing.T) {
 			return
 		}
 
-		if req.Method == "initialize" {
+		switch req.Method {
+		case "initialize":
 			resp := map[string]any{
 				"jsonrpc": "2.0",
 				"id":      "123",
@@ -631,12 +637,14 @@ func TestInitializeSession_PassesHeadersToWire(t *testing.T) {
 					"serverInfo":      map[string]any{"name": "test", "version": "1.0"},
 				},
 			}
-			json.NewEncoder(w).Encode(resp)
-		} else if req.Method == "notifications/initialized" {
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case "notifications/initialized":
 			// Verify notification success
 			w.WriteHeader(http.StatusNoContent)
-		} else {
-			w.WriteHeader(http.StatusNotFound)
+		default:
+			t.Errorf("Unexpected RPC method called: %q", req.Method)
+			w.WriteHeader(http.StatusBadRequest)
 		}
 	}))
 	defer ts.Close()

--- a/core/transport/mcp/v20251125/mcp.go
+++ b/core/transport/mcp/v20251125/mcp.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport"
@@ -182,7 +183,7 @@ func (t *McpTransport) initializeSession(ctx context.Context, headers map[string
 
 	// Protocol Version Check
 	if result.ProtocolVersion != t.protocolVersion {
-		return fmt.Errorf("MCP version mismatch: client (%s) != server (%s)", t.protocolVersion, result.ProtocolVersion)
+		return &transport.ProtocolNegotiationError{FallbackVersion: result.ProtocolVersion}
 	}
 
 	// Capabilities Check
@@ -248,13 +249,42 @@ func (t *McpTransport) doRPC(ctx context.Context, url string, reqBody any, heade
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusOK {
-		// Continue to body parsing
-	} else if (resp.StatusCode == http.StatusAccepted || resp.StatusCode == http.StatusNoContent) && dest == nil {
+	checkRPCError := func(rpcErr *jsonRPCError) error {
+		if rpcErr == nil {
+			return nil
+		}
+		if rpcErr.Code == -32004 || rpcErr.Code == -32022 {
+			if data, ok := rpcErr.Data.(map[string]any); ok {
+				if supported, ok := data["supported"].([]any); ok && len(supported) > 0 {
+					if fallbackStr, ok := supported[0].(string); ok {
+						return &transport.ProtocolNegotiationError{FallbackVersion: fallbackStr}
+					}
+				}
+			}
+			return &transport.ProtocolNegotiationError{FallbackVersion: "2025-06-18"}
+		}
+		errMsgLower := strings.ToLower(rpcErr.Message)
+		if strings.Contains(errMsgLower, "invalid protocol version") || strings.Contains(errMsgLower, "unsupported protocol version") {
+			return &transport.ProtocolNegotiationError{FallbackVersion: "2025-06-18"}
+		}
+		return fmt.Errorf("MCP request failed with code %d: %s", rpcErr.Code, rpcErr.Message)
+	}
+
+	if (resp.StatusCode == http.StatusAccepted || resp.StatusCode == http.StatusNoContent) && dest == nil {
 		return nil // Valid notification success
-	} else {
-		// Any other code, OR a 202/204 when we expected a result, is a failure.
+	}
+	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+		var rpcResp jsonRPCResponse
+		if err := json.Unmarshal(body, &rpcResp); err == nil && rpcResp.Error != nil {
+			if err := checkRPCError(rpcResp.Error); err != nil {
+				return err
+			}
+		}
+		bodyStrLower := strings.ToLower(string(body))
+		if strings.Contains(bodyStrLower, "invalid protocol version") || strings.Contains(bodyStrLower, "unsupported protocol version") {
+			return &transport.ProtocolNegotiationError{FallbackVersion: "2025-06-18"}
+		}
 		return fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -275,7 +305,9 @@ func (t *McpTransport) doRPC(ctx context.Context, url string, reqBody any, heade
 
 	// Check RPC Error
 	if rpcResp.Error != nil {
-		return fmt.Errorf("MCP request failed with code %d: %s", rpcResp.Error.Code, rpcResp.Error.Message)
+		if err := checkRPCError(rpcResp.Error); err != nil {
+			return err
+		}
 	}
 
 	// Decode Result into specific struct

--- a/core/transport/mcp/v20251125/mcp_test.go
+++ b/core/transport/mcp/v20251125/mcp_test.go
@@ -23,8 +23,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport/mcp"
 	"testing"
+
+	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport"
+	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport/mcp"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -305,8 +307,9 @@ func TestProtocolMismatch(t *testing.T) {
 	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
 
 	_, err := client.ListTools(context.Background(), "", nil)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "MCP version mismatch")
+	var negErr *transport.ProtocolNegotiationError
+	require.True(t, errors.As(err, &negErr))
+	assert.Equal(t, "2099-01-01", negErr.FallbackVersion)
 }
 
 func TestInitialize_MissingCapabilities(t *testing.T) {
@@ -401,7 +404,7 @@ func TestRequest_NetworkError(t *testing.T) {
 func TestRequest_ServerError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte("Internal Error"))
+		_, _ = w.Write([]byte("Internal Error"))
 	}))
 	defer server.Close()
 
@@ -414,8 +417,9 @@ func TestRequest_ServerError(t *testing.T) {
 func TestRequest_BadJSON(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{ broken json `))
+		_, _ = w.Write([]byte(`{ broken json `))
 	}))
+
 	defer server.Close()
 
 	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
@@ -589,7 +593,7 @@ func TestEnsureInitialized_PassesHeaders(t *testing.T) {
 	require.NoError(t, err)
 
 	capturedHeaders := make(map[string]string)
-	tr.BaseMcpTransport.HandshakeHook = func(ctx context.Context, headers map[string]string) error {
+	tr.HandshakeHook = func(ctx context.Context, headers map[string]string) error {
 		for k, v := range headers {
 			capturedHeaders[k] = v
 		}
@@ -621,7 +625,8 @@ func TestInitializeSession_PassesHeadersToWire(t *testing.T) {
 			return
 		}
 
-		if req.Method == "initialize" {
+		switch req.Method {
+		case "initialize":
 			resp := map[string]any{
 				"jsonrpc": "2.0",
 				"id":      "123",
@@ -631,12 +636,14 @@ func TestInitializeSession_PassesHeadersToWire(t *testing.T) {
 					"serverInfo":      map[string]any{"name": "test", "version": "1.0"},
 				},
 			}
-			json.NewEncoder(w).Encode(resp)
-		} else if req.Method == "notifications/initialized" {
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case "notifications/initialized":
 			// Verify notification success
 			w.WriteHeader(http.StatusNoContent)
-		} else {
-			w.WriteHeader(http.StatusNotFound)
+		default:
+			t.Errorf("Unexpected RPC method called: %q", req.Method)
+			w.WriteHeader(http.StatusBadRequest)
 		}
 	}))
 	defer ts.Close()
@@ -675,4 +682,44 @@ func TestNew_ClientVersion(t *testing.T) {
 			t.Errorf("expected clientVersion %q, got %q", mcp.SDKVersion, tr2.clientVersion)
 		}
 	})
+}
+
+func TestJSONRPCError_ProtocolNegotiation(t *testing.T) {
+	testCases := []struct {
+		name    string
+		code    int
+		message string
+	}{
+		{"Code -32022", -32022, "version mismatch"},
+		{"Code -32004", -32004, "version mismatch"},
+		{"Message invalid protocol version", -32000, "invalid protocol version"},
+		{"Message unsupported protocol version", -32000, "unsupported protocol version"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				resp := jsonRPCResponse{
+					JSONRPC: "2.0",
+					ID:      "1",
+					Error: &jsonRPCError{
+						Code:    tc.code,
+						Message: tc.message,
+					},
+				}
+				_ = json.NewEncoder(w).Encode(resp)
+			}))
+			defer server.Close()
+
+			tr, err := New(server.URL, server.Client(), "test-client", "1.0.0")
+			require.NoError(t, err)
+
+			_, err = tr.ListTools(context.Background(), "", nil)
+			require.Error(t, err)
+			var negErr *transport.ProtocolNegotiationError
+			require.True(t, errors.As(err, &negErr))
+			assert.Equal(t, "2025-06-18", negErr.FallbackVersion)
+		})
+	}
 }

--- a/core/transport/mcp/v20260618/mcp.go
+++ b/core/transport/mcp/v20260618/mcp.go
@@ -230,11 +230,18 @@ func (t *McpTransport) sendRequest(ctx context.Context, reqURL string, bodyPaylo
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		bodyStr := string(body)
 		var rpcResp jsonRPCResponse
 		if err := json.Unmarshal(body, &rpcResp); err == nil && rpcResp.Error != nil {
-			return fmt.Errorf("MCP request failed with code %d: %s", rpcResp.Error.Code, rpcResp.Error.Message)
+			if err := checkRPCError(rpcResp.Error); err != nil {
+				return err
+			}
 		}
-		return fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+		bodyStrLower := strings.ToLower(bodyStr)
+		if strings.Contains(bodyStrLower, "invalid protocol version") || strings.Contains(bodyStrLower, "unsupported protocol version") {
+			return &transport.ProtocolNegotiationError{FallbackVersion: mcp20251125.ProtocolVersion}
+		}
+		return fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, bodyStr)
 	}
 
 	var rpcResp jsonRPCResponse


### PR DESCRIPTION
## Overview
This PR introduces automatic protocol version fallback and negotiation. It enables `ToolboxClient` to gracefully negotiate protocol versions when communicating with both legacy stateful MCP servers (Pre-2026) and stateless MCP servers (2026 / SEP-2243 compliant).

## Motivation
With the transition between stateful (`initialize` handshake) and stateless MCP specification eras, protocol mismatches can result in HTTP 400 errors or JSON-RPC version rejection errors (`-32004`, `-32022`). Without automated client-side negotiation, users are forced into lock-step upgrades between client SDKs and server instances. 

This change allows `ToolboxClient` to intercept protocol mismatch responses and execute an automated fallback loop to down-negotiate to a mutually supported protocol version.

## Changes
- Introduced `ProtocolNegotiationError` containing `FallbackVersion` to explicitly represent version negotiation demands from the server.
- Implemented `executeWithFallback` on `ToolboxClient` to intercept `ProtocolNegotiationError` and re-instantiate transport instances across supported version specifications (`MCPv20260618`, `MCPv20251125`, `MCPv20250618`, `MCPv20250326`, `MCPv20241105`).
- Wrapped tool discovery workflows (`GetTool`, `ListTools`) in the fallback execution wrapper.
- Added `GetProtocol()` getter method to inspect active negotiated protocol.
- Added read-locking (`tc.mu.RLock()`) for thread-safe active transport access during fallback updates.
- Updated `ToolboxTool` to retain `clientName`, `clientVersion`, and `supportedProtocols` to preserve metadata across fallback transitions.
- Updated `v20241105`, `v20250326`, `v20250618`, `v20251125`, and `v20260618` transport packages to detect:
  - JSON-RPC error codes `-32004` and `-32022` (returning recommended fallback version from server error payload).
  - Error messages containing `"invalid protocol version"` or `"unsupported protocol version"`.
- Returns `ProtocolNegotiationError` instead of generic HTTP/RPC error strings.
