### PR TITLE
test(e2e): add dual-server support for integration tests

### DIFF
--- a/core/client.go
+++ b/core/client.go
@@ -455,12 +455,19 @@ func (tc *ToolboxClient) LoadToolset(name string, ctx context.Context, opts ...T
 
 // GetProtocol returns the active protocol version for the client.
 func (tc *ToolboxClient) GetProtocol() Protocol {
+	tc.mu.RLock()
+	defer tc.mu.RUnlock()
 	return tc.protocol
 }
 
 func (tc *ToolboxClient) executeWithFallback(fn func(tr transport.Transport) (any, error)) (any, error) {
 	for {
-		result, err := fn(tc.transport)
+		tc.mu.RLock()
+		tr := tc.transport
+		currentProtocol := tc.protocol
+		tc.mu.RUnlock()
+
+		result, err := fn(tr)
 		if err == nil {
 			return result, nil
 		}
@@ -488,22 +495,26 @@ func (tc *ToolboxClient) executeWithFallback(fn func(tr transport.Transport) (an
 			}
 
 			var fallbackProtocol Protocol
-			if len(tc.supportedProtocols) > 0 {
+			tc.mu.RLock()
+			supportedProtos := tc.supportedProtocols
+			tc.mu.RUnlock()
+
+			if len(supportedProtos) > 0 {
 				var mutuallySupported []Protocol
-				for _, v := range tc.supportedProtocols {
+				for _, v := range supportedProtos {
 					if slices.Contains(serverSupported, v) {
 						mutuallySupported = append(mutuallySupported, v)
 					}
 				}
 				if len(mutuallySupported) == 0 {
-					return nil, fmt.Errorf("no mutually supported protocol version. Client supports: %v, Server supports: %s", tc.supportedProtocols, fallbackVersion)
+					return nil, fmt.Errorf("no mutually supported protocol version. Client supports: %v, Server supports: %s", supportedProtos, fallbackVersion)
 				}
 				fallbackProtocol = mutuallySupported[0]
 			} else {
 				fallbackProtocol = fallbackVersion
 			}
 
-			if fallbackProtocol == tc.protocol {
+			if fallbackProtocol == currentProtocol {
 				return nil, err
 			}
 
@@ -528,8 +539,10 @@ func (tc *ToolboxClient) executeWithFallback(fn func(tr transport.Transport) (an
 				return nil, fmt.Errorf("failed to create transport for fallback version %s: %w", fallbackProtocol, createErr)
 			}
 
+			tc.mu.Lock()
 			tc.protocol = fallbackProtocol
 			tc.transport = fallbackTransport
+			tc.mu.Unlock()
 		} else {
 			return nil, err
 		}

--- a/core/client_test.go
+++ b/core/client_test.go
@@ -20,13 +20,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-
+	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1214,6 +1215,81 @@ func TestExecuteWithFallback_EdgeCases(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "modern_tool", tool.Name())
 		assert.Equal(t, MCPv20241105, client.GetProtocol())
+	})
+
+	t.Run("Concurrent Goroutines Fallback & Thread Safety Test", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("MCP-Protocol-Version") == "DRAFT-2026-v1" {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"1","error":{"code":-32022,"message":"Unsupported","data":{"supported":["2025-11-25"]}}}`))
+				return
+			}
+			body, _ := io.ReadAll(r.Body)
+			var req mcpRPCRequest
+			_ = json.Unmarshal(body, &req)
+
+			var result any
+			switch req.Method {
+			case "initialize":
+				result = map[string]any{
+					"protocolVersion": "2025-11-25",
+					"capabilities":    map[string]any{"tools": map[string]any{}},
+					"serverInfo":      map[string]any{"name": "mock-server", "version": "1.0.0"},
+				}
+			case "notifications/initialized":
+				w.WriteHeader(http.StatusOK)
+				return
+			case "tools/list":
+				result = map[string]any{
+					"tools": []mcpTool{{Name: "concurrent_tool", Description: "tool"}},
+				}
+			}
+			resBytes, _ := json.Marshal(result)
+			resp := mcpRPCResponse{
+				JSONRPC: "2.0",
+				ID:      req.ID,
+				Result:  resBytes,
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+		}))
+		defer ts.Close()
+
+		client, err := NewToolboxClient(ts.URL,
+			WithHTTPClient(ts.Client()),
+			WithSupportedProtocols([]Protocol{MCPDraft, MCPv20251125}),
+		)
+		require.NoError(t, err)
+
+		const numGoroutines = 20
+		var wg sync.WaitGroup
+		errs := make(chan error, numGoroutines)
+
+		for i := 0; i < numGoroutines; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_ = client.GetProtocol()
+				tool, err := client.LoadTool("concurrent_tool", context.Background())
+				if err != nil {
+					errs <- err
+					return
+				}
+				if tool.Name() != "concurrent_tool" {
+					errs <- fmt.Errorf("unexpected tool name %s", tool.Name())
+					return
+				}
+				_ = client.GetProtocol()
+			}()
+		}
+
+		wg.Wait()
+		close(errs)
+
+		for err := range errs {
+			t.Errorf("Concurrent execution error: %v", err)
+		}
+		assert.Equal(t, MCPv20251125, client.GetProtocol())
 	})
 }
 

--- a/core/e2e_mcp_test.go
+++ b/core/e2e_mcp_test.go
@@ -32,6 +32,13 @@ import (
 	"golang.org/x/oauth2"
 )
 
+const (
+	DefaultPortStable      = "5000"
+	DefaultPortDraft       = "5001"
+	DefaultServerURLStable = "http://localhost:5000"
+	DefaultServerURLDraft  = "http://localhost:5001"
+)
+
 // Global variables to hold session-scoped fixtures
 var (
 	projectID       string = getEnvVar("GOOGLE_CLOUD_PROJECT")
@@ -40,6 +47,17 @@ var (
 	authToken2      string
 	manifestVersion string = getEnvVar("TOOLBOX_MANIFEST_VERSION")
 )
+
+
+func getTestServerURLs() []string {
+	if os.Getenv("TOOLBOX_SERVER_URL") != "" {
+		return []string{os.Getenv("TOOLBOX_SERVER_URL")}
+	}
+	return []string{
+		getEnvVarWithDefault("TOOLBOX_SERVER_URL_STABLE", DefaultServerURLStable),
+		getEnvVarWithDefault("TOOLBOX_SERVER_URL_DRAFT", DefaultServerURLDraft),
+	}
+}
 
 func TestMain(m *testing.M) {
 	ctx := context.Background()
@@ -65,19 +83,25 @@ func TestMain(m *testing.M) {
 	toolsFilePath := toolsFile.Name()
 	defer os.Remove(toolsFilePath) // Ensure cleanup
 
-	// Download and start the toolbox server
-	cmd := setupAndStartToolboxServer(ctx, toolboxVersion, toolsFilePath)
+	// Download and start both stable and draft toolbox servers
+	cmdStable := setupAndStartToolboxServerWithFlags(ctx, toolboxVersion, toolsFilePath, DefaultPortStable)
+	cmdDraft := setupAndStartToolboxServerWithFlags(ctx, toolboxVersion, toolsFilePath, DefaultPortDraft, "--enable-draft-specs")
 
 	// Run Tests
 	log.Println("Setup complete. Running tests...")
 	exitCode := m.Run()
 
 	// Teardown Phase
-	log.Println("Tearing down toolbox server...")
-	if err := cmd.Process.Kill(); err != nil {
-		log.Printf("Failed to kill toolbox server process: %v", err)
+	log.Println("Tearing down toolbox servers...")
+	if err := cmdStable.Process.Kill(); err != nil {
+		log.Printf("Failed to kill stable toolbox server process: %v", err)
 	}
-	_ = cmd.Wait() // Clean up the process resources
+	_ = cmdStable.Wait()
+
+	if err := cmdDraft.Process.Kill(); err != nil {
+		log.Printf("Failed to kill draft toolbox server process: %v", err)
+	}
+	_ = cmdDraft.Wait()
 
 	os.Exit(exitCode)
 }
@@ -135,7 +159,11 @@ func (c *CapturingTransport) CapturedHeaders() http.Header {
 }
 
 // helper factory to create a client with a specific protocol
-func getNewMCPToolboxClient(t *testing.T, tc protocolTestCase) *core.ToolboxClient {
+func getNewMCPToolboxClient(t *testing.T, tc protocolTestCase, serverURL ...string) *core.ToolboxClient {
+	url := DefaultServerURLStable
+	if len(serverURL) > 0 && serverURL[0] != "" {
+		url = serverURL[0]
+	}
 	opts := []core.ClientOption{}
 
 	// Only add WithProtocol if it's NOT the default test case
@@ -143,46 +171,48 @@ func getNewMCPToolboxClient(t *testing.T, tc protocolTestCase) *core.ToolboxClie
 		opts = append(opts, core.WithProtocol(tc.protocol))
 	}
 
-	client, err := core.NewToolboxClient("http://localhost:5000", opts...)
+	client, err := core.NewToolboxClient(url, opts...)
 	require.NoError(t, err, "Failed to create MCP ToolboxClient for %s", tc.name)
 	return client
 }
 
 func TestMCP_Basic(t *testing.T) {
-	for _, proto := range protocolsToTest {
-		t.Run(proto.name, func(t *testing.T) {
-			// Helper to create a new client for each sub-test
-			newClient := func(t *testing.T) *core.ToolboxClient {
-				return getNewMCPToolboxClient(t, proto)
-			}
+	for _, serverURL := range getTestServerURLs() {
+		t.Run("server_"+serverURL, func(t *testing.T) {
+			for _, proto := range protocolsToTest {
+				t.Run(proto.name, func(t *testing.T) {
+					// Helper to create a new client for each sub-test
+					newClient := func(t *testing.T) *core.ToolboxClient {
+						return getNewMCPToolboxClient(t, proto, serverURL)
+					}
 
-			// Helper to load the get-n-rows tool
-			getNRowsTool := func(t *testing.T, client *core.ToolboxClient) *core.ToolboxTool {
-				tool, err := client.LoadTool("get-n-rows", context.Background())
-				require.NoError(t, err, "Failed to load tool 'get-n-rows'")
-				require.Equal(t, "get-n-rows", tool.Name())
-				return tool
-			}
+					// Helper to load the get-n-rows tool
+					getNRowsTool := func(t *testing.T, client *core.ToolboxClient) *core.ToolboxTool {
+						tool, err := client.LoadTool("get-n-rows", context.Background())
+						require.NoError(t, err, "Failed to load tool 'get-n-rows'")
+						require.Equal(t, "get-n-rows", tool.Name())
+						return tool
+					}
 
-			t.Run("test_mcp_client_headers", func(t *testing.T) {
-				// Setup the Transport to capture headers
-				capturer := &CapturingTransport{}
-				httpClient := &http.Client{
-					Transport: capturer,
-					Timeout:   30 * time.Second,
-				}
+					t.Run("test_mcp_client_headers", func(t *testing.T) {
+						// Setup the Transport to capture headers
+						capturer := &CapturingTransport{}
+						httpClient := &http.Client{
+							Transport: capturer,
+							Timeout:   30 * time.Second,
+						}
 
-				// Build options manually to inject HTTP client
-				opts := []core.ClientOption{
-					core.WithHTTPClient(httpClient),
-				}
-				// Logic to handle Default vs Explicit protocol
-				if !proto.isDefault {
-					opts = append(opts, core.WithProtocol(proto.protocol))
-				}
+						// Build options manually to inject HTTP client
+						opts := []core.ClientOption{
+							core.WithHTTPClient(httpClient),
+						}
+						// Logic to handle Default vs Explicit protocol
+						if !proto.isDefault {
+							opts = append(opts, core.WithProtocol(proto.protocol))
+						}
 
-				// Inject Transport into Client
-				client, err := core.NewToolboxClient("http://localhost:5000", opts...)
+						// Inject Transport into Client
+						client, err := core.NewToolboxClient(serverURL, opts...)
 				require.NoError(t, err)
 
 				// Trigger a request
@@ -309,6 +339,8 @@ func TestMCP_Basic(t *testing.T) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "parameter 'num_rows' expects a string, but got int")
 			})
+				})
+			}
 		})
 	}
 }
@@ -336,7 +368,7 @@ func TestMCP_LoadErrors(t *testing.T) {
 	}
 
 	t.Run("test_new_client_with_nil_option", func(t *testing.T) {
-		_, err := core.NewToolboxClient("http://localhost:5000", nil)
+		_, err := core.NewToolboxClient(DefaultServerURLStable, nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "received a nil ClientOption")
 	})
@@ -853,6 +885,59 @@ func TestMCP_ContextHandling(t *testing.T) {
 				require.Error(t, err)
 				assert.ErrorIs(t, err, context.DeadlineExceeded)
 			})
+		})
+	}
+}
+
+func TestMcpProtocols_E2E(t *testing.T) {
+	tests := []struct {
+		name       string
+		clientOpts []core.ClientOption
+		validate   func(t *testing.T, client *core.ToolboxClient, serverURL string)
+	}{
+		{
+			name:       "DraftFallback",
+			clientOpts: []core.ClientOption{core.WithProtocol(core.MCPDraft)},
+		},
+		{
+			name:       "LatestProtocol",
+			clientOpts: []core.ClientOption{core.WithProtocol(core.MCPLatest)},
+		},
+		{
+			name: "CustomProtocolsList",
+			clientOpts: []core.ClientOption{core.WithSupportedProtocols([]core.Protocol{
+				core.MCPv20241105,
+				core.MCPv20250326,
+				core.MCPLatest,
+				core.MCPDraft,
+			})},
+			validate: func(t *testing.T, client *core.ToolboxClient, serverURL string) {
+				if serverURL == DefaultServerURLStable {
+					assert.Equal(t, core.MCPLatest, client.GetProtocol())
+				} else {
+					assert.Equal(t, core.MCPDraft, client.GetProtocol())
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, serverURL := range getTestServerURLs() {
+				t.Run("server_"+serverURL, func(t *testing.T) {
+					client, err := core.NewToolboxClient(serverURL, tc.clientOpts...)
+					require.NoError(t, err)
+					tool, err := client.LoadTool("get-n-rows", context.Background())
+					require.NoError(t, err)
+					res, err := tool.Invoke(context.Background(), map[string]any{"num_rows": "1"})
+					require.NoError(t, err)
+					assert.Contains(t, res, "row1")
+
+					if tc.validate != nil {
+						tc.validate(t, client, serverURL)
+					}
+				})
+			}
 		})
 	}
 }

--- a/core/e2e_setup_test.go
+++ b/core/e2e_setup_test.go
@@ -43,6 +43,14 @@ func getEnvVar(key string) string {
 	return value
 }
 
+func getEnvVarWithDefault(key, defaultValue string) string {
+	val := os.Getenv(key)
+	if val == "" {
+		return defaultValue
+	}
+	return val
+}
+
 func accessSecretVersion(ctx context.Context, projectID, secretID string, version string) string {
 	client, err := secretmanager.NewClient(ctx)
 	if err != nil {
@@ -104,15 +112,17 @@ func getAuthToken(ctx context.Context, clientID string) string {
 	return token.AccessToken
 }
 
-func setupAndStartToolboxServer(ctx context.Context, version, toolsFilePath string) *exec.Cmd {
-	log.Println("Downloading toolbox binary from GCS bucket...")
-	binaryURL := getToolboxBinaryURL(version)
+func setupAndStartToolboxServerWithFlags(ctx context.Context, version, toolsFilePath, port string, extraFlags ...string) *exec.Cmd {
 	binaryPath := "toolbox"
-	downloadBlob(ctx, "mcp-toolbox-for-databases", binaryURL, binaryPath)
-	log.Println("Toolbox binary downloaded successfully.")
+	if _, err := os.Stat(binaryPath); os.IsNotExist(err) {
+		log.Println("Downloading toolbox binary from GCS bucket...")
+		binaryURL := getToolboxBinaryURL(version)
+		downloadBlob(ctx, "mcp-toolbox-for-databases", binaryURL, binaryPath)
+		log.Println("Toolbox binary downloaded successfully.")
 
-	if err := os.Chmod(binaryPath, 0755); err != nil {
-		log.Fatalf("Failed to make toolbox binary executable: %v", err)
+		if err := os.Chmod(binaryPath, 0755); err != nil {
+			log.Fatalf("Failed to make toolbox binary executable: %v", err)
+		}
 	}
 
 	absBinaryPath, err := filepath.Abs(binaryPath)
@@ -120,24 +130,24 @@ func setupAndStartToolboxServer(ctx context.Context, version, toolsFilePath stri
 		log.Fatalf("Failed to get absolute path for toolbox binary: %v", err)
 	}
 
-	log.Println("Starting toolbox server process...")
-	cmd := exec.Command(absBinaryPath, "--tools-file", toolsFilePath)
+	args := []string{"--tools-file", toolsFilePath, "--port", port}
+	args = append(args, extraFlags...)
+
+	log.Printf("Starting toolbox server process on port %s with args %v...", port, args)
+	cmd := exec.Command(absBinaryPath, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
 	if err := cmd.Start(); err != nil {
-		log.Fatalf("Failed to start toolbox server: %v", err)
+		log.Fatalf("Failed to start toolbox server on port %s: %v", port, err)
 	}
 
-	log.Println("Waiting for server to initialize...")
-	// A more robust way to check for server readiness is to poll the health endpoint.
-	// For now, Sleep is a simple way to wait.
 	time.Sleep(5 * time.Second)
 
 	if cmd.ProcessState != nil && cmd.ProcessState.Exited() {
-		log.Fatalf("Toolbox server failed to start and exited with code: %d", cmd.ProcessState.ExitCode())
+		log.Fatalf("Toolbox server failed to start on port %s and exited with code: %d", port, cmd.ProcessState.ExitCode())
 	}
 
-	log.Println("Toolbox server started successfully.")
+	log.Printf("Toolbox server started successfully on port %s.", port)
 	return cmd
 }

--- a/tbadk/e2e_setup_test.go
+++ b/tbadk/e2e_setup_test.go
@@ -43,6 +43,14 @@ func getEnvVar(key string) string {
 	return value
 }
 
+func getEnvVarWithDefault(key, defaultValue string) string {
+	val := os.Getenv(key)
+	if val == "" {
+		return defaultValue
+	}
+	return val
+}
+
 func accessSecretVersion(ctx context.Context, projectID, secretID string, version string) string {
 	client, err := secretmanager.NewClient(ctx)
 	if err != nil {
@@ -104,15 +112,17 @@ func getAuthToken(ctx context.Context, clientID string) string {
 	return token.AccessToken
 }
 
-func setupAndStartToolboxServer(ctx context.Context, version, toolsFilePath string) *exec.Cmd {
-	log.Println("Downloading toolbox binary from GCS bucket...")
-	binaryURL := getToolboxBinaryURL(version)
+func setupAndStartToolboxServerWithFlags(ctx context.Context, version, toolsFilePath, port string, extraFlags ...string) *exec.Cmd {
 	binaryPath := "toolbox"
-	downloadBlob(ctx, "mcp-toolbox-for-databases", binaryURL, binaryPath)
-	log.Println("Toolbox binary downloaded successfully.")
+	if _, err := os.Stat(binaryPath); os.IsNotExist(err) {
+		log.Println("Downloading toolbox binary from GCS bucket...")
+		binaryURL := getToolboxBinaryURL(version)
+		downloadBlob(ctx, "mcp-toolbox-for-databases", binaryURL, binaryPath)
+		log.Println("Toolbox binary downloaded successfully.")
 
-	if err := os.Chmod(binaryPath, 0755); err != nil {
-		log.Fatalf("Failed to make toolbox binary executable: %v", err)
+		if err := os.Chmod(binaryPath, 0755); err != nil {
+			log.Fatalf("Failed to make toolbox binary executable: %v", err)
+		}
 	}
 
 	absBinaryPath, err := filepath.Abs(binaryPath)
@@ -120,24 +130,24 @@ func setupAndStartToolboxServer(ctx context.Context, version, toolsFilePath stri
 		log.Fatalf("Failed to get absolute path for toolbox binary: %v", err)
 	}
 
-	log.Println("Starting toolbox server process...")
-	cmd := exec.Command(absBinaryPath, "--tools-file", toolsFilePath)
+	args := []string{"--tools-file", toolsFilePath, "--port", port}
+	args = append(args, extraFlags...)
+
+	log.Printf("Starting toolbox server process on port %s with args %v...", port, args)
+	cmd := exec.Command(absBinaryPath, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
 	if err := cmd.Start(); err != nil {
-		log.Fatalf("Failed to start toolbox server: %v", err)
+		log.Fatalf("Failed to start toolbox server on port %s: %v", port, err)
 	}
 
-	log.Println("Waiting for server to initialize...")
-	// A more robust way to check for server readiness is to poll the health endpoint.
-	// For now, Sleep is a simple way to wait.
 	time.Sleep(5 * time.Second)
 
 	if cmd.ProcessState != nil && cmd.ProcessState.Exited() {
-		log.Fatalf("Toolbox server failed to start and exited with code: %d", cmd.ProcessState.ExitCode())
+		log.Fatalf("Toolbox server failed to start on port %s and exited with code: %d", port, cmd.ProcessState.ExitCode())
 	}
 
-	log.Println("Toolbox server started successfully.")
+	log.Printf("Toolbox server started successfully on port %s.", port)
 	return cmd
 }

--- a/tbadk/e2e_test.go
+++ b/tbadk/e2e_test.go
@@ -139,6 +139,23 @@ func (c *BodyCapturingTransport) RoundTrip(req *http.Request) (*http.Response, e
 	return base.RoundTrip(req)
 }
 
+const (
+	DefaultPortStable      = "5000"
+	DefaultPortDraft       = "5001"
+	DefaultServerURLStable = "http://localhost:5000"
+	DefaultServerURLDraft  = "http://localhost:5001"
+)
+
+func getTestServerURLs() []string {
+	if os.Getenv("TOOLBOX_SERVER_URL") != "" {
+		return []string{os.Getenv("TOOLBOX_SERVER_URL")}
+	}
+	return []string{
+		getEnvVarWithDefault("TOOLBOX_SERVER_URL_STABLE", DefaultServerURLStable),
+		getEnvVarWithDefault("TOOLBOX_SERVER_URL_DRAFT", DefaultServerURLDraft),
+	}
+}
+
 func TestMain(m *testing.M) {
 	ctx := context.Background()
 	log.Println("Starting E2E test setup...")
@@ -163,780 +180,814 @@ func TestMain(m *testing.M) {
 	toolsFilePath := toolsFile.Name()
 	defer os.Remove(toolsFilePath) // Ensure cleanup
 
-	// Download and start the toolbox server
-	cmd := setupAndStartToolboxServer(ctx, toolboxVersion, toolsFilePath)
+	// Download and start both stable and draft toolbox servers
+	cmdStable := setupAndStartToolboxServerWithFlags(ctx, toolboxVersion, toolsFilePath, DefaultPortStable)
+	cmdDraft := setupAndStartToolboxServerWithFlags(ctx, toolboxVersion, toolsFilePath, DefaultPortDraft, "--enable-draft-specs")
 
 	// Run Tests ---
 	log.Println("Setup complete. Running tests...")
 	exitCode := m.Run()
 
 	// Teardown Phase ---
-	log.Println("Tearing down toolbox server...")
-	if err := cmd.Process.Kill(); err != nil {
-		log.Printf("Failed to kill toolbox server process: %v", err)
+	log.Println("Tearing down toolbox servers...")
+	if err := cmdStable.Process.Kill(); err != nil {
+		log.Printf("Failed to kill stable toolbox server process: %v", err)
 	}
-	_ = cmd.Wait() // Clean up the process resources
+	_ = cmdStable.Wait()
+
+	if err := cmdDraft.Process.Kill(); err != nil {
+		log.Printf("Failed to kill draft toolbox server process: %v", err)
+	}
+	_ = cmdDraft.Wait()
 
 	os.Exit(exitCode)
 }
 
 func TestE2E_Basic(t *testing.T) {
-	for _, proto := range protocolsToTest {
-		t.Run(proto.name, func(t *testing.T) {
-			// Helper to create a new client for each sub-test, like a function-scoped fixture
-			newClient := func(t *testing.T) tbadk.ToolboxClient {
-				opts := []core.ClientOption{}
-				if !proto.isDefault {
-					opts = append(opts, core.WithProtocol(proto.protocol))
-				}
-				client, err := tbadk.NewToolboxClient("http://localhost:5000", opts...)
-				require.NoError(t, err, "Failed to create ToolboxClient")
-				return client
-			}
-			agentCtx := &mockAgentContext{
-				ctx: context.Background(),
-			}
+	for _, serverURL := range getTestServerURLs() {
+		t.Run("server_"+serverURL, func(t *testing.T) {
+			for _, proto := range protocolsToTest {
+				t.Run(proto.name, func(t *testing.T) {
+					// Helper to create a new client for each sub-test, like a function-scoped fixture
+					newClient := func(t *testing.T) tbadk.ToolboxClient {
+						opts := []core.ClientOption{}
+						if !proto.isDefault {
+							opts = append(opts, core.WithProtocol(proto.protocol))
+						}
+						client, err := tbadk.NewToolboxClient(serverURL, opts...)
+						require.NoError(t, err, "Failed to create ToolboxClient")
+						return client
+					}
+					agentCtx := &mockAgentContext{
+						ctx: context.Background(),
+					}
 
-			testToolCtx := &mockToolContext{
-				mockAgentContext: agentCtx,
-				MockFuncCallID:   "specific-test-id",
-			}
+					testToolCtx := &mockToolContext{
+						mockAgentContext: agentCtx,
+						MockFuncCallID:   "specific-test-id",
+					}
 
-			// Helper to load the get-n-rows tool, like the get_n_rows_tool fixture
-			getNRowsTool := func(t *testing.T, client tbadk.ToolboxClient) tbadk.ToolboxTool {
-				tool, err := client.LoadTool("get-n-rows", context.Background())
-				require.NoError(t, err, "Failed to load tool 'get-n-rows'")
-				require.Equal(t, "get-n-rows", tool.Name())
-				return tool
-			}
+					// Helper to load the get-n-rows tool, like the get_n_rows_tool fixture
+					getNRowsTool := func(t *testing.T, client tbadk.ToolboxClient) tbadk.ToolboxTool {
+						tool, err := client.LoadTool("get-n-rows", context.Background())
+						require.NoError(t, err, "Failed to load tool 'get-n-rows'")
+						require.Equal(t, "get-n-rows", tool.Name())
+						return tool
+					}
 
-			t.Run("test_client_version_is_picked_up", func(t *testing.T) {
-				capturer := &BodyCapturingTransport{}
-				httpClient := &http.Client{Transport: capturer}
+					t.Run("test_client_version_is_picked_up", func(t *testing.T) {
+						capturer := &BodyCapturingTransport{}
+						httpClient := &http.Client{Transport: capturer}
 
-				opts := []core.ClientOption{
-					core.WithHTTPClient(httpClient),
-				}
-				if !proto.isDefault {
-					opts = append(opts, core.WithProtocol(proto.protocol))
-				}
+						opts := []core.ClientOption{
+							core.WithHTTPClient(httpClient),
+						}
+						if !proto.isDefault {
+							opts = append(opts, core.WithProtocol(proto.protocol))
+						}
 
-				client, err := tbadk.NewToolboxClient("http://localhost:5000", opts...)
-				require.NoError(t, err)
-
-				// Trigger the handshake by loading a tool
-				_, err = client.LoadTool("get-n-rows", context.Background())
-				require.NoError(t, err)
-
-				capturer.mu.Lock()
-				defer capturer.mu.Unlock()
-
-				require.NotEmpty(t, capturer.lastBody, "Expected to capture an initialize request")
-
-				// Parse the JSON-RPC request to verify clientInfo
-				var req struct {
-					Params struct {
-						ClientInfo struct {
-							Name    string `json:"name"`
-							Version string `json:"version"`
-						} `json:"clientInfo"`
-					} `json:"params"`
-				}
-				err = json.Unmarshal(capturer.lastBody, &req)
-				require.NoError(t, err)
-
-				assert.Equal(t, "toolbox-adk-go", req.Params.ClientInfo.Name)
-				assert.Equal(t, tbadk.Version, req.Params.ClientInfo.Version, "Expected client version to match tbadk.Version")
-			})
-
-			t.Run("test_load_toolset_specific", func(t *testing.T) {
-				testCases := []struct {
-					name           string
-					toolsetName    string
-					expectedLength int
-					expectedTools  []string
-				}{
-					{"my-toolset", "my-toolset", 1, []string{"get-row-by-id"}},
-					{"my-toolset-2", "my-toolset-2", 2, []string{"get-n-rows", "get-row-by-id"}},
-				}
-
-				for _, tc := range testCases {
-					t.Run(tc.name, func(t *testing.T) {
-						client := newClient(t)
-						toolset, err := client.LoadToolset(tc.toolsetName, context.Background())
-
+						client, err := tbadk.NewToolboxClient(serverURL, opts...)
 						require.NoError(t, err)
 
-						assert.Len(t, toolset, tc.expectedLength)
+						// Trigger the handshake by loading a tool
+						_, err = client.LoadTool("get-n-rows", context.Background())
+						require.NoError(t, err)
 
+						capturer.mu.Lock()
+						defer capturer.mu.Unlock()
+
+						require.NotEmpty(t, capturer.lastBody, "Expected to capture an initialize request")
+
+						// Parse the JSON-RPC request to verify clientInfo
+						var req struct {
+							Params struct {
+								ClientInfo struct {
+									Name    string `json:"name"`
+									Version string `json:"version"`
+								} `json:"clientInfo"`
+							} `json:"params"`
+						}
+						err = json.Unmarshal(capturer.lastBody, &req)
+						require.NoError(t, err)
+
+						assert.Equal(t, "toolbox-adk-go", req.Params.ClientInfo.Name)
+						assert.Equal(t, tbadk.Version, req.Params.ClientInfo.Version, "Expected client version to match tbadk.Version")
+					})
+
+					t.Run("test_load_toolset_specific", func(t *testing.T) {
+						testCases := []struct {
+							name           string
+							toolsetName    string
+							expectedLength int
+							expectedTools  []string
+						}{
+							{"my-toolset", "my-toolset", 1, []string{"get-row-by-id"}},
+							{"my-toolset-2", "my-toolset-2", 2, []string{"get-n-rows", "get-row-by-id"}},
+						}
+
+						for _, tc := range testCases {
+							t.Run(tc.name, func(t *testing.T) {
+								client := newClient(t)
+								toolset, err := client.LoadToolset(tc.toolsetName, context.Background())
+
+								require.NoError(t, err)
+
+								assert.Len(t, toolset, tc.expectedLength)
+
+								toolNames := make(map[string]struct{})
+								for _, tool := range toolset {
+									toolNames[tool.Name()] = struct{}{}
+								}
+								expectedToolsSet := make(map[string]struct{})
+								for _, name := range tc.expectedTools {
+									expectedToolsSet[name] = struct{}{}
+								}
+								assert.Equal(t, expectedToolsSet, toolNames)
+							})
+						}
+					})
+
+					t.Run("test_load_toolset_default", func(t *testing.T) {
+						client := newClient(t)
+						toolset, err := client.LoadToolset("", context.Background())
+						require.NoError(t, err)
+
+						assert.Len(t, toolset, 7)
 						toolNames := make(map[string]struct{})
+
 						for _, tool := range toolset {
 							toolNames[tool.Name()] = struct{}{}
 						}
-						expectedToolsSet := make(map[string]struct{})
-						for _, name := range tc.expectedTools {
-							expectedToolsSet[name] = struct{}{}
+						expectedTools := map[string]struct{}{
+							"get-row-by-content-auth": {},
+							"get-row-by-email-auth":   {},
+							"get-row-by-id-auth":      {},
+							"get-row-by-id":           {},
+							"get-n-rows":              {},
+							"search-rows":             {},
+							"process-data":            {},
 						}
-						assert.Equal(t, expectedToolsSet, toolNames)
+						assert.Equal(t, expectedTools, toolNames)
 					})
-				}
-			})
 
-			t.Run("test_load_toolset_default", func(t *testing.T) {
-				client := newClient(t)
-				toolset, err := client.LoadToolset("", context.Background())
-				require.NoError(t, err)
+					t.Run("test_run_tool", func(t *testing.T) {
+						client := newClient(t)
+						tool := getNRowsTool(t, client)
 
-				assert.Len(t, toolset, 7)
-				toolNames := make(map[string]struct{})
+						response, err := tool.Run(testToolCtx, map[string]any{"num_rows": "2"})
+						require.NoError(t, err)
 
-				for _, tool := range toolset {
-					toolNames[tool.Name()] = struct{}{}
-				}
-				expectedTools := map[string]struct{}{
-					"get-row-by-content-auth": {},
-					"get-row-by-email-auth":   {},
-					"get-row-by-id-auth":      {},
-					"get-row-by-id":           {},
-					"get-n-rows":              {},
-					"search-rows":             {},
-					"process-data":            {},
-				}
-				assert.Equal(t, expectedTools, toolNames)
-			})
+						respStr, ok := response["output"].(string)
+						require.True(t, ok, "Response should be a string")
+						assert.Contains(t, respStr, "row1")
+						assert.Contains(t, respStr, "row2")
+						assert.NotContains(t, respStr, "row3")
+					})
 
-			t.Run("test_run_tool", func(t *testing.T) {
-				client := newClient(t)
-				tool := getNRowsTool(t, client)
+					t.Run("test_run_tool_missing_params", func(t *testing.T) {
+						client := newClient(t)
+						tool := getNRowsTool(t, client)
 
-				response, err := tool.Run(testToolCtx, map[string]any{"num_rows": "2"})
-				require.NoError(t, err)
+						_, err := tool.Run(testToolCtx, map[string]any{})
+						require.Error(t, err)
+						assert.Contains(t, err.Error(), "missing required parameter 'num_rows'")
+					})
 
-				respStr, ok := response["output"].(string)
-				require.True(t, ok, "Response should be a string")
-				assert.Contains(t, respStr, "row1")
-				assert.Contains(t, respStr, "row2")
-				assert.NotContains(t, respStr, "row3")
-			})
+					t.Run("test_run_tool_wrong_param_type", func(t *testing.T) {
+						client := newClient(t)
+						tool := getNRowsTool(t, client)
 
-			t.Run("test_run_tool_missing_params", func(t *testing.T) {
-				client := newClient(t)
-				tool := getNRowsTool(t, client)
-
-				_, err := tool.Run(testToolCtx, map[string]any{})
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "missing required parameter 'num_rows'")
-			})
-
-			t.Run("test_run_tool_wrong_param_type", func(t *testing.T) {
-				client := newClient(t)
-				tool := getNRowsTool(t, client)
-
-				_, err := tool.Run(testToolCtx, map[string]any{"num_rows": 2})
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "parameter 'num_rows' expects a string, but got int")
-			})
+						_, err := tool.Run(testToolCtx, map[string]any{"num_rows": 2})
+						require.Error(t, err)
+						assert.Contains(t, err.Error(), "parameter 'num_rows' expects a string, but got int")
+					})
+				})
+			}
 		})
 	}
 }
 
 func TestE2E_LoadErrors(t *testing.T) {
-	for _, proto := range protocolsToTest {
-		t.Run(proto.name, func(t *testing.T) {
-			newClient := func(t *testing.T) tbadk.ToolboxClient {
-				opts := []core.ClientOption{}
-				if !proto.isDefault {
-					opts = append(opts, core.WithProtocol(proto.protocol))
-				}
-				client, err := tbadk.NewToolboxClient("http://localhost:5000", opts...)
-				require.NoError(t, err, "Failed to create ToolboxClient")
-				return client
+	for _, serverURL := range getTestServerURLs() {
+		t.Run("server_"+serverURL, func(t *testing.T) {
+			for _, proto := range protocolsToTest {
+				t.Run(proto.name, func(t *testing.T) {
+					newClient := func(t *testing.T) tbadk.ToolboxClient {
+						opts := []core.ClientOption{}
+						if !proto.isDefault {
+							opts = append(opts, core.WithProtocol(proto.protocol))
+						}
+						client, err := tbadk.NewToolboxClient(serverURL, opts...)
+						require.NoError(t, err, "Failed to create ToolboxClient")
+						return client
+					}
+
+					t.Run("test_load_non_existent_tool", func(t *testing.T) {
+						client := newClient(t)
+						_, err := client.LoadTool("non-existent-tool", context.Background())
+						require.Error(t, err)
+						assert.Contains(t, err.Error(), "tool 'non-existent-tool' not found")
+					})
+
+					t.Run("test_load_non_existent_toolset", func(t *testing.T) {
+						client := newClient(t)
+						_, err := client.LoadToolset("non-existent-toolset", context.Background())
+						require.Error(t, err)
+						assert.Contains(t, err.Error(), "toolset does not exist")
+					})
+
+					t.Run("test_new_client_with_nil_option", func(t *testing.T) {
+						_, err := tbadk.NewToolboxClient(serverURL, nil)
+						require.Error(t, err)
+						assert.Contains(t, err.Error(), "received a nil ClientOption")
+					})
+
+					t.Run("test_load_tool_with_nil_option", func(t *testing.T) {
+						client := newClient(t)
+						_, err := client.LoadTool("get-n-rows", context.Background(), nil)
+						require.Error(t, err)
+						assert.Contains(t, err.Error(), "received a nil ToolOption")
+					})
+				})
 			}
-
-			t.Run("test_load_non_existent_tool", func(t *testing.T) {
-				client := newClient(t)
-				_, err := client.LoadTool("non-existent-tool", context.Background())
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "tool 'non-existent-tool' not found")
-			})
-
-			t.Run("test_load_non_existent_toolset", func(t *testing.T) {
-				client := newClient(t)
-				_, err := client.LoadToolset("non-existent-toolset", context.Background())
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "toolset does not exist")
-			})
-
-			t.Run("test_new_client_with_nil_option", func(t *testing.T) {
-				_, err := tbadk.NewToolboxClient("http://localhost:5000", nil)
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "received a nil ClientOption")
-			})
-
-			t.Run("test_load_tool_with_nil_option", func(t *testing.T) {
-				client := newClient(t)
-				_, err := client.LoadTool("get-n-rows", context.Background(), nil)
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "received a nil ToolOption")
-			})
 		})
 	}
 }
 
 func TestE2E_BindParams(t *testing.T) {
-	for _, proto := range protocolsToTest {
-		t.Run(proto.name, func(t *testing.T) {
-			newClient := func(t *testing.T) tbadk.ToolboxClient {
-				opts := []core.ClientOption{}
-				if !proto.isDefault {
-					opts = append(opts, core.WithProtocol(proto.protocol))
-				}
-				client, err := tbadk.NewToolboxClient("http://localhost:5000", opts...)
-				require.NoError(t, err)
-				return client
+	for _, serverURL := range getTestServerURLs() {
+		t.Run("server_"+serverURL, func(t *testing.T) {
+			for _, proto := range protocolsToTest {
+				t.Run(proto.name, func(t *testing.T) {
+					newClient := func(t *testing.T) tbadk.ToolboxClient {
+						opts := []core.ClientOption{}
+						if !proto.isDefault {
+							opts = append(opts, core.WithProtocol(proto.protocol))
+						}
+						client, err := tbadk.NewToolboxClient(serverURL, opts...)
+						require.NoError(t, err)
+						return client
+					}
+					getNRowsTool := func(t *testing.T, client tbadk.ToolboxClient) tbadk.ToolboxTool {
+						tool, err := client.LoadTool("get-n-rows", context.Background())
+						require.NoError(t, err)
+						return tool
+					}
+					agentCtx := &mockAgentContext{
+						ctx: context.Background(),
+					}
+
+					testToolCtx := &mockToolContext{
+						mockAgentContext: agentCtx,
+						MockFuncCallID:   "specific-test-id",
+					}
+
+					t.Run("test_bind_params", func(t *testing.T) {
+						client := newClient(t)
+						tool := getNRowsTool(t, client)
+
+						newTool, err := tool.ToolFrom(core.WithBindParamString("num_rows", "3"))
+						require.NoError(t, err)
+
+						response, err := newTool.Run(testToolCtx, map[string]any{})
+						require.NoError(t, err)
+
+						respStr, ok := response["output"].(string)
+						require.True(t, ok)
+						assert.Contains(t, respStr, "row1")
+						assert.Contains(t, respStr, "row2")
+						assert.Contains(t, respStr, "row3")
+						assert.NotContains(t, respStr, "row4")
+					})
+
+					t.Run("test_bind_params_callable", func(t *testing.T) {
+						client := newClient(t)
+						tool := getNRowsTool(t, client)
+
+						callable := func() (string, error) {
+							return "3", nil
+						}
+
+						newTool, err := tool.ToolFrom(core.WithBindParamStringFunc("num_rows", callable))
+						require.NoError(t, err)
+
+						response, err := newTool.Run(testToolCtx, map[string]any{})
+						require.NoError(t, err)
+
+						respStr, ok := response["output"].(string)
+						require.True(t, ok)
+						assert.Contains(t, respStr, "row1")
+						assert.Contains(t, respStr, "row2")
+						assert.Contains(t, respStr, "row3")
+						assert.NotContains(t, respStr, "row4")
+					})
+				})
 			}
-			getNRowsTool := func(t *testing.T, client tbadk.ToolboxClient) tbadk.ToolboxTool {
-				tool, err := client.LoadTool("get-n-rows", context.Background())
-				require.NoError(t, err)
-				return tool
-			}
-			agentCtx := &mockAgentContext{
-				ctx: context.Background(),
-			}
-
-			testToolCtx := &mockToolContext{
-				mockAgentContext: agentCtx,
-				MockFuncCallID:   "specific-test-id",
-			}
-
-			t.Run("test_bind_params", func(t *testing.T) {
-				client := newClient(t)
-				tool := getNRowsTool(t, client)
-
-				newTool, err := tool.ToolFrom(core.WithBindParamString("num_rows", "3"))
-				require.NoError(t, err)
-
-				response, err := newTool.Run(testToolCtx, map[string]any{})
-				require.NoError(t, err)
-
-				respStr, ok := response["output"].(string)
-				require.True(t, ok)
-				assert.Contains(t, respStr, "row1")
-				assert.Contains(t, respStr, "row2")
-				assert.Contains(t, respStr, "row3")
-				assert.NotContains(t, respStr, "row4")
-			})
-
-			t.Run("test_bind_params_callable", func(t *testing.T) {
-				client := newClient(t)
-				tool := getNRowsTool(t, client)
-
-				callable := func() (string, error) {
-					return "3", nil
-				}
-
-				newTool, err := tool.ToolFrom(core.WithBindParamStringFunc("num_rows", callable))
-				require.NoError(t, err)
-
-				response, err := newTool.Run(testToolCtx, map[string]any{})
-				require.NoError(t, err)
-
-				respStr, ok := response["output"].(string)
-				require.True(t, ok)
-				assert.Contains(t, respStr, "row1")
-				assert.Contains(t, respStr, "row2")
-				assert.Contains(t, respStr, "row3")
-				assert.NotContains(t, respStr, "row4")
-			})
 		})
 	}
 }
 
 func TestE2E_BindParamErrors(t *testing.T) {
-	for _, proto := range protocolsToTest {
-		t.Run(proto.name, func(t *testing.T) {
-			opts := []core.ClientOption{}
-			if !proto.isDefault {
-				opts = append(opts, core.WithProtocol(proto.protocol))
+	for _, serverURL := range getTestServerURLs() {
+		t.Run("server_"+serverURL, func(t *testing.T) {
+			for _, proto := range protocolsToTest {
+				t.Run(proto.name, func(t *testing.T) {
+					opts := []core.ClientOption{}
+					if !proto.isDefault {
+						opts = append(opts, core.WithProtocol(proto.protocol))
+					}
+					client, err := tbadk.NewToolboxClient(serverURL, opts...)
+					require.NoError(t, err)
+					tool, err := client.LoadTool("get-n-rows", context.Background())
+					require.NoError(t, err)
+
+					t.Run("test_bind_non_existent_param", func(t *testing.T) {
+						_, err := tool.ToolFrom(core.WithBindParamString("non-existent-param", "3"))
+						require.Error(t, err)
+						assert.Contains(t, err.Error(), "unable to bind parameter: no parameter named 'non-existent-param' on the tool")
+					})
+
+					t.Run("test_override_bound_param", func(t *testing.T) {
+						newTool, err := tool.ToolFrom(core.WithBindParamString("num_rows", "2"))
+						require.NoError(t, err)
+
+						_, err = newTool.ToolFrom(core.WithBindParamString("num_rows", "3"))
+						require.Error(t, err)
+						assert.Contains(t, err.Error(), "cannot override existing bound parameter: 'num_rows'")
+					})
+				})
 			}
-			client, err := tbadk.NewToolboxClient("http://localhost:5000", opts...)
-			require.NoError(t, err)
-			tool, err := client.LoadTool("get-n-rows", context.Background())
-			require.NoError(t, err)
-
-			t.Run("test_bind_non_existent_param", func(t *testing.T) {
-				_, err := tool.ToolFrom(core.WithBindParamString("non-existent-param", "3"))
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "unable to bind parameter: no parameter named 'non-existent-param' on the tool")
-			})
-
-			t.Run("test_override_bound_param", func(t *testing.T) {
-				newTool, err := tool.ToolFrom(core.WithBindParamString("num_rows", "2"))
-				require.NoError(t, err)
-
-				_, err = newTool.ToolFrom(core.WithBindParamString("num_rows", "3"))
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "cannot override existing bound parameter: 'num_rows'")
-			})
 		})
 	}
 }
 
 func TestE2E_Auth(t *testing.T) {
-	for _, proto := range protocolsToTest {
-		t.Run(proto.name, func(t *testing.T) {
-			newClient := func(t *testing.T) tbadk.ToolboxClient {
-				opts := []core.ClientOption{}
-				if !proto.isDefault {
-					opts = append(opts, core.WithProtocol(proto.protocol))
-				}
-				client, err := tbadk.NewToolboxClient("http://localhost:5000", opts...)
-				require.NoError(t, err)
-				return client
+	for _, serverURL := range getTestServerURLs() {
+		t.Run("server_"+serverURL, func(t *testing.T) {
+			for _, proto := range protocolsToTest {
+				t.Run(proto.name, func(t *testing.T) {
+					newClient := func(t *testing.T) tbadk.ToolboxClient {
+						opts := []core.ClientOption{}
+						if !proto.isDefault {
+							opts = append(opts, core.WithProtocol(proto.protocol))
+						}
+						client, err := tbadk.NewToolboxClient(serverURL, opts...)
+						require.NoError(t, err)
+						return client
+					}
+
+					// Helper to create a static token source from a string token
+					staticTokenSource := func(token string) oauth2.TokenSource {
+						return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+					}
+
+					agentCtx := &mockAgentContext{
+						ctx: context.Background(),
+					}
+
+					testToolCtx := &mockToolContext{
+						mockAgentContext: agentCtx,
+						MockFuncCallID:   "specific-test-id",
+					}
+
+					t.Run("test_run_tool_unauth_with_auth", func(t *testing.T) {
+						client := newClient(t)
+						_, err := client.LoadTool("get-row-by-id", context.Background(),
+							core.WithAuthTokenSource("my-test-auth", staticTokenSource(authToken2)),
+						)
+						require.Error(t, err)
+						assert.Contains(t, err.Error(), "validation failed for tool 'get-row-by-id': unused auth tokens: my-test-auth")
+					})
+
+					t.Run("test_run_tool_no_auth", func(t *testing.T) {
+						client := newClient(t)
+						tool, err := client.LoadTool("get-row-by-id-auth", context.Background())
+						require.NoError(t, err)
+
+						_, err = tool.Run(testToolCtx, map[string]any{"id": "2"})
+						require.Error(t, err)
+						assert.Contains(t, err.Error(), "permission error: auth service 'my-test-auth' is required")
+					})
+
+					t.Run("test_run_tool_wrong_auth", func(t *testing.T) {
+						client := newClient(t)
+						tool, err := client.LoadTool("get-row-by-id-auth", context.Background())
+						require.NoError(t, err)
+
+						authedTool, err := tool.ToolFrom(
+							core.WithAuthTokenSource("my-test-auth", staticTokenSource(authToken2)),
+						)
+						require.NoError(t, err)
+
+						_, err = authedTool.Run(testToolCtx, map[string]any{"id": "2"})
+						require.Error(t, err)
+						assert.Contains(t, err.Error(), "unauthorized Tool call")
+					})
+
+					t.Run("test_run_tool_auth", func(t *testing.T) {
+						client := newClient(t)
+						tool, err := client.LoadTool("get-row-by-id-auth", context.Background(),
+							core.WithAuthTokenSource("my-test-auth", staticTokenSource(authToken1)),
+						)
+						require.NoError(t, err)
+
+						response, err := tool.Run(testToolCtx, map[string]any{"id": "2"})
+						require.NoError(t, err)
+
+						respStr, ok := response["output"].(string)
+						require.True(t, ok)
+						assert.Contains(t, respStr, "row2")
+					})
+
+					t.Run("test_run_tool_param_auth_no_auth", func(t *testing.T) {
+						client := newClient(t)
+						tool, err := client.LoadTool("get-row-by-email-auth", context.Background())
+						require.NoError(t, err)
+
+						_, err = tool.Run(testToolCtx, map[string]any{})
+						require.Error(t, err)
+						assert.Contains(t, err.Error(), "permission error: auth service 'my-test-auth' is required")
+					})
+
+					t.Run("test_run_tool_param_auth", func(t *testing.T) {
+						client := newClient(t)
+						tool, err := client.LoadTool("get-row-by-email-auth", context.Background(),
+							core.WithAuthTokenSource("my-test-auth", staticTokenSource(authToken1)),
+						)
+						require.NoError(t, err)
+
+						response, err := tool.Run(testToolCtx, map[string]any{})
+						require.NoError(t, err)
+
+						respStr, ok := response["output"].(string)
+						require.True(t, ok)
+						assert.Contains(t, respStr, "row4")
+						assert.Contains(t, respStr, "row5")
+						assert.Contains(t, respStr, "row6")
+					})
+
+					t.Run("test_run_tool_param_auth_no_field", func(t *testing.T) {
+						client := newClient(t)
+						tool, err := client.LoadTool("get-row-by-content-auth", context.Background(),
+							core.WithAuthTokenSource("my-test-auth", staticTokenSource(authToken1)),
+						)
+						require.NoError(t, err)
+
+						_, err = tool.Run(testToolCtx, map[string]any{})
+						require.Error(t, err)
+						assert.Contains(t, err.Error(), "no field named row_data in claims")
+					})
+
+					t.Run("test_run_tool_with_failing_token_source", func(t *testing.T) {
+						client := newClient(t)
+						tool, err := client.LoadTool("get-row-by-id-auth", context.Background(),
+							core.WithAuthTokenSource("my-test-auth", &failingTokenSource{}),
+						)
+						require.NoError(t, err)
+
+						_, err = tool.Run(testToolCtx, map[string]any{"id": "2"})
+						require.Error(t, err)
+						assert.Contains(t, err.Error(), "failed to resolve auth token my-test-auth")
+						assert.Contains(t, err.Error(), "token source failed as designed")
+					})
+				})
 			}
-
-			// Helper to create a static token source from a string token
-			staticTokenSource := func(token string) oauth2.TokenSource {
-				return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
-			}
-
-			agentCtx := &mockAgentContext{
-				ctx: context.Background(),
-			}
-
-			testToolCtx := &mockToolContext{
-				mockAgentContext: agentCtx,
-				MockFuncCallID:   "specific-test-id",
-			}
-
-			t.Run("test_run_tool_unauth_with_auth", func(t *testing.T) {
-				client := newClient(t)
-				_, err := client.LoadTool("get-row-by-id", context.Background(),
-					core.WithAuthTokenSource("my-test-auth", staticTokenSource(authToken2)),
-				)
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "validation failed for tool 'get-row-by-id': unused auth tokens: my-test-auth")
-			})
-
-			t.Run("test_run_tool_no_auth", func(t *testing.T) {
-				client := newClient(t)
-				tool, err := client.LoadTool("get-row-by-id-auth", context.Background())
-				require.NoError(t, err)
-
-				_, err = tool.Run(testToolCtx, map[string]any{"id": "2"})
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "permission error: auth service 'my-test-auth' is required")
-			})
-
-			t.Run("test_run_tool_wrong_auth", func(t *testing.T) {
-				client := newClient(t)
-				tool, err := client.LoadTool("get-row-by-id-auth", context.Background())
-				require.NoError(t, err)
-
-				authedTool, err := tool.ToolFrom(
-					core.WithAuthTokenSource("my-test-auth", staticTokenSource(authToken2)),
-				)
-				require.NoError(t, err)
-
-				_, err = authedTool.Run(testToolCtx, map[string]any{"id": "2"})
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "unauthorized Tool call")
-			})
-
-			t.Run("test_run_tool_auth", func(t *testing.T) {
-				client := newClient(t)
-				tool, err := client.LoadTool("get-row-by-id-auth", context.Background(),
-					core.WithAuthTokenSource("my-test-auth", staticTokenSource(authToken1)),
-				)
-				require.NoError(t, err)
-
-				response, err := tool.Run(testToolCtx, map[string]any{"id": "2"})
-				require.NoError(t, err)
-
-				respStr, ok := response["output"].(string)
-				require.True(t, ok)
-				assert.Contains(t, respStr, "row2")
-			})
-
-			t.Run("test_run_tool_param_auth_no_auth", func(t *testing.T) {
-				client := newClient(t)
-				tool, err := client.LoadTool("get-row-by-email-auth", context.Background())
-				require.NoError(t, err)
-
-				_, err = tool.Run(testToolCtx, map[string]any{})
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "permission error: auth service 'my-test-auth' is required")
-			})
-
-			t.Run("test_run_tool_param_auth", func(t *testing.T) {
-				client := newClient(t)
-				tool, err := client.LoadTool("get-row-by-email-auth", context.Background(),
-					core.WithAuthTokenSource("my-test-auth", staticTokenSource(authToken1)),
-				)
-				require.NoError(t, err)
-
-				response, err := tool.Run(testToolCtx, map[string]any{})
-				require.NoError(t, err)
-
-				respStr, ok := response["output"].(string)
-				require.True(t, ok)
-				assert.Contains(t, respStr, "row4")
-				assert.Contains(t, respStr, "row5")
-				assert.Contains(t, respStr, "row6")
-			})
-
-			t.Run("test_run_tool_param_auth_no_field", func(t *testing.T) {
-				client := newClient(t)
-				tool, err := client.LoadTool("get-row-by-content-auth", context.Background(),
-					core.WithAuthTokenSource("my-test-auth", staticTokenSource(authToken1)),
-				)
-				require.NoError(t, err)
-
-				_, err = tool.Run(testToolCtx, map[string]any{})
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "no field named row_data in claims")
-			})
-
-			t.Run("test_run_tool_with_failing_token_source", func(t *testing.T) {
-				client := newClient(t)
-				tool, err := client.LoadTool("get-row-by-id-auth", context.Background(),
-					core.WithAuthTokenSource("my-test-auth", &failingTokenSource{}),
-				)
-				require.NoError(t, err)
-
-				_, err = tool.Run(testToolCtx, map[string]any{"id": "2"})
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "failed to resolve auth token my-test-auth")
-				assert.Contains(t, err.Error(), "token source failed as designed")
-			})
 		})
 	}
 }
 
 func TestE2E_OptionalParams(t *testing.T) {
-	for _, proto := range protocolsToTest {
-		t.Run(proto.name, func(t *testing.T) {
-			// Helper to create a new client
-			newClient := func(t *testing.T) tbadk.ToolboxClient {
-				opts := []core.ClientOption{}
-				if !proto.isDefault {
-					opts = append(opts, core.WithProtocol(proto.protocol))
-				}
-				client, err := tbadk.NewToolboxClient("http://localhost:5000", opts...)
-				require.NoError(t, err, "Failed to create ToolboxClient")
-				return client
+	for _, serverURL := range getTestServerURLs() {
+		t.Run("server_"+serverURL, func(t *testing.T) {
+			for _, proto := range protocolsToTest {
+				t.Run(proto.name, func(t *testing.T) {
+					// Helper to create a new client
+					newClient := func(t *testing.T) tbadk.ToolboxClient {
+						opts := []core.ClientOption{}
+						if !proto.isDefault {
+							opts = append(opts, core.WithProtocol(proto.protocol))
+						}
+						client, err := tbadk.NewToolboxClient(serverURL, opts...)
+						require.NoError(t, err, "Failed to create ToolboxClient")
+						return client
+					}
+
+					// Helper to load the search-rows tool
+					searchRowsTool := func(t *testing.T, client tbadk.ToolboxClient) tbadk.ToolboxTool {
+						tool, err := client.LoadTool("search-rows", context.Background())
+						require.NoError(t, err, "Failed to load tool 'search-rows'")
+						return tool
+					}
+
+					agentCtx := &mockAgentContext{
+						ctx: context.Background(),
+					}
+
+					testToolCtx := &mockToolContext{
+						mockAgentContext: agentCtx,
+						MockFuncCallID:   "specific-test-id",
+					}
+
+					t.Run("test_tool_schema_is_correct", func(t *testing.T) {
+						client := newClient(t)
+						tool := searchRowsTool(t, client)
+						params := tool.Parameters()
+
+						// Convert slice to map for easy lookup
+						paramMap := make(map[string]core.ParameterSchema)
+						for _, p := range params {
+							paramMap[p.Name] = p
+						}
+
+						// Check required parameter 'email'
+						emailParam, ok := paramMap["email"]
+						require.True(t, ok, "email parameter should exist")
+						assert.True(t, emailParam.Required, "'email' should be required")
+						assert.Equal(t, "string", emailParam.Type)
+
+						// Check optional parameter 'data'
+						dataParam, ok := paramMap["data"]
+						require.True(t, ok, "data parameter should exist")
+						assert.False(t, dataParam.Required, "'data' should be optional")
+						assert.Equal(t, "string", dataParam.Type)
+
+						// Check optional parameter 'id'
+						idParam, ok := paramMap["id"]
+						require.True(t, ok, "id parameter should exist")
+						assert.False(t, idParam.Required, "'id' should be optional")
+						assert.Equal(t, "integer", idParam.Type)
+					})
+
+					t.Run("test_run_tool_omitting_optionals", func(t *testing.T) {
+						client := newClient(t)
+						tool := searchRowsTool(t, client)
+
+						// Test case 1: Optional params are completely omitted
+						response1, err1 := tool.Run(testToolCtx, map[string]any{
+							"email": "twishabansal@google.com",
+						})
+						require.NoError(t, err1)
+						respStr1, ok1 := response1["output"].(string)
+						require.True(t, ok1)
+						assert.Contains(t, respStr1, `"email":"twishabansal@google.com"`)
+						assert.Contains(t, respStr1, "row2")
+						assert.NotContains(t, respStr1, "row3")
+
+						// Test case 2: Optional params are explicitly nil
+						// This should produce the same result as omitting them
+						response2, err2 := tool.Run(testToolCtx, map[string]any{
+							"email": "twishabansal@google.com",
+							"data":  nil,
+							"id":    nil,
+						})
+						require.NoError(t, err2)
+						respStr2, ok2 := response2["output"].(string)
+						require.True(t, ok2)
+						assert.Equal(t, respStr1, respStr2)
+					})
+
+					t.Run("test_run_tool_with_all_params_provided", func(t *testing.T) {
+						client := newClient(t)
+						tool := searchRowsTool(t, client)
+						response, err := tool.Run(testToolCtx, map[string]any{
+							"email": "twishabansal@google.com",
+							"data":  "row3",
+							"id":    3,
+						})
+						require.NoError(t, err)
+						respStr, ok := response["output"].(string)
+						require.True(t, ok)
+						assert.Contains(t, respStr, `"email":"twishabansal@google.com"`)
+						assert.Contains(t, respStr, `"id":3`)
+						assert.Contains(t, respStr, "row3")
+						assert.NotContains(t, respStr, "row2")
+					})
+
+					t.Run("test_run_tool_missing_required_param", func(t *testing.T) {
+						client := newClient(t)
+						tool := searchRowsTool(t, client)
+						_, err := tool.Run(testToolCtx, map[string]any{
+							"data": "row5",
+							"id":   5,
+						})
+						require.Error(t, err)
+						assert.Contains(t, err.Error(), "missing required parameter 'email'")
+					})
+
+					t.Run("test_run_tool_required_param_is_nil", func(t *testing.T) {
+						client := newClient(t)
+						tool := searchRowsTool(t, client)
+						_, err := tool.Run(testToolCtx, map[string]any{
+							"email": nil,
+							"id":    5,
+						})
+						require.Error(t, err)
+						assert.Contains(t, err.Error(), "parameter 'email' is required but received a nil value")
+					})
+
+					// Corresponds to tests that check server-side logic by providing data that doesn't match
+					t.Run("test_run_tool_with_non_matching_data", func(t *testing.T) {
+						client := newClient(t)
+						tool := searchRowsTool(t, client)
+
+						// Test with a different email
+						response, err := tool.Run(testToolCtx, map[string]any{
+							"email": "anubhavdhawan@google.com",
+							"id":    3,
+							"data":  "row3",
+						})
+						result := response["output"]
+						require.NoError(t, err)
+						assert.Equal(t, "null", result, "Response should be null for non-matching email")
+
+						// Test with different data
+						response, err = tool.Run(testToolCtx, map[string]any{
+							"email": "twishabansal@google.com",
+							"id":    3,
+							"data":  "row4", // This data doesn't match the id
+						})
+						result = response["output"]
+						require.NoError(t, err)
+						assert.Equal(t, "null", result, "Response should be null for non-matching data")
+					})
+
+					t.Run("test_run_tool_wrong_type_for_integer", func(t *testing.T) {
+						client := newClient(t)
+						tool := searchRowsTool(t, client)
+
+						_, err := tool.Run(testToolCtx, map[string]any{
+							"email": "twishabansal@google.com",
+							"id":    "not-an-integer",
+						})
+						require.Error(t, err)
+						assert.Contains(t, err.Error(), "parameter 'id' expects an integer, but got string")
+					})
+
+					t.Run("test_run_tool_with_default_behavior", func(t *testing.T) {
+						client := newClient(t)
+						tool := searchRowsTool(t, client)
+
+						// Omit default params, ensure they fallback to defaults
+						response1, err1 := tool.Run(testToolCtx, map[string]any{
+							"email": "twishabansal@google.com",
+						})
+						require.NoError(t, err1)
+						respStr1, ok1 := response1["output"].(string)
+						require.True(t, ok1)
+						assert.Contains(t, respStr1, `"email":"twishabansal@google.com"`)
+						assert.Contains(t, respStr1, "row2")
+
+						// Override 'data' default
+						response2, err2 := tool.Run(testToolCtx, map[string]any{
+							"email": "twishabansal@google.com",
+							"data":  "row3",
+						})
+						require.NoError(t, err2)
+						respStr2, ok2 := response2["output"].(string)
+						require.True(t, ok2)
+						assert.Contains(t, respStr2, `"email":"twishabansal@google.com"`)
+						assert.Contains(t, respStr2, "row3")
+
+						// Override 'id' default
+						response3, err3 := tool.Run(testToolCtx, map[string]any{
+							"email": "twishabansal@google.com",
+							"id":    4,
+						})
+						require.NoError(t, err3)
+						assert.Equal(t, "null", response3["output"])
+					})
+				})
 			}
-
-			// Helper to load the search-rows tool
-			searchRowsTool := func(t *testing.T, client tbadk.ToolboxClient) tbadk.ToolboxTool {
-				tool, err := client.LoadTool("search-rows", context.Background())
-				require.NoError(t, err, "Failed to load tool 'search-rows'")
-				return tool
-			}
-
-			agentCtx := &mockAgentContext{
-				ctx: context.Background(),
-			}
-
-			testToolCtx := &mockToolContext{
-				mockAgentContext: agentCtx,
-				MockFuncCallID:   "specific-test-id",
-			}
-
-			t.Run("test_tool_schema_is_correct", func(t *testing.T) {
-				client := newClient(t)
-				tool := searchRowsTool(t, client)
-				params := tool.Parameters()
-
-				// Convert slice to map for easy lookup
-				paramMap := make(map[string]core.ParameterSchema)
-				for _, p := range params {
-					paramMap[p.Name] = p
-				}
-
-				// Check required parameter 'email'
-				emailParam, ok := paramMap["email"]
-				require.True(t, ok, "email parameter should exist")
-				assert.True(t, emailParam.Required, "'email' should be required")
-				assert.Equal(t, "string", emailParam.Type)
-
-				// Check optional parameter 'data'
-				dataParam, ok := paramMap["data"]
-				require.True(t, ok, "data parameter should exist")
-				assert.False(t, dataParam.Required, "'data' should be optional")
-				assert.Equal(t, "string", dataParam.Type)
-
-				// Check optional parameter 'id'
-				idParam, ok := paramMap["id"]
-				require.True(t, ok, "id parameter should exist")
-				assert.False(t, idParam.Required, "'id' should be optional")
-				assert.Equal(t, "integer", idParam.Type)
-			})
-
-			t.Run("test_run_tool_omitting_optionals", func(t *testing.T) {
-				client := newClient(t)
-				tool := searchRowsTool(t, client)
-
-				// Test case 1: Optional params are completely omitted
-				response1, err1 := tool.Run(testToolCtx, map[string]any{
-					"email": "twishabansal@google.com",
-				})
-				require.NoError(t, err1)
-				respStr1, ok1 := response1["output"].(string)
-				require.True(t, ok1)
-				assert.Contains(t, respStr1, `"email":"twishabansal@google.com"`)
-				assert.Contains(t, respStr1, "row2")
-				assert.NotContains(t, respStr1, "row3")
-
-				// Test case 2: Optional params are explicitly nil
-				// This should produce the same result as omitting them
-				response2, err2 := tool.Run(testToolCtx, map[string]any{
-					"email": "twishabansal@google.com",
-					"data":  nil,
-					"id":    nil,
-				})
-				require.NoError(t, err2)
-				respStr2, ok2 := response2["output"].(string)
-				require.True(t, ok2)
-				assert.Equal(t, respStr1, respStr2)
-			})
-
-			t.Run("test_run_tool_with_all_params_provided", func(t *testing.T) {
-				client := newClient(t)
-				tool := searchRowsTool(t, client)
-				response, err := tool.Run(testToolCtx, map[string]any{
-					"email": "twishabansal@google.com",
-					"data":  "row3",
-					"id":    3,
-				})
-				require.NoError(t, err)
-				respStr, ok := response["output"].(string)
-				require.True(t, ok)
-				assert.Contains(t, respStr, `"email":"twishabansal@google.com"`)
-				assert.Contains(t, respStr, `"id":3`)
-				assert.Contains(t, respStr, "row3")
-				assert.NotContains(t, respStr, "row2")
-			})
-
-			t.Run("test_run_tool_missing_required_param", func(t *testing.T) {
-				client := newClient(t)
-				tool := searchRowsTool(t, client)
-				_, err := tool.Run(testToolCtx, map[string]any{
-					"data": "row5",
-					"id":   5,
-				})
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "missing required parameter 'email'")
-			})
-
-			t.Run("test_run_tool_required_param_is_nil", func(t *testing.T) {
-				client := newClient(t)
-				tool := searchRowsTool(t, client)
-				_, err := tool.Run(testToolCtx, map[string]any{
-					"email": nil,
-					"id":    5,
-				})
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "parameter 'email' is required but received a nil value")
-			})
-
-			// Corresponds to tests that check server-side logic by providing data that doesn't match
-			t.Run("test_run_tool_with_non_matching_data", func(t *testing.T) {
-				client := newClient(t)
-				tool := searchRowsTool(t, client)
-
-				// Test with a different email
-				response, err := tool.Run(testToolCtx, map[string]any{
-					"email": "anubhavdhawan@google.com",
-					"id":    3,
-					"data":  "row3",
-				})
-				result := response["output"]
-				require.NoError(t, err)
-				assert.Equal(t, "null", result, "Response should be null for non-matching email")
-
-				// Test with different data
-				response, err = tool.Run(testToolCtx, map[string]any{
-					"email": "twishabansal@google.com",
-					"id":    3,
-					"data":  "row4", // This data doesn't match the id
-				})
-				result = response["output"]
-				require.NoError(t, err)
-				assert.Equal(t, "null", result, "Response should be null for non-matching data")
-			})
-
-			t.Run("test_run_tool_wrong_type_for_integer", func(t *testing.T) {
-				client := newClient(t)
-				tool := searchRowsTool(t, client)
-
-				_, err := tool.Run(testToolCtx, map[string]any{
-					"email": "twishabansal@google.com",
-					"id":    "not-an-integer",
-				})
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "parameter 'id' expects an integer, but got string")
-			})
-
-			t.Run("test_run_tool_with_default_behavior", func(t *testing.T) {
-				client := newClient(t)
-				tool := searchRowsTool(t, client)
-
-				// Omit default params, ensure they fallback to defaults
-				response1, err1 := tool.Run(testToolCtx, map[string]any{
-					"email": "twishabansal@google.com",
-				})
-				require.NoError(t, err1)
-				respStr1, ok1 := response1["output"].(string)
-				require.True(t, ok1)
-				assert.Contains(t, respStr1, `"email":"twishabansal@google.com"`)
-				assert.Contains(t, respStr1, "row2")
-
-				// Override 'data' default
-				response2, err2 := tool.Run(testToolCtx, map[string]any{
-					"email": "twishabansal@google.com",
-					"data":  "row3",
-				})
-				require.NoError(t, err2)
-				respStr2, ok2 := response2["output"].(string)
-				require.True(t, ok2)
-				assert.Contains(t, respStr2, `"email":"twishabansal@google.com"`)
-				assert.Contains(t, respStr2, "row3")
-
-				// Override 'id' default
-				response3, err3 := tool.Run(testToolCtx, map[string]any{
-					"email": "twishabansal@google.com",
-					"id":    4,
-				})
-				require.NoError(t, err3)
-				assert.Equal(t, "null", response3["output"])
-			})
 		})
 	}
 }
 
 func TestE2E_MapParams(t *testing.T) {
-	for _, proto := range protocolsToTest {
-		t.Run(proto.name, func(t *testing.T) {
-			// Helper to create a new client
-			newClient := func(t *testing.T) tbadk.ToolboxClient {
-				opts := []core.ClientOption{}
-				if !proto.isDefault {
-					opts = append(opts, core.WithProtocol(proto.protocol))
-				}
-				client, err := tbadk.NewToolboxClient("http://localhost:5000", opts...)
-				require.NoError(t, err, "Failed to create ToolboxClient")
-				return client
-			}
+	for _, serverURL := range getTestServerURLs() {
+		t.Run("server_"+serverURL, func(t *testing.T) {
+			for _, proto := range protocolsToTest {
+				t.Run(proto.name, func(t *testing.T) {
+					// Helper to create a new client
+					newClient := func(t *testing.T) tbadk.ToolboxClient {
+						opts := []core.ClientOption{}
+						if !proto.isDefault {
+							opts = append(opts, core.WithProtocol(proto.protocol))
+						}
+						client, err := tbadk.NewToolboxClient(serverURL, opts...)
+						require.NoError(t, err, "Failed to create ToolboxClient")
+						return client
+					}
 
-			// Helper to load the process-data tool
-			processDataTool := func(t *testing.T, client tbadk.ToolboxClient) tbadk.ToolboxTool {
-				tool, err := client.LoadTool("process-data", context.Background())
-				require.NoError(t, err, "Failed to load tool 'process-data'")
-				return tool
-			}
+					// Helper to load the process-data tool
+					processDataTool := func(t *testing.T, client tbadk.ToolboxClient) tbadk.ToolboxTool {
+						tool, err := client.LoadTool("process-data", context.Background())
+						require.NoError(t, err, "Failed to load tool 'process-data'")
+						return tool
+					}
 
-			agentCtx := &mockAgentContext{
-				ctx: context.Background(),
-			}
+					agentCtx := &mockAgentContext{
+						ctx: context.Background(),
+					}
 
-			testToolCtx := &mockToolContext{
-				mockAgentContext: agentCtx,
-				MockFuncCallID:   "specific-test-id",
-			}
+					testToolCtx := &mockToolContext{
+						mockAgentContext: agentCtx,
+						MockFuncCallID:   "specific-test-id",
+					}
 
-			t.Run("test_tool_schema_is_correct", func(t *testing.T) {
-				client := newClient(t)
-				tool := processDataTool(t, client)
-				params := tool.Parameters()
+					t.Run("test_tool_schema_is_correct", func(t *testing.T) {
+						client := newClient(t)
+						tool := processDataTool(t, client)
+						params := tool.Parameters()
 
-				// Convert slice to map for easy lookup
-				paramMap := make(map[string]core.ParameterSchema)
-				for _, p := range params {
-					paramMap[p.Name] = p
-				}
+						// Convert slice to map for easy lookup
+						paramMap := make(map[string]core.ParameterSchema)
+						for _, p := range params {
+							paramMap[p.Name] = p
+						}
 
-				// Verify 'execution_context' parameter.
-				execCtxParam, ok := paramMap["execution_context"]
-				require.True(t, ok, "'execution_context' parameter should exist")
-				assert.True(t, execCtxParam.Required, "'execution_context' should be required")
-				assert.Equal(t, "object", execCtxParam.Type, "'execution_context' type should be object")
+						// Verify 'execution_context' parameter.
+						execCtxParam, ok := paramMap["execution_context"]
+						require.True(t, ok, "'execution_context' parameter should exist")
+						assert.True(t, execCtxParam.Required, "'execution_context' should be required")
+						assert.Equal(t, "object", execCtxParam.Type, "'execution_context' type should be object")
 
-				// Verify 'user_scores' parameter.
-				userScoresParam, ok := paramMap["user_scores"]
-				require.True(t, ok, "'user_scores' parameter should exist")
-				assert.True(t, userScoresParam.Required, "'user_scores' should be required")
-				assert.Equal(t, "object", userScoresParam.Type, "'user_scores' type should be object")
+						// Verify 'user_scores' parameter.
+						userScoresParam, ok := paramMap["user_scores"]
+						require.True(t, ok, "'user_scores' parameter should exist")
+						assert.True(t, userScoresParam.Required, "'user_scores' should be required")
+						assert.Equal(t, "object", userScoresParam.Type, "'user_scores' type should be object")
 
-				// Verify 'feature_flags' parameter.
-				featureFlagsParam, ok := paramMap["feature_flags"]
-				require.True(t, ok, "'feature_flags' parameter should exist")
-				assert.False(t, featureFlagsParam.Required, "'feature_flags' should be optional")
-				assert.Equal(t, "object", featureFlagsParam.Type, "'feature_flags' type should be object")
-			})
+						// Verify 'feature_flags' parameter.
+						featureFlagsParam, ok := paramMap["feature_flags"]
+						require.True(t, ok, "'feature_flags' parameter should exist")
+						assert.False(t, featureFlagsParam.Required, "'feature_flags' should be optional")
+						assert.Equal(t, "object", featureFlagsParam.Type, "'feature_flags' type should be object")
+					})
 
-			t.Run("test_run_tool_with_all_map_params", func(t *testing.T) {
-				client := newClient(t)
-				tool := processDataTool(t, client)
+					t.Run("test_run_tool_with_all_map_params", func(t *testing.T) {
+						client := newClient(t)
+						tool := processDataTool(t, client)
 
-				// Invoke the tool with valid map parameters.
-				response, err := tool.Run(testToolCtx, map[string]any{
-					"execution_context": map[string]any{
-						"env":  "prod",
-						"id":   1234,
-						"user": 1234.5,
-					},
-					"user_scores": map[string]any{
-						"user1": 100,
-						"user2": 200,
-					},
-					"feature_flags": map[string]any{
-						"new_feature": true,
-					},
+						// Invoke the tool with valid map parameters.
+						response, err := tool.Run(testToolCtx, map[string]any{
+							"execution_context": map[string]any{
+								"env":  "prod",
+								"id":   1234,
+								"user": 1234.5,
+							},
+							"user_scores": map[string]any{
+								"user1": 100,
+								"user2": 200,
+							},
+							"feature_flags": map[string]any{
+								"new_feature": true,
+							},
+						})
+						require.NoError(t, err)
+						respStr, ok := response["output"].(string)
+						require.True(t, ok, "Response should be a string")
+
+						assert.Contains(t, respStr, `"execution_context":{"env":"prod","id":1234,"user":1234.5}`)
+						assert.Contains(t, respStr, `"user_scores":{"user1":100,"user2":200}`)
+						assert.Contains(t, respStr, `"feature_flags":{"new_feature":true}`)
+					})
+
+					t.Run("test_run_tool_omitting_optional_map", func(t *testing.T) {
+						client := newClient(t)
+						tool := processDataTool(t, client)
+
+						// Invoke the tool without the optional 'feature_flags' parameter.
+						response, err := tool.Run(testToolCtx, map[string]any{
+							"execution_context": map[string]any{"env": "dev"},
+							"user_scores":       map[string]any{"user3": 300},
+						})
+						require.NoError(t, err)
+						respStr, ok := response["output"].(string)
+						require.True(t, ok, "Response should be a string")
+
+						assert.Contains(t, respStr, `"execution_context":{"env":"dev"}`)
+						assert.Contains(t, respStr, `"user_scores":{"user3":300}`)
+						assert.Contains(t, respStr, `"feature_flags":null`)
+					})
+
+					t.Run("test_run_tool_with_wrong_map_value_type", func(t *testing.T) {
+						client := newClient(t)
+						tool := processDataTool(t, client)
+
+						// Attempt to invoke the tool with an incorrect type in a map value.
+						_, err := tool.Run(testToolCtx, map[string]any{
+							"execution_context": map[string]any{"env": "staging"},
+							"user_scores": map[string]any{
+								"user4": "not-an-integer",
+							},
+						})
+
+						// Assert that an error was returned.
+						require.Error(t, err, "Expected an error for wrong map value type")
+						assert.Contains(t, err.Error(), "expects an integer, but got string", "Error message should indicate a validation failure")
+					})
 				})
-				require.NoError(t, err)
-				respStr, ok := response["output"].(string)
-				require.True(t, ok, "Response should be a string")
-
-				assert.Contains(t, respStr, `"execution_context":{"env":"prod","id":1234,"user":1234.5}`)
-				assert.Contains(t, respStr, `"user_scores":{"user1":100,"user2":200}`)
-				assert.Contains(t, respStr, `"feature_flags":{"new_feature":true}`)
-			})
-
-			t.Run("test_run_tool_omitting_optional_map", func(t *testing.T) {
-				client := newClient(t)
-				tool := processDataTool(t, client)
-
-				// Invoke the tool without the optional 'feature_flags' parameter.
-				response, err := tool.Run(testToolCtx, map[string]any{
-					"execution_context": map[string]any{"env": "dev"},
-					"user_scores":       map[string]any{"user3": 300},
-				})
-				require.NoError(t, err)
-				respStr, ok := response["output"].(string)
-				require.True(t, ok, "Response should be a string")
-
-				assert.Contains(t, respStr, `"execution_context":{"env":"dev"}`)
-				assert.Contains(t, respStr, `"user_scores":{"user3":300}`)
-				assert.Contains(t, respStr, `"feature_flags":null`)
-			})
-
-			t.Run("test_run_tool_with_wrong_map_value_type", func(t *testing.T) {
-				client := newClient(t)
-				tool := processDataTool(t, client)
-
-				// Attempt to invoke the tool with an incorrect type in a map value.
-				_, err := tool.Run(testToolCtx, map[string]any{
-					"execution_context": map[string]any{"env": "staging"},
-					"user_scores": map[string]any{
-						"user4": "not-an-integer",
-					},
-				})
-
-				// Assert that an error was returned.
-				require.Error(t, err, "Expected an error for wrong map value type")
-				assert.Contains(t, err.Error(), "expects an integer, but got string", "Error message should indicate a validation failure")
-			})
+			}
 		})
 	}
 }

--- a/tbgenkit/tbgenkit_setup_test.go
+++ b/tbgenkit/tbgenkit_setup_test.go
@@ -43,6 +43,14 @@ func getEnvVar(key string) string {
 	return value
 }
 
+func getEnvVarWithDefault(key, defaultValue string) string {
+	val := os.Getenv(key)
+	if val == "" {
+		return defaultValue
+	}
+	return val
+}
+
 func accessSecretVersion(ctx context.Context, projectID, secretID string, version string) string {
 	client, err := secretmanager.NewClient(ctx)
 	if err != nil {
@@ -104,15 +112,17 @@ func getAuthToken(ctx context.Context, clientID string) string {
 	return token.AccessToken
 }
 
-func setupAndStartToolboxServer(ctx context.Context, version, toolsFilePath string) *exec.Cmd {
-	log.Println("Downloading toolbox binary from GCS bucket...")
-	binaryURL := getToolboxBinaryURL(version)
+func setupAndStartToolboxServerWithFlags(ctx context.Context, version, toolsFilePath, port string, extraFlags ...string) *exec.Cmd {
 	binaryPath := "toolbox"
-	downloadBlob(ctx, "mcp-toolbox-for-databases", binaryURL, binaryPath)
-	log.Println("Toolbox binary downloaded successfully.")
+	if _, err := os.Stat(binaryPath); os.IsNotExist(err) {
+		log.Println("Downloading toolbox binary from GCS bucket...")
+		binaryURL := getToolboxBinaryURL(version)
+		downloadBlob(ctx, "mcp-toolbox-for-databases", binaryURL, binaryPath)
+		log.Println("Toolbox binary downloaded successfully.")
 
-	if err := os.Chmod(binaryPath, 0755); err != nil {
-		log.Fatalf("Failed to make toolbox binary executable: %v", err)
+		if err := os.Chmod(binaryPath, 0755); err != nil {
+			log.Fatalf("Failed to make toolbox binary executable: %v", err)
+		}
 	}
 
 	absBinaryPath, err := filepath.Abs(binaryPath)
@@ -120,24 +130,24 @@ func setupAndStartToolboxServer(ctx context.Context, version, toolsFilePath stri
 		log.Fatalf("Failed to get absolute path for toolbox binary: %v", err)
 	}
 
-	log.Println("Starting toolbox server process...")
-	cmd := exec.Command(absBinaryPath, "--tools-file", toolsFilePath)
+	args := []string{"--tools-file", toolsFilePath, "--port", port}
+	args = append(args, extraFlags...)
+
+	log.Printf("Starting toolbox server process on port %s with args %v...", port, args)
+	cmd := exec.Command(absBinaryPath, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
 	if err := cmd.Start(); err != nil {
-		log.Fatalf("Failed to start toolbox server: %v", err)
+		log.Fatalf("Failed to start toolbox server on port %s: %v", port, err)
 	}
 
-	log.Println("Waiting for server to initialize...")
-	// A more robust way to check for server readiness is to poll the health endpoint.
-	// For now, Sleep is a simple way to wait.
 	time.Sleep(5 * time.Second)
 
 	if cmd.ProcessState != nil && cmd.ProcessState.Exited() {
-		log.Fatalf("Toolbox server failed to start and exited with code: %d", cmd.ProcessState.ExitCode())
+		log.Fatalf("Toolbox server failed to start on port %s and exited with code: %d", port, cmd.ProcessState.ExitCode())
 	}
 
-	log.Println("Toolbox server started successfully.")
+	log.Printf("Toolbox server started successfully on port %s.", port)
 	return cmd
 }

--- a/tbgenkit/tbgenkit_test.go
+++ b/tbgenkit/tbgenkit_test.go
@@ -62,6 +62,23 @@ var protocolsToTest = []protocolTestCase{
 	{name: "MCP Alias (Latest)", protocol: core.MCP},
 }
 
+const (
+	DefaultPortStable      = "5000"
+	DefaultPortDraft       = "5001"
+	DefaultServerURLStable = "http://localhost:5000"
+	DefaultServerURLDraft  = "http://localhost:5001"
+)
+
+func getTestServerURLs() []string {
+	if os.Getenv("TOOLBOX_SERVER_URL") != "" {
+		return []string{os.Getenv("TOOLBOX_SERVER_URL")}
+	}
+	return []string{
+		getEnvVarWithDefault("TOOLBOX_SERVER_URL_STABLE", DefaultServerURLStable),
+		getEnvVarWithDefault("TOOLBOX_SERVER_URL_DRAFT", DefaultServerURLDraft),
+	}
+}
+
 func TestMain(m *testing.M) {
 	ctx := context.Background()
 	log.Println("Starting E2E test setup...")
@@ -86,800 +103,826 @@ func TestMain(m *testing.M) {
 	toolsFilePath := toolsFile.Name()
 	defer os.Remove(toolsFilePath) // Ensure cleanup
 
-	// Download and start the toolbox server
-	cmd := setupAndStartToolboxServer(ctx, toolboxVersion, toolsFilePath)
+	// Download and start both stable and draft toolbox servers
+	cmdStable := setupAndStartToolboxServerWithFlags(ctx, toolboxVersion, toolsFilePath, DefaultPortStable)
+	cmdDraft := setupAndStartToolboxServerWithFlags(ctx, toolboxVersion, toolsFilePath, DefaultPortDraft, "--enable-draft-specs")
 
 	// --- 2. Run Tests ---
 	log.Println("Setup complete. Running tests...")
 	exitCode := m.Run()
 
 	// --- 3. Teardown Phase ---
-	log.Println("Tearing down toolbox server...")
-	if err := cmd.Process.Kill(); err != nil {
-		log.Printf("Failed to kill toolbox server process: %v", err)
+	log.Println("Tearing down toolbox servers...")
+	if err := cmdStable.Process.Kill(); err != nil {
+		log.Printf("Failed to kill stable toolbox server process: %v", err)
 	}
-	_ = cmd.Wait() // Clean up the process resources
+	_ = cmdStable.Wait()
+
+	if err := cmdDraft.Process.Kill(); err != nil {
+		log.Printf("Failed to kill draft toolbox server process: %v", err)
+	}
+	_ = cmdDraft.Wait()
 
 	os.Exit(exitCode)
 }
 
 func TestToGenkitTool(t *testing.T) {
-	for _, proto := range protocolsToTest {
-		t.Run(proto.name, func(t *testing.T) {
-			// Helper to create a new client for each sub-test, like a function-scoped fixture
-			newClient := func(t *testing.T) *core.ToolboxClient {
-				opts := []core.ClientOption{}
-				if !proto.isDefault {
-					opts = append(opts, core.WithProtocol(proto.protocol))
-				}
-				client, err := core.NewToolboxClient("http://localhost:5000", opts...)
-				require.NoError(t, err, "Failed to create ToolboxClient")
-				return client
+	for _, serverURL := range getTestServerURLs() {
+		t.Run("server_"+serverURL, func(t *testing.T) {
+			for _, proto := range protocolsToTest {
+				t.Run(proto.name, func(t *testing.T) {
+					// Helper to create a new client for each sub-test, like a function-scoped fixture
+					newClient := func(t *testing.T) *core.ToolboxClient {
+						opts := []core.ClientOption{}
+						if !proto.isDefault {
+							opts = append(opts, core.WithProtocol(proto.protocol))
+						}
+						client, err := core.NewToolboxClient(serverURL, opts...)
+						require.NoError(t, err, "Failed to create ToolboxClient")
+						return client
+					}
+
+					ctx := context.Background()
+
+					newGenkit := func() *genkit.Genkit {
+						g := genkit.Init(ctx)
+						return g
+					}
+
+					// Helper to load the get-n-rows tool
+					getNRowsTool := func(t *testing.T, client *core.ToolboxClient) *core.ToolboxTool {
+						tool, err := client.LoadTool("get-n-rows", ctx)
+						require.NoError(t, err, "Failed to load tool 'get-n-rows'")
+						require.Equal(t, "get-n-rows", tool.Name())
+						return tool
+					}
+
+					t.Run("SuccessfulConversionAndExecution", func(t *testing.T) {
+						client := newClient(t)
+						tool := getNRowsTool(t, client)
+						g := newGenkit()
+
+						genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
+						if err != nil {
+							t.Fatalf("ToGenkitTool returned unexpected error: %v", err)
+						}
+						if genkitTool == nil {
+							t.Fatal("ToGenkitTool returned nil tool, expected as valid tool")
+						}
+
+						// Verify the properties of the returned genkitTool
+						if genkitTool.Name() != tool.Name() {
+							t.Errorf("Returned genkit tool name mismatch: got %q, want %q", genkitTool.Name(), tool.Name())
+						}
+
+						// Execute the wrapped function and verify its output
+						inputForExecute := map[string]any{"num_rows": "2"}
+						actualResult, execErr := genkitTool.RunRaw(ctx, inputForExecute)
+						if execErr != nil {
+							t.Errorf("ExecuteFn returned unexpected error: %v", execErr)
+						}
+						respStr, ok := actualResult.(string)
+						require.True(t, ok, "Response should be a string")
+						assert.Contains(t, respStr, "row1")
+						assert.Contains(t, respStr, "row2")
+						assert.NotContains(t, respStr, "row3")
+					})
+
+					// --- Test Case 2: tool is nil ---
+					t.Run("NilTool", func(t *testing.T) {
+						g := newGenkit()
+						genkitTool, err := tbgenkit.ToGenkitTool(nil, g)
+						if err == nil {
+							t.Fatal("Expected error when tool is nil, got nil")
+						}
+						if genkitTool != nil {
+							t.Error("Expected nil tool when tool is nil, got non-nil")
+						}
+						expectedErrStr := "error: ToGenkitTool received a nil core.ToolboxTool pointer"
+						if err.Error() != expectedErrStr {
+							t.Errorf("Unexpected error message for nil tool: got %q, want %q", err.Error(), expectedErrStr)
+						}
+					})
+
+					// --- Test Case 3: g is nil ---
+					t.Run("NilGenkit", func(t *testing.T) {
+						client := newClient(t)
+						tool := getNRowsTool(t, client)
+						genkitTool, err := tbgenkit.ToGenkitTool(tool, nil)
+						if err == nil {
+							t.Fatal("Expected error when Genkit instance is nil, got nil")
+						}
+						if genkitTool != nil {
+							t.Error("Expected nil tool when Genkit instance is nil, got non-nil")
+						}
+						expectedErrStr := "error: ToGenkitTool received a nil genkit.Genkit pointer"
+						if err.Error() != expectedErrStr {
+							t.Errorf("Unexpected error message for nil Genkit: got %q, want %q", err.Error(), expectedErrStr)
+						}
+					})
+
+				})
 			}
-
-			ctx := context.Background()
-
-			newGenkit := func() *genkit.Genkit {
-				g := genkit.Init(ctx)
-				return g
-			}
-
-			// Helper to load the get-n-rows tool
-			getNRowsTool := func(t *testing.T, client *core.ToolboxClient) *core.ToolboxTool {
-				tool, err := client.LoadTool("get-n-rows", ctx)
-				require.NoError(t, err, "Failed to load tool 'get-n-rows'")
-				require.Equal(t, "get-n-rows", tool.Name())
-				return tool
-			}
-
-			t.Run("SuccessfulConversionAndExecution", func(t *testing.T) {
-				client := newClient(t)
-				tool := getNRowsTool(t, client)
-				g := newGenkit()
-
-				genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
-				if err != nil {
-					t.Fatalf("ToGenkitTool returned unexpected error: %v", err)
-				}
-				if genkitTool == nil {
-					t.Fatal("ToGenkitTool returned nil tool, expected as valid tool")
-				}
-
-				// Verify the properties of the returned genkitTool
-				if genkitTool.Name() != tool.Name() {
-					t.Errorf("Returned genkit tool name mismatch: got %q, want %q", genkitTool.Name(), tool.Name())
-				}
-
-				// Execute the wrapped function and verify its output
-				inputForExecute := map[string]any{"num_rows": "2"}
-				actualResult, execErr := genkitTool.RunRaw(ctx, inputForExecute)
-				if execErr != nil {
-					t.Errorf("ExecuteFn returned unexpected error: %v", execErr)
-				}
-				respStr, ok := actualResult.(string)
-				require.True(t, ok, "Response should be a string")
-				assert.Contains(t, respStr, "row1")
-				assert.Contains(t, respStr, "row2")
-				assert.NotContains(t, respStr, "row3")
-			})
-
-			// --- Test Case 2: tool is nil ---
-			t.Run("NilTool", func(t *testing.T) {
-				g := newGenkit()
-				genkitTool, err := tbgenkit.ToGenkitTool(nil, g)
-				if err == nil {
-					t.Fatal("Expected error when tool is nil, got nil")
-				}
-				if genkitTool != nil {
-					t.Error("Expected nil tool when tool is nil, got non-nil")
-				}
-				expectedErrStr := "error: ToGenkitTool received a nil core.ToolboxTool pointer"
-				if err.Error() != expectedErrStr {
-					t.Errorf("Unexpected error message for nil tool: got %q, want %q", err.Error(), expectedErrStr)
-				}
-			})
-
-			// --- Test Case 3: g is nil ---
-			t.Run("NilGenkit", func(t *testing.T) {
-				client := newClient(t)
-				tool := getNRowsTool(t, client)
-				genkitTool, err := tbgenkit.ToGenkitTool(tool, nil)
-				if err == nil {
-					t.Fatal("Expected error when Genkit instance is nil, got nil")
-				}
-				if genkitTool != nil {
-					t.Error("Expected nil tool when Genkit instance is nil, got non-nil")
-				}
-				expectedErrStr := "error: ToGenkitTool received a nil genkit.Genkit pointer"
-				if err.Error() != expectedErrStr {
-					t.Errorf("Unexpected error message for nil Genkit: got %q, want %q", err.Error(), expectedErrStr)
-				}
-			})
-
 		})
 	}
 }
 
 func TestToGenkitTool_BoundParams(t *testing.T) {
-	for _, proto := range protocolsToTest {
-		t.Run(proto.name, func(t *testing.T) {
-			// Helper to create a new client for each sub-test, like a function-scoped fixture
-			newClient := func(t *testing.T) *core.ToolboxClient {
-				opts := []core.ClientOption{}
-				if !proto.isDefault {
-					opts = append(opts, core.WithProtocol(proto.protocol))
-				}
-				client, err := core.NewToolboxClient("http://localhost:5000", opts...)
-				require.NoError(t, err, "Failed to create ToolboxClient")
-				return client
+	for _, serverURL := range getTestServerURLs() {
+		t.Run("server_"+serverURL, func(t *testing.T) {
+			for _, proto := range protocolsToTest {
+				t.Run(proto.name, func(t *testing.T) {
+					// Helper to create a new client for each sub-test, like a function-scoped fixture
+					newClient := func(t *testing.T) *core.ToolboxClient {
+						opts := []core.ClientOption{}
+						if !proto.isDefault {
+							opts = append(opts, core.WithProtocol(proto.protocol))
+						}
+						client, err := core.NewToolboxClient(serverURL, opts...)
+						require.NoError(t, err, "Failed to create ToolboxClient")
+						return client
+					}
+					ctx := context.Background()
+					newGenkit := func() *genkit.Genkit {
+						g := genkit.Init(ctx)
+						return g
+					}
+
+					// Helper to load the get-n-rows tool
+					getNRowsTool := func(t *testing.T, client *core.ToolboxClient) *core.ToolboxTool {
+						tool, err := client.LoadTool("get-n-rows", ctx)
+						require.NoError(t, err, "Failed to load tool 'get-n-rows'")
+						require.Equal(t, "get-n-rows", tool.Name())
+						return tool
+					}
+
+					t.Run("WithBoundParams", func(t *testing.T) {
+						client := newClient(t)
+						tool := getNRowsTool(t, client)
+						g := newGenkit()
+
+						boundTool, err := tool.ToolFrom(core.WithBindParamString("num_rows", "3"))
+						require.NoError(t, err)
+
+						genkitTool, err := tbgenkit.ToGenkitTool(boundTool, g)
+						if err != nil {
+							t.Fatalf("ToGenkitTool failed: %v", err)
+						}
+
+						schema := genkitTool.Definition().InputSchema
+
+						expectedSchema := map[string]any{
+							"type":       "object",
+							"properties": struct{}{},
+						}
+
+						if reflect.DeepEqual(schema, expectedSchema) {
+							t.Fatal("Input schema does not match")
+						}
+
+						result, err := genkitTool.RunRaw(ctx, map[string]any{})
+
+						require.NoError(t, err)
+
+						respStr, ok := result.(string)
+						require.True(t, ok)
+						assert.Contains(t, respStr, "row1")
+						assert.Contains(t, respStr, "row2")
+						assert.Contains(t, respStr, "row3")
+						assert.NotContains(t, respStr, "row4")
+					})
+
+					t.Run("WithBoundParams Callable", func(t *testing.T) {
+						client := newClient(t)
+						tool := getNRowsTool(t, client)
+						callable := func() (string, error) {
+							return "3", nil
+						}
+						g := newGenkit()
+
+						boundTool, err := tool.ToolFrom(core.WithBindParamStringFunc("num_rows", callable))
+						require.NoError(t, err)
+
+						genkitTool, err := tbgenkit.ToGenkitTool(boundTool, g)
+						if err != nil {
+							t.Fatalf("ToGenkitTool failed: %v", err)
+						}
+
+						schema := genkitTool.Definition().InputSchema
+
+						expectedSchema := map[string]any{
+							"type":       "object",
+							"properties": struct{}{},
+						}
+
+						if reflect.DeepEqual(schema, expectedSchema) {
+							t.Fatal("Input schema does not match")
+						}
+
+						result, err := genkitTool.RunRaw(ctx, map[string]any{})
+
+						require.NoError(t, err)
+
+						respStr, ok := result.(string)
+						require.True(t, ok)
+						assert.Contains(t, respStr, "row1")
+						assert.Contains(t, respStr, "row2")
+						assert.Contains(t, respStr, "row3")
+						assert.NotContains(t, respStr, "row4")
+					})
+				})
 			}
-			ctx := context.Background()
-			newGenkit := func() *genkit.Genkit {
-				g := genkit.Init(ctx)
-				return g
-			}
-
-			// Helper to load the get-n-rows tool
-			getNRowsTool := func(t *testing.T, client *core.ToolboxClient) *core.ToolboxTool {
-				tool, err := client.LoadTool("get-n-rows", ctx)
-				require.NoError(t, err, "Failed to load tool 'get-n-rows'")
-				require.Equal(t, "get-n-rows", tool.Name())
-				return tool
-			}
-
-			t.Run("WithBoundParams", func(t *testing.T) {
-				client := newClient(t)
-				tool := getNRowsTool(t, client)
-				g := newGenkit()
-
-				boundTool, err := tool.ToolFrom(core.WithBindParamString("num_rows", "3"))
-				require.NoError(t, err)
-
-				genkitTool, err := tbgenkit.ToGenkitTool(boundTool, g)
-				if err != nil {
-					t.Fatalf("ToGenkitTool failed: %v", err)
-				}
-
-				schema := genkitTool.Definition().InputSchema
-
-				expectedSchema := map[string]any{
-					"type":       "object",
-					"properties": struct{}{},
-				}
-
-				if reflect.DeepEqual(schema, expectedSchema) {
-					t.Fatal("Input schema does not match")
-				}
-
-				result, err := genkitTool.RunRaw(ctx, map[string]any{})
-
-				require.NoError(t, err)
-
-				respStr, ok := result.(string)
-				require.True(t, ok)
-				assert.Contains(t, respStr, "row1")
-				assert.Contains(t, respStr, "row2")
-				assert.Contains(t, respStr, "row3")
-				assert.NotContains(t, respStr, "row4")
-			})
-
-			t.Run("WithBoundParams Callable", func(t *testing.T) {
-				client := newClient(t)
-				tool := getNRowsTool(t, client)
-				callable := func() (string, error) {
-					return "3", nil
-				}
-				g := newGenkit()
-
-				boundTool, err := tool.ToolFrom(core.WithBindParamStringFunc("num_rows", callable))
-				require.NoError(t, err)
-
-				genkitTool, err := tbgenkit.ToGenkitTool(boundTool, g)
-				if err != nil {
-					t.Fatalf("ToGenkitTool failed: %v", err)
-				}
-
-				schema := genkitTool.Definition().InputSchema
-
-				expectedSchema := map[string]any{
-					"type":       "object",
-					"properties": struct{}{},
-				}
-
-				if reflect.DeepEqual(schema, expectedSchema) {
-					t.Fatal("Input schema does not match")
-				}
-
-				result, err := genkitTool.RunRaw(ctx, map[string]any{})
-
-				require.NoError(t, err)
-
-				respStr, ok := result.(string)
-				require.True(t, ok)
-				assert.Contains(t, respStr, "row1")
-				assert.Contains(t, respStr, "row2")
-				assert.Contains(t, respStr, "row3")
-				assert.NotContains(t, respStr, "row4")
-			})
 		})
 	}
 }
 
 func TestToGenkitTool_Auth(t *testing.T) {
-	for _, proto := range protocolsToTest {
-		t.Run(proto.name, func(t *testing.T) {
-			// Helper to create a new client for each sub-test, like a function-scoped fixture
-			newClient := func(t *testing.T) *core.ToolboxClient {
-				opts := []core.ClientOption{}
-				if !proto.isDefault {
-					opts = append(opts, core.WithProtocol(proto.protocol))
-				}
-				client, err := core.NewToolboxClient("http://localhost:5000", opts...)
-				require.NoError(t, err, "Failed to create ToolboxClient")
-				return client
+	for _, serverURL := range getTestServerURLs() {
+		t.Run("server_"+serverURL, func(t *testing.T) {
+			for _, proto := range protocolsToTest {
+				t.Run(proto.name, func(t *testing.T) {
+					// Helper to create a new client for each sub-test, like a function-scoped fixture
+					newClient := func(t *testing.T) *core.ToolboxClient {
+						opts := []core.ClientOption{}
+						if !proto.isDefault {
+							opts = append(opts, core.WithProtocol(proto.protocol))
+						}
+						client, err := core.NewToolboxClient(serverURL, opts...)
+						require.NoError(t, err, "Failed to create ToolboxClient")
+						return client
+					}
+
+					// Helper to create a static token source from a string token
+					staticTokenSource := func(token string) oauth2.TokenSource {
+						return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+					}
+					ctx := context.Background()
+					newGenkit := func() *genkit.Genkit {
+						g := genkit.Init(ctx)
+						return g
+					}
+
+					t.Run("test_run_tool_no_auth", func(t *testing.T) {
+						client := newClient(t)
+						tool, err := client.LoadTool("get-row-by-id-auth", ctx)
+						require.NoError(t, err)
+						g := newGenkit()
+
+						genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
+						if err != nil {
+							t.Fatalf("ToGenkitTool failed: %v", err)
+						}
+
+						_, err = genkitTool.RunRaw(ctx, map[string]any{"id": "2"})
+						require.Error(t, err)
+						assert.Contains(t, err.Error(), "permission error: auth service 'my-test-auth' is required")
+					})
+
+					t.Run("test_run_tool_wrong_auth", func(t *testing.T) {
+						client := newClient(t)
+						tool, err := client.LoadTool("get-row-by-id-auth", ctx)
+						require.NoError(t, err)
+						g := newGenkit()
+
+						authedTool, err := tool.ToolFrom(
+							core.WithAuthTokenSource("my-test-auth", staticTokenSource(authToken2)),
+						)
+						require.NoError(t, err)
+
+						genkitTool, err := tbgenkit.ToGenkitTool(authedTool, g)
+						if err != nil {
+							t.Fatalf("ToGenkitTool failed: %v", err)
+						}
+
+						_, err = genkitTool.RunRaw(ctx, map[string]any{"id": "2"})
+						require.Error(t, err)
+						assert.Contains(t, err.Error(), "unauthorized Tool call")
+					})
+
+					t.Run("test_run_tool_auth", func(t *testing.T) {
+						client := newClient(t)
+						tool, err := client.LoadTool("get-row-by-id-auth", ctx,
+							core.WithAuthTokenSource("my-test-auth", staticTokenSource(authToken1)),
+						)
+						require.NoError(t, err)
+						g := newGenkit()
+
+						genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
+						if err != nil {
+							t.Fatalf("ToGenkitTool failed: %v", err)
+						}
+
+						response, err := genkitTool.RunRaw(ctx, map[string]any{"id": "2"})
+						require.NoError(t, err)
+
+						respStr, ok := response.(string)
+						require.True(t, ok)
+						assert.Contains(t, respStr, "row2")
+					})
+
+					t.Run("test_run_tool_param_auth_no_auth", func(t *testing.T) {
+						client := newClient(t)
+						tool, err := client.LoadTool("get-row-by-email-auth", ctx)
+						require.NoError(t, err)
+						g := newGenkit()
+
+						genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
+						if err != nil {
+							t.Fatalf("ToGenkitTool failed: %v", err)
+						}
+
+						_, err = genkitTool.RunRaw(ctx, map[string]any{})
+						require.Error(t, err)
+						assert.Contains(t, err.Error(), "permission error: auth service 'my-test-auth' is required")
+					})
+
+					t.Run("test_run_tool_param_auth", func(t *testing.T) {
+						client := newClient(t)
+						tool, err := client.LoadTool("get-row-by-email-auth", ctx,
+							core.WithAuthTokenSource("my-test-auth", staticTokenSource(authToken1)),
+						)
+						require.NoError(t, err)
+						g := newGenkit()
+
+						genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
+						if err != nil {
+							t.Fatalf("ToGenkitTool failed: %v", err)
+						}
+
+						response, err := genkitTool.RunRaw(ctx, map[string]any{})
+						require.NoError(t, err)
+
+						respStr, ok := response.(string)
+						require.True(t, ok)
+						assert.Contains(t, respStr, "row4")
+						assert.Contains(t, respStr, "row5")
+						assert.Contains(t, respStr, "row6")
+					})
+
+					t.Run("test_run_tool_param_auth_no_field", func(t *testing.T) {
+						client := newClient(t)
+						tool, err := client.LoadTool("get-row-by-content-auth", ctx,
+							core.WithAuthTokenSource("my-test-auth", staticTokenSource(authToken1)),
+						)
+						require.NoError(t, err)
+
+						g := newGenkit()
+
+						genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
+						if err != nil {
+							t.Fatalf("ToGenkitTool failed: %v", err)
+						}
+
+						_, err = genkitTool.RunRaw(ctx, map[string]any{})
+						require.Error(t, err)
+						assert.Contains(t, err.Error(), "no field named row_data in claims")
+					})
+
+					t.Run("test_run_tool_with_failing_token_source", func(t *testing.T) {
+						client := newClient(t)
+						tool, err := client.LoadTool("get-row-by-id-auth", ctx,
+							core.WithAuthTokenSource("my-test-auth", &failingTokenSource{}),
+						)
+						require.NoError(t, err)
+
+						g := newGenkit()
+
+						genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
+						if err != nil {
+							t.Fatalf("ToGenkitTool failed: %v", err)
+						}
+
+						_, err = genkitTool.RunRaw(ctx, map[string]any{"id": "2"})
+						require.Error(t, err)
+						assert.Contains(t, err.Error(), "failed to resolve auth token my-test-auth")
+						assert.Contains(t, err.Error(), "token source failed as designed")
+					})
+				})
 			}
-
-			// Helper to create a static token source from a string token
-			staticTokenSource := func(token string) oauth2.TokenSource {
-				return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
-			}
-			ctx := context.Background()
-			newGenkit := func() *genkit.Genkit {
-				g := genkit.Init(ctx)
-				return g
-			}
-
-			t.Run("test_run_tool_no_auth", func(t *testing.T) {
-				client := newClient(t)
-				tool, err := client.LoadTool("get-row-by-id-auth", ctx)
-				require.NoError(t, err)
-				g := newGenkit()
-
-				genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
-				if err != nil {
-					t.Fatalf("ToGenkitTool failed: %v", err)
-				}
-
-				_, err = genkitTool.RunRaw(ctx, map[string]any{"id": "2"})
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "permission error: auth service 'my-test-auth' is required")
-			})
-
-			t.Run("test_run_tool_wrong_auth", func(t *testing.T) {
-				client := newClient(t)
-				tool, err := client.LoadTool("get-row-by-id-auth", ctx)
-				require.NoError(t, err)
-				g := newGenkit()
-
-				authedTool, err := tool.ToolFrom(
-					core.WithAuthTokenSource("my-test-auth", staticTokenSource(authToken2)),
-				)
-				require.NoError(t, err)
-
-				genkitTool, err := tbgenkit.ToGenkitTool(authedTool, g)
-				if err != nil {
-					t.Fatalf("ToGenkitTool failed: %v", err)
-				}
-
-				_, err = genkitTool.RunRaw(ctx, map[string]any{"id": "2"})
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "unauthorized Tool call")
-			})
-
-			t.Run("test_run_tool_auth", func(t *testing.T) {
-				client := newClient(t)
-				tool, err := client.LoadTool("get-row-by-id-auth", ctx,
-					core.WithAuthTokenSource("my-test-auth", staticTokenSource(authToken1)),
-				)
-				require.NoError(t, err)
-				g := newGenkit()
-
-				genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
-				if err != nil {
-					t.Fatalf("ToGenkitTool failed: %v", err)
-				}
-
-				response, err := genkitTool.RunRaw(ctx, map[string]any{"id": "2"})
-				require.NoError(t, err)
-
-				respStr, ok := response.(string)
-				require.True(t, ok)
-				assert.Contains(t, respStr, "row2")
-			})
-
-			t.Run("test_run_tool_param_auth_no_auth", func(t *testing.T) {
-				client := newClient(t)
-				tool, err := client.LoadTool("get-row-by-email-auth", ctx)
-				require.NoError(t, err)
-				g := newGenkit()
-
-				genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
-				if err != nil {
-					t.Fatalf("ToGenkitTool failed: %v", err)
-				}
-
-				_, err = genkitTool.RunRaw(ctx, map[string]any{})
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "permission error: auth service 'my-test-auth' is required")
-			})
-
-			t.Run("test_run_tool_param_auth", func(t *testing.T) {
-				client := newClient(t)
-				tool, err := client.LoadTool("get-row-by-email-auth", ctx,
-					core.WithAuthTokenSource("my-test-auth", staticTokenSource(authToken1)),
-				)
-				require.NoError(t, err)
-				g := newGenkit()
-
-				genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
-				if err != nil {
-					t.Fatalf("ToGenkitTool failed: %v", err)
-				}
-
-				response, err := genkitTool.RunRaw(ctx, map[string]any{})
-				require.NoError(t, err)
-
-				respStr, ok := response.(string)
-				require.True(t, ok)
-				assert.Contains(t, respStr, "row4")
-				assert.Contains(t, respStr, "row5")
-				assert.Contains(t, respStr, "row6")
-			})
-
-			t.Run("test_run_tool_param_auth_no_field", func(t *testing.T) {
-				client := newClient(t)
-				tool, err := client.LoadTool("get-row-by-content-auth", ctx,
-					core.WithAuthTokenSource("my-test-auth", staticTokenSource(authToken1)),
-				)
-				require.NoError(t, err)
-
-				g := newGenkit()
-
-				genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
-				if err != nil {
-					t.Fatalf("ToGenkitTool failed: %v", err)
-				}
-
-				_, err = genkitTool.RunRaw(ctx, map[string]any{})
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "no field named row_data in claims")
-			})
-
-			t.Run("test_run_tool_with_failing_token_source", func(t *testing.T) {
-				client := newClient(t)
-				tool, err := client.LoadTool("get-row-by-id-auth", ctx,
-					core.WithAuthTokenSource("my-test-auth", &failingTokenSource{}),
-				)
-				require.NoError(t, err)
-
-				g := newGenkit()
-
-				genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
-				if err != nil {
-					t.Fatalf("ToGenkitTool failed: %v", err)
-				}
-
-				_, err = genkitTool.RunRaw(ctx, map[string]any{"id": "2"})
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "failed to resolve auth token my-test-auth")
-				assert.Contains(t, err.Error(), "token source failed as designed")
-			})
 		})
 	}
 }
 
 func TestToGenkitTool_OptionalParams(t *testing.T) {
-	for _, proto := range protocolsToTest {
-		t.Run(proto.name, func(t *testing.T) {
-			// Helper to create a new client for each sub-test, like a function-scoped fixture
-			newClient := func(t *testing.T) *core.ToolboxClient {
-				opts := []core.ClientOption{}
-				if !proto.isDefault {
-					opts = append(opts, core.WithProtocol(proto.protocol))
-				}
-				client, err := core.NewToolboxClient("http://localhost:5000", opts...)
-				require.NoError(t, err, "Failed to create ToolboxClient")
-				return client
+	for _, serverURL := range getTestServerURLs() {
+		t.Run("server_"+serverURL, func(t *testing.T) {
+			for _, proto := range protocolsToTest {
+				t.Run(proto.name, func(t *testing.T) {
+					// Helper to create a new client for each sub-test, like a function-scoped fixture
+					newClient := func(t *testing.T) *core.ToolboxClient {
+						opts := []core.ClientOption{}
+						if !proto.isDefault {
+							opts = append(opts, core.WithProtocol(proto.protocol))
+						}
+						client, err := core.NewToolboxClient(serverURL, opts...)
+						require.NoError(t, err, "Failed to create ToolboxClient")
+						return client
+					}
+					ctx := context.Background()
+					newGenkit := func() *genkit.Genkit {
+						g := genkit.Init(ctx)
+						return g
+					}
+
+					// Helper to load the search-rows tool
+					searchRowsTool := func(t *testing.T, client *core.ToolboxClient) *core.ToolboxTool {
+						tool, err := client.LoadTool("search-rows", ctx)
+						require.NoError(t, err, "Failed to load tool 'search-rows'")
+						return tool
+					}
+
+					t.Run("test_tool_schema_is_correct", func(t *testing.T) {
+						client := newClient(t)
+						tool := searchRowsTool(t, client)
+						g := newGenkit()
+
+						genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
+						if err != nil {
+							t.Fatalf("ToGenkitTool failed: %v", err)
+						}
+
+						expectedSchema := map[string]any{
+							"type": "object",
+							"properties": map[string]any{
+								"data": map[string]any{
+									"description": "The row to narrow down the search.",
+									"type":        "string",
+									"default":     "row2",
+								},
+								"email": map[string]any{
+									"description": "The email to search for.",
+									"type":        "string",
+								},
+								"id": map[string]any{
+									"description": "The id to narrow down the search.",
+									"type":        "integer",
+									"default":     0.0, // TODO: Re-confirm Genkit bug which parses integer as float https://github.com/genkit-ai/genkit/issues/3414
+								}},
+							"required": []any{"email"},
+						}
+
+						schema := genkitTool.Definition().InputSchema
+
+						assert.Equal(t, schema, expectedSchema)
+					})
+
+					t.Run("test_run_tool_omitting_optionals", func(t *testing.T) {
+						client := newClient(t)
+						tool := searchRowsTool(t, client)
+
+						g := newGenkit()
+
+						genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
+						if err != nil {
+							t.Fatalf("ToGenkitTool failed: %v", err)
+						}
+
+						// Test case 1: Optional params are completely omitted
+						response1, err1 := genkitTool.RunRaw(ctx, map[string]any{
+							"email": "twishabansal@google.com",
+						})
+						require.NoError(t, err1)
+						respStr1, ok1 := response1.(string)
+						require.True(t, ok1)
+						assert.Contains(t, respStr1, `"email":"twishabansal@google.com"`)
+						assert.Contains(t, respStr1, "row2")
+						assert.NotContains(t, respStr1, "row3")
+
+						// Test case 2: Optional params are explicitly nil
+						// This should produce the same result as omitting them
+						response2, err2 := genkitTool.RunRaw(ctx, map[string]any{
+							"email": "twishabansal@google.com",
+							"data":  nil,
+							"id":    nil,
+						})
+						require.NoError(t, err2)
+						respStr2, ok2 := response2.(string)
+						require.True(t, ok2)
+						assert.Equal(t, respStr1, respStr2)
+					})
+
+					t.Run("test_run_tool_with_all_params_provided", func(t *testing.T) {
+						client := newClient(t)
+						tool := searchRowsTool(t, client)
+
+						g := newGenkit()
+
+						genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
+						if err != nil {
+							t.Fatalf("ToGenkitTool failed: %v", err)
+						}
+
+						response, err := genkitTool.RunRaw(ctx, map[string]any{
+							"email": "twishabansal@google.com",
+							"data":  "row3",
+							"id":    3,
+						})
+						require.NoError(t, err)
+						respStr, ok := response.(string)
+						require.True(t, ok)
+						assert.Contains(t, respStr, `"email":"twishabansal@google.com"`)
+						assert.Contains(t, respStr, `"id":3`)
+						assert.Contains(t, respStr, "row3")
+						assert.NotContains(t, respStr, "row2")
+					})
+
+					t.Run("test_run_tool_missing_required_param", func(t *testing.T) {
+						client := newClient(t)
+						tool := searchRowsTool(t, client)
+						g := newGenkit()
+
+						genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
+						if err != nil {
+							t.Fatalf("ToGenkitTool failed: %v", err)
+						}
+						_, err = genkitTool.RunRaw(ctx, map[string]any{
+							"data": "row5",
+							"id":   5,
+						})
+						require.Error(t, err)
+						assert.Contains(t, err.Error(), "email is required")
+					})
+
+					t.Run("test_run_tool_required_param_is_nil", func(t *testing.T) {
+						client := newClient(t)
+						tool := searchRowsTool(t, client)
+
+						g := newGenkit()
+
+						genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
+						if err != nil {
+							t.Fatalf("ToGenkitTool failed: %v", err)
+						}
+
+						_, err = genkitTool.RunRaw(ctx, map[string]any{
+							"email": nil,
+							"id":    5,
+						})
+						require.Error(t, err)
+						assert.Contains(t, err.Error(), "email is required")
+					})
+
+					// Corresponds to tests that check server-side logic by providing data that doesn't match
+					t.Run("test_run_tool_with_non_matching_data", func(t *testing.T) {
+						client := newClient(t)
+						tool := searchRowsTool(t, client)
+
+						g := newGenkit()
+
+						genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
+						if err != nil {
+							t.Fatalf("ToGenkitTool failed: %v", err)
+						}
+
+						// Test with a different email
+						response, err := genkitTool.RunRaw(ctx, map[string]any{
+							"email": "anubhavdhawan@google.com",
+							"id":    3,
+							"data":  "row3",
+						})
+						require.NoError(t, err)
+						assert.Equal(t, "null", response, "Response should be null for non-matching email")
+
+						// Test with different data
+						response, err = genkitTool.RunRaw(ctx, map[string]any{
+							"email": "twishabansal@google.com",
+							"id":    3,
+							"data":  "row4", // This data doesn't match the id
+						})
+						require.NoError(t, err)
+						assert.Equal(t, "null", response, "Response should be null for non-matching data")
+					})
+
+					t.Run("test_run_tool_wrong_type_for_integer", func(t *testing.T) {
+						client := newClient(t)
+						tool := searchRowsTool(t, client)
+
+						g := newGenkit()
+
+						genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
+						if err != nil {
+							t.Fatalf("ToGenkitTool failed: %v", err)
+						}
+
+						_, err = genkitTool.RunRaw(ctx, map[string]any{
+							"email": "twishabansal@google.com",
+							"id":    "not-an-integer",
+						})
+						require.Error(t, err)
+						assert.Contains(t, err.Error(), "data did not match expected schema")
+					})
+
+					t.Run("test_run_tool_with_default_behavior", func(t *testing.T) {
+						client := newClient(t)
+						tool := searchRowsTool(t, client)
+
+						g := newGenkit()
+
+						genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
+						if err != nil {
+							t.Fatalf("ToGenkitTool failed: %v", err)
+						}
+
+						// Omit default params, ensure they fallback to defaults
+						response1, err1 := genkitTool.RunRaw(ctx, map[string]any{
+							"email": "twishabansal@google.com",
+						})
+						require.NoError(t, err1)
+						respStr1, ok1 := response1.(string)
+						require.True(t, ok1)
+						assert.Contains(t, respStr1, `"email":"twishabansal@google.com"`)
+						assert.Contains(t, respStr1, "row2")
+
+						// Override 'data' default
+						response2, err2 := genkitTool.RunRaw(ctx, map[string]any{
+							"email": "twishabansal@google.com",
+							"data":  "row3",
+						})
+						require.NoError(t, err2)
+						respStr2, ok2 := response2.(string)
+						require.True(t, ok2)
+						assert.Contains(t, respStr2, `"email":"twishabansal@google.com"`)
+						assert.Contains(t, respStr2, "row3")
+
+						// Override 'id' default
+						response3, err3 := genkitTool.RunRaw(ctx, map[string]any{
+							"email": "twishabansal@google.com",
+							"id":    4,
+						})
+						require.NoError(t, err3)
+						assert.Equal(t, "null", response3)
+					})
+				})
 			}
-			ctx := context.Background()
-			newGenkit := func() *genkit.Genkit {
-				g := genkit.Init(ctx)
-				return g
-			}
-
-			// Helper to load the search-rows tool
-			searchRowsTool := func(t *testing.T, client *core.ToolboxClient) *core.ToolboxTool {
-				tool, err := client.LoadTool("search-rows", ctx)
-				require.NoError(t, err, "Failed to load tool 'search-rows'")
-				return tool
-			}
-
-			t.Run("test_tool_schema_is_correct", func(t *testing.T) {
-				client := newClient(t)
-				tool := searchRowsTool(t, client)
-				g := newGenkit()
-
-				genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
-				if err != nil {
-					t.Fatalf("ToGenkitTool failed: %v", err)
-				}
-
-				expectedSchema := map[string]any{
-					"type": "object",
-					"properties": map[string]any{
-						"data": map[string]any{
-							"description": "The row to narrow down the search.",
-							"type":        "string",
-							"default":     "row2",
-						},
-						"email": map[string]any{
-							"description": "The email to search for.",
-							"type":        "string",
-						},
-						"id": map[string]any{
-							"description": "The id to narrow down the search.",
-							"type":        "integer",
-							"default":     0.0, // TODO: Re-confirm Genkit bug which parses integer as float https://github.com/genkit-ai/genkit/issues/3414
-						}},
-					"required": []any{"email"},
-				}
-
-				schema := genkitTool.Definition().InputSchema
-
-				assert.Equal(t, schema, expectedSchema)
-			})
-
-			t.Run("test_run_tool_omitting_optionals", func(t *testing.T) {
-				client := newClient(t)
-				tool := searchRowsTool(t, client)
-
-				g := newGenkit()
-
-				genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
-				if err != nil {
-					t.Fatalf("ToGenkitTool failed: %v", err)
-				}
-
-				// Test case 1: Optional params are completely omitted
-				response1, err1 := genkitTool.RunRaw(ctx, map[string]any{
-					"email": "twishabansal@google.com",
-				})
-				require.NoError(t, err1)
-				respStr1, ok1 := response1.(string)
-				require.True(t, ok1)
-				assert.Contains(t, respStr1, `"email":"twishabansal@google.com"`)
-				assert.Contains(t, respStr1, "row2")
-				assert.NotContains(t, respStr1, "row3")
-
-				// Test case 2: Optional params are explicitly nil
-				// This should produce the same result as omitting them
-				response2, err2 := genkitTool.RunRaw(ctx, map[string]any{
-					"email": "twishabansal@google.com",
-					"data":  nil,
-					"id":    nil,
-				})
-				require.NoError(t, err2)
-				respStr2, ok2 := response2.(string)
-				require.True(t, ok2)
-				assert.Equal(t, respStr1, respStr2)
-			})
-
-			t.Run("test_run_tool_with_all_params_provided", func(t *testing.T) {
-				client := newClient(t)
-				tool := searchRowsTool(t, client)
-
-				g := newGenkit()
-
-				genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
-				if err != nil {
-					t.Fatalf("ToGenkitTool failed: %v", err)
-				}
-
-				response, err := genkitTool.RunRaw(ctx, map[string]any{
-					"email": "twishabansal@google.com",
-					"data":  "row3",
-					"id":    3,
-				})
-				require.NoError(t, err)
-				respStr, ok := response.(string)
-				require.True(t, ok)
-				assert.Contains(t, respStr, `"email":"twishabansal@google.com"`)
-				assert.Contains(t, respStr, `"id":3`)
-				assert.Contains(t, respStr, "row3")
-				assert.NotContains(t, respStr, "row2")
-			})
-
-			t.Run("test_run_tool_missing_required_param", func(t *testing.T) {
-				client := newClient(t)
-				tool := searchRowsTool(t, client)
-				g := newGenkit()
-
-				genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
-				if err != nil {
-					t.Fatalf("ToGenkitTool failed: %v", err)
-				}
-				_, err = genkitTool.RunRaw(ctx, map[string]any{
-					"data": "row5",
-					"id":   5,
-				})
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "email is required")
-			})
-
-			t.Run("test_run_tool_required_param_is_nil", func(t *testing.T) {
-				client := newClient(t)
-				tool := searchRowsTool(t, client)
-
-				g := newGenkit()
-
-				genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
-				if err != nil {
-					t.Fatalf("ToGenkitTool failed: %v", err)
-				}
-
-				_, err = genkitTool.RunRaw(ctx, map[string]any{
-					"email": nil,
-					"id":    5,
-				})
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "email is required")
-			})
-
-			// Corresponds to tests that check server-side logic by providing data that doesn't match
-			t.Run("test_run_tool_with_non_matching_data", func(t *testing.T) {
-				client := newClient(t)
-				tool := searchRowsTool(t, client)
-
-				g := newGenkit()
-
-				genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
-				if err != nil {
-					t.Fatalf("ToGenkitTool failed: %v", err)
-				}
-
-				// Test with a different email
-				response, err := genkitTool.RunRaw(ctx, map[string]any{
-					"email": "anubhavdhawan@google.com",
-					"id":    3,
-					"data":  "row3",
-				})
-				require.NoError(t, err)
-				assert.Equal(t, "null", response, "Response should be null for non-matching email")
-
-				// Test with different data
-				response, err = genkitTool.RunRaw(ctx, map[string]any{
-					"email": "twishabansal@google.com",
-					"id":    3,
-					"data":  "row4", // This data doesn't match the id
-				})
-				require.NoError(t, err)
-				assert.Equal(t, "null", response, "Response should be null for non-matching data")
-			})
-
-			t.Run("test_run_tool_wrong_type_for_integer", func(t *testing.T) {
-				client := newClient(t)
-				tool := searchRowsTool(t, client)
-
-				g := newGenkit()
-
-				genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
-				if err != nil {
-					t.Fatalf("ToGenkitTool failed: %v", err)
-				}
-
-				_, err = genkitTool.RunRaw(ctx, map[string]any{
-					"email": "twishabansal@google.com",
-					"id":    "not-an-integer",
-				})
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "data did not match expected schema")
-			})
-
-			t.Run("test_run_tool_with_default_behavior", func(t *testing.T) {
-				client := newClient(t)
-				tool := searchRowsTool(t, client)
-
-				g := newGenkit()
-
-				genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
-				if err != nil {
-					t.Fatalf("ToGenkitTool failed: %v", err)
-				}
-
-				// Omit default params, ensure they fallback to defaults
-				response1, err1 := genkitTool.RunRaw(ctx, map[string]any{
-					"email": "twishabansal@google.com",
-				})
-				require.NoError(t, err1)
-				respStr1, ok1 := response1.(string)
-				require.True(t, ok1)
-				assert.Contains(t, respStr1, `"email":"twishabansal@google.com"`)
-				assert.Contains(t, respStr1, "row2")
-
-				// Override 'data' default
-				response2, err2 := genkitTool.RunRaw(ctx, map[string]any{
-					"email": "twishabansal@google.com",
-					"data":  "row3",
-				})
-				require.NoError(t, err2)
-				respStr2, ok2 := response2.(string)
-				require.True(t, ok2)
-				assert.Contains(t, respStr2, `"email":"twishabansal@google.com"`)
-				assert.Contains(t, respStr2, "row3")
-
-				// Override 'id' default
-				response3, err3 := genkitTool.RunRaw(ctx, map[string]any{
-					"email": "twishabansal@google.com",
-					"id":    4,
-				})
-				require.NoError(t, err3)
-				assert.Equal(t, "null", response3)
-			})
 		})
 	}
 }
 
 func TestToGenkitTool_MapParams(t *testing.T) {
-	for _, proto := range protocolsToTest {
-		t.Run(proto.name, func(t *testing.T) {
-			// Helper to create a new client for each sub-test, like a function-scoped fixture
-			newClient := func(t *testing.T) *core.ToolboxClient {
-				opts := []core.ClientOption{}
-				if !proto.isDefault {
-					opts = append(opts, core.WithProtocol(proto.protocol))
-				}
-				client, err := core.NewToolboxClient("http://localhost:5000", opts...)
-				require.NoError(t, err, "Failed to create ToolboxClient")
-				return client
-			}
-			ctx := context.Background()
-			newGenkit := func() *genkit.Genkit {
-				g := genkit.Init(ctx)
-				return g
-			}
+	for _, serverURL := range getTestServerURLs() {
+		t.Run("server_"+serverURL, func(t *testing.T) {
+			for _, proto := range protocolsToTest {
+				t.Run(proto.name, func(t *testing.T) {
+					// Helper to create a new client for each sub-test, like a function-scoped fixture
+					newClient := func(t *testing.T) *core.ToolboxClient {
+						opts := []core.ClientOption{}
+						if !proto.isDefault {
+							opts = append(opts, core.WithProtocol(proto.protocol))
+						}
+						client, err := core.NewToolboxClient(serverURL, opts...)
+						require.NoError(t, err, "Failed to create ToolboxClient")
+						return client
+					}
+					ctx := context.Background()
+					newGenkit := func() *genkit.Genkit {
+						g := genkit.Init(ctx)
+						return g
+					}
 
-			// Helper to load the process-data tool
-			processDataTool := func(t *testing.T, client *core.ToolboxClient) *core.ToolboxTool {
-				tool, err := client.LoadTool("process-data", ctx)
-				require.NoError(t, err, "Failed to load tool 'process-data'")
-				return tool
-			}
+					// Helper to load the process-data tool
+					processDataTool := func(t *testing.T, client *core.ToolboxClient) *core.ToolboxTool {
+						tool, err := client.LoadTool("process-data", ctx)
+						require.NoError(t, err, "Failed to load tool 'process-data'")
+						return tool
+					}
 
-			t.Run("test_tool_schema_is_correct", func(t *testing.T) {
-				client := newClient(t)
-				tool := processDataTool(t, client)
-				g := newGenkit()
+					t.Run("test_tool_schema_is_correct", func(t *testing.T) {
+						client := newClient(t)
+						tool := processDataTool(t, client)
+						g := newGenkit()
 
-				genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
-				if err != nil {
-					t.Fatalf("ToGenkitTool failed: %v", err)
-				}
+						genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
+						if err != nil {
+							t.Fatalf("ToGenkitTool failed: %v", err)
+						}
 
-				expectedSchema := map[string]any{
-					"type": "object",
-					"properties": map[string]any{
-						"execution_context": map[string]any{
-							"description": "A flexible set of key-value pairs for the execution environment.",
-							"type":        "object",
-							"additionalProperties": true,
-						},
-						"user_scores": map[string]any{
-							"description": "A map of user IDs to their scores.",
-							"type":        "object",
-							"additionalProperties": map[string]any{
-								"type": "integer",
+						expectedSchema := map[string]any{
+							"type": "object",
+							"properties": map[string]any{
+								"execution_context": map[string]any{
+									"description": "A flexible set of key-value pairs for the execution environment.",
+									"type":        "object",
+									"additionalProperties": true,
+								},
+								"user_scores": map[string]any{
+									"description": "A map of user IDs to their scores.",
+									"type":        "object",
+									"additionalProperties": map[string]any{
+										"type": "integer",
+									},
+								},
+								"feature_flags": map[string]any{
+									"description": "Optional feature flags.",
+									"type":        "object",
+									"additionalProperties": map[string]any{
+										"type": "boolean",
+									},
+								}},
+							"required": []any{"execution_context", "user_scores"},
+						}
+
+						schema := genkitTool.Definition().InputSchema
+						// Extract 'required' fields for separate comparison
+						actualRequired := schema["required"]
+						expectedRequired := expectedSchema["required"]
+
+						// Remove them from the maps to compare the rest of the structure
+						delete(schema, "required")
+						delete(expectedSchema, "required")
+
+						// Compare the main structure
+						assert.Equal(t, expectedSchema, schema)
+
+						// Compare the slices ignoring order
+						assert.ElementsMatch(t, expectedRequired, actualRequired)
+					})
+
+					t.Run("test_run_tool_with_all_map_params", func(t *testing.T) {
+						// Skipping this test until integer typed maps are parsed correctly within genkit
+						t.Skip()
+						client := newClient(t)
+						tool := processDataTool(t, client)
+						g := newGenkit()
+
+						genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
+						if err != nil {
+							t.Fatalf("ToGenkitTool failed: %v", err)
+						}
+
+						// Invoke the tool with valid map parameters.
+						response, err := genkitTool.RunRaw(context.Background(), map[string]any{
+							"execution_context": map[string]any{
+								"env":  "prod",
+								"id":   1234,
+								"user": 1234.5,
 							},
-						},
-						"feature_flags": map[string]any{
-							"description": "Optional feature flags.",
-							"type":        "object",
-							"additionalProperties": map[string]any{
-								"type": "boolean",
+							"user_scores": map[string]any{
+								"user1": int(100),
+								"user2": int(200),
 							},
-						}},
-					"required": []any{"execution_context", "user_scores"},
-				}
+							"feature_flags": map[string]any{
+								"new_feature": true,
+							},
+						})
+						require.NoError(t, err)
+						respStr, ok := response.(string)
+						require.True(t, ok, "Response should be a string")
 
-				schema := genkitTool.Definition().InputSchema
-				// Extract 'required' fields for separate comparison
-				actualRequired := schema["required"]
-				expectedRequired := expectedSchema["required"]
+						assert.Contains(t, respStr, `"execution_context":{"env":"prod","id":1234,"user":1234.5}`)
+						assert.Contains(t, respStr, `"user_scores":{"user1":100,"user2":200}`)
+						assert.Contains(t, respStr, `"feature_flags":{"new_feature":true}`)
+					})
 
-				// Remove them from the maps to compare the rest of the structure
-				delete(schema, "required")
-				delete(expectedSchema, "required")
+					t.Run("test_run_tool_omitting_optional_map", func(t *testing.T) {
+						// Skipping this test until integer typed maps are parsed correctly within genkit
+						t.Skip()
+						client := newClient(t)
+						tool := processDataTool(t, client)
+						g := newGenkit()
 
-				// Compare the main structure
-				assert.Equal(t, expectedSchema, schema)
+						genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
+						if err != nil {
+							t.Fatalf("ToGenkitTool failed: %v", err)
+						}
 
-				// Compare the slices ignoring order
-				assert.ElementsMatch(t, expectedRequired, actualRequired)
-			})
+						// Invoke the tool without the optional 'feature_flags' parameter.
+						response, err := genkitTool.RunRaw(ctx, map[string]any{
+							"execution_context": map[string]any{"env": "dev"},
+							"user_scores":       map[string]any{"user3": 300},
+						})
+						require.NoError(t, err)
+						respStr, ok := response.(string)
+						require.True(t, ok, "Response should be a string")
 
-			t.Run("test_run_tool_with_all_map_params", func(t *testing.T) {
-				// Skipping this test until integer typed maps are parsed correctly within genkit
-				t.Skip()
-				client := newClient(t)
-				tool := processDataTool(t, client)
-				g := newGenkit()
+						assert.Contains(t, respStr, `"execution_context":{"env":"dev"}`)
+						assert.Contains(t, respStr, `"user_scores":{"user3":300}`)
+						assert.Contains(t, respStr, `"feature_flags":null`)
+					})
 
-				genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
-				if err != nil {
-					t.Fatalf("ToGenkitTool failed: %v", err)
-				}
+					t.Run("test_run_tool_with_wrong_map_value_type", func(t *testing.T) {
+						client := newClient(t)
+						tool := processDataTool(t, client)
+						g := newGenkit()
 
-				// Invoke the tool with valid map parameters.
-				response, err := genkitTool.RunRaw(context.Background(), map[string]any{
-					"execution_context": map[string]any{
-						"env":  "prod",
-						"id":   1234,
-						"user": 1234.5,
-					},
-					"user_scores": map[string]any{
-						"user1": int(100),
-						"user2": int(200),
-					},
-					"feature_flags": map[string]any{
-						"new_feature": true,
-					},
+						genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
+						if err != nil {
+							t.Fatalf("ToGenkitTool failed: %v", err)
+						}
+
+						// Attempt to invoke the tool with an incorrect type in a map value.
+						_, err = genkitTool.RunRaw(ctx, map[string]any{
+							"execution_context": map[string]any{"env": "staging"},
+							"user_scores": map[string]any{
+								"user4": "not-an-integer",
+							},
+						})
+
+						// Assert that an error was returned.
+						require.Error(t, err, "Expected an error for wrong map value type")
+						assert.Contains(t, err.Error(), "Expected: integer, given: string", "Error message should indicate a validation failure")
+					})
 				})
-				require.NoError(t, err)
-				respStr, ok := response.(string)
-				require.True(t, ok, "Response should be a string")
-
-				assert.Contains(t, respStr, `"execution_context":{"env":"prod","id":1234,"user":1234.5}`)
-				assert.Contains(t, respStr, `"user_scores":{"user1":100,"user2":200}`)
-				assert.Contains(t, respStr, `"feature_flags":{"new_feature":true}`)
-			})
-
-			t.Run("test_run_tool_omitting_optional_map", func(t *testing.T) {
-				// Skipping this test until integer typed maps are parsed correctly within genkit
-				t.Skip()
-				client := newClient(t)
-				tool := processDataTool(t, client)
-				g := newGenkit()
-
-				genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
-				if err != nil {
-					t.Fatalf("ToGenkitTool failed: %v", err)
-				}
-
-				// Invoke the tool without the optional 'feature_flags' parameter.
-				response, err := genkitTool.RunRaw(ctx, map[string]any{
-					"execution_context": map[string]any{"env": "dev"},
-					"user_scores":       map[string]any{"user3": 300},
-				})
-				require.NoError(t, err)
-				respStr, ok := response.(string)
-				require.True(t, ok, "Response should be a string")
-
-				assert.Contains(t, respStr, `"execution_context":{"env":"dev"}`)
-				assert.Contains(t, respStr, `"user_scores":{"user3":300}`)
-				assert.Contains(t, respStr, `"feature_flags":null`)
-			})
-
-			t.Run("test_run_tool_with_wrong_map_value_type", func(t *testing.T) {
-				client := newClient(t)
-				tool := processDataTool(t, client)
-				g := newGenkit()
-
-				genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
-				if err != nil {
-					t.Fatalf("ToGenkitTool failed: %v", err)
-				}
-
-				// Attempt to invoke the tool with an incorrect type in a map value.
-				_, err = genkitTool.RunRaw(ctx, map[string]any{
-					"execution_context": map[string]any{"env": "staging"},
-					"user_scores": map[string]any{
-						"user4": "not-an-integer",
-					},
-				})
-
-				// Assert that an error was returned.
-				require.Error(t, err, "Expected an error for wrong map value type")
-				assert.Contains(t, err.Error(), "Expected: integer, given: string", "Error message should indicate a validation failure")
-			})
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Description

This PR upgrades the integration test harnesses across the SDK to support running integration tests against multiple Toolbox server configurations simultaneously. 

1.  **Stable Server (Port 5000):** Runs stable server.
2.  **Draft-Enabled Server (Port 5001):** Runs with the draft specs enabled.

### Motivation
This is a pure testing infrastructure change. It lays the groundwork for the upcoming draft protocol support, ensuring we can test backward compatibility (graceful protocol downgrading) against older servers without breaking any existing test cases.
