### PR TITLE
feat(core): preserve query parameters in connection URLs for toolset binding

### DIFF
--- a/core/client_test.go
+++ b/core/client_test.go
@@ -154,7 +154,6 @@ func TestNewToolboxClient(t *testing.T) {
 
 }
 
-
 func TestNewToolboxClient_HTTPWarning(t *testing.T) {
 	var buf bytes.Buffer
 	log.SetOutput(&buf)
@@ -1300,7 +1299,7 @@ func TestExecuteWithFallback_NoInfiniteLoop(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client, err := NewToolboxClient(ts.URL, WithHTTPClient(ts.Client()))
+	client, err := NewToolboxClient(ts.URL, WithHTTPClient(ts.Client()), WithSupportedProtocols([]Protocol{MCPDraft}))
 	require.NoError(t, err)
 
 	done := make(chan error, 1)
@@ -1315,4 +1314,57 @@ func TestExecuteWithFallback_NoInfiniteLoop(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("executeWithFallback hung in an infinite loop")
 	}
+}
+
+func TestToolInvocation_PreservesURLQueryParams(t *testing.T) {
+	var requestedRawQuery string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedRawQuery = r.URL.RawQuery
+		body, _ := io.ReadAll(r.Body)
+		var req mcpRPCRequest
+		_ = json.Unmarshal(body, &req)
+
+		var result any
+		switch req.Method {
+		case "initialize":
+			result = map[string]any{
+				"protocolVersion": "2025-11-25",
+				"capabilities":    map[string]any{"tools": map[string]any{}},
+				"serverInfo":      map[string]any{"name": "mock-server", "version": "1.0.0"},
+			}
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusOK)
+			return
+		case "tools/list":
+			result = map[string]any{
+				"tools": []mcpTool{{Name: "query_tool", Description: "Tool testing query params"}},
+			}
+		case "tools/call":
+			result = map[string]any{
+				"content": []map[string]any{
+					{"type": "text", "text": "result_ok"},
+				},
+			}
+		}
+		resBytes, _ := json.Marshal(result)
+		resp := mcpRPCResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Result:  resBytes,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer ts.Close()
+
+	client, err := NewToolboxClient(ts.URL+"?foo=bar&baz=123", WithHTTPClient(ts.Client()))
+	require.NoError(t, err)
+
+	tool, err := client.LoadTool("query_tool", context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "foo=bar&baz=123", requestedRawQuery)
+
+	_, err = tool.Invoke(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, "foo=bar&baz=123", requestedRawQuery)
 }

--- a/core/e2e_mcp_test.go
+++ b/core/e2e_mcp_test.go
@@ -889,6 +889,24 @@ func TestMCP_ContextHandling(t *testing.T) {
 	}
 }
 
+func TestRunToolURLBinding(t *testing.T) {
+	for _, serverURL := range getTestServerURLs() {
+		t.Run("server_"+serverURL, func(t *testing.T) {
+			client, err := core.NewToolboxClient(serverURL + "?num_rows=2")
+			require.NoError(t, err)
+			tool, err := client.LoadTool("get-n-rows", context.Background())
+			require.NoError(t, err)
+			res, err := tool.Invoke(context.Background(), map[string]any{})
+			require.NoError(t, err)
+			resStr, ok := res.(string)
+			require.True(t, ok)
+			assert.Contains(t, resStr, "row1")
+			assert.Contains(t, resStr, "row2")
+			assert.NotContains(t, resStr, "row3")
+		})
+	}
+}
+
 func TestMcpProtocols_E2E(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/core/transport/mcp/base.go
+++ b/core/transport/mcp/base.go
@@ -55,31 +55,37 @@ func NewBaseTransport(baseURL string, client *http.Client) (*BaseMcpTransport, e
 	if client == nil {
 		client = &http.Client{}
 	}
-	var fullURL string
-	var err error
-	// Normalize by removing trailing slash first
-	cleanBaseURL := strings.TrimRight(baseURL, "/")
+	parsedURL, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid base URL: %w", err)
+	}
 
-	// Only append "/mcp/" if it is not already present
-	if strings.HasSuffix(cleanBaseURL, "/mcp") {
-		// It's already correct, just use it
-		fullURL = cleanBaseURL
-	} else {
-		// It's missing, so join it safely
-		// url.JoinPath handles the slash insertion automatically
-		fullURL, err = url.JoinPath(cleanBaseURL, "mcp")
+	path := strings.TrimRight(parsedURL.Path, "/")
+	if !strings.HasSuffix(path, "/mcp") {
+		path, err = url.JoinPath(path, "mcp")
 		if err != nil {
 			return nil, err
 		}
 	}
-
-	// Ensure trailing slash
-	fullURL += "/"
+	parsedURL.Path = path + "/"
 
 	return &BaseMcpTransport{
-		baseURL:    fullURL,
+		baseURL:    parsedURL.String(),
 		HTTPClient: client,
 	}, nil
+}
+
+// AppendToolsetPath appends a toolset name to the base URL path while preserving query parameters.
+func AppendToolsetPath(baseURLStr, toolsetName string) (string, error) {
+	if toolsetName == "" {
+		return baseURLStr, nil
+	}
+	parsedURL, err := url.Parse(baseURLStr)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse URL: %w", err)
+	}
+	parsedURL.Path = strings.TrimRight(parsedURL.Path, "/") + "/" + toolsetName
+	return parsedURL.String(), nil
 }
 
 // EnsureInitialized guarantees the session is ready before making requests.

--- a/core/transport/mcp/base_test.go
+++ b/core/transport/mcp/base_test.go
@@ -53,6 +53,26 @@ func TestNewBaseTransport(t *testing.T) {
 			baseURL:  "http://example.com/api/v1",
 			expected: "http://example.com/api/v1/mcp/",
 		},
+		{
+			name:     "Preserves Query Parameters",
+			baseURL:  "http://example.com?num_rows=2",
+			expected: "http://example.com/mcp/?num_rows=2",
+		},
+		{
+			name:     "Multiple Query Parameters",
+			baseURL:  "http://api.com?proj=xyz&env=prod",
+			expected: "http://api.com/mcp/?proj=xyz&env=prod",
+		},
+		{
+			name:     "Escaped Query Parameters",
+			baseURL:  "http://api.com/mcp?q=a%20b&flag=true",
+			expected: "http://api.com/mcp/?q=a%20b&flag=true",
+		},
+		{
+			name:     "Repeated Query Parameters",
+			baseURL:  "http://api.com?tag=1&tag=2",
+			expected: "http://api.com/mcp/?tag=1&tag=2",
+		},
 	}
 
 	for _, tc := range tests {
@@ -63,6 +83,52 @@ func TestNewBaseTransport(t *testing.T) {
 			}
 			if tr.HTTPClient == nil {
 				t.Error("Expected HTTPClient to be initialized, got nil")
+			}
+		})
+	}
+}
+
+func TestAppendToolsetPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		baseURL     string
+		toolsetName string
+		expected    string
+	}{
+		{
+			name:        "Empty toolset name",
+			baseURL:     "http://example.com/mcp/",
+			toolsetName: "",
+			expected:    "http://example.com/mcp/",
+		},
+		{
+			name:        "Append toolset name without query",
+			baseURL:     "http://example.com/mcp/",
+			toolsetName: "my_toolset",
+			expected:    "http://example.com/mcp/my_toolset",
+		},
+		{
+			name:        "Append toolset name with query parameters preserved",
+			baseURL:     "http://example.com/mcp/?num_rows=2&env=test",
+			toolsetName: "my_toolset",
+			expected:    "http://example.com/mcp/my_toolset?num_rows=2&env=test",
+		},
+		{
+			name:        "Append toolset name with spaces and special characters",
+			baseURL:     "http://example.com/mcp/?num_rows=2",
+			toolsetName: "my toolset",
+			expected:    "http://example.com/mcp/my%20toolset?num_rows=2",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := AppendToolsetPath(tc.baseURL, tc.toolsetName)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if res != tc.expected {
+				t.Errorf("Expected %s, got %s", tc.expected, res)
 			}
 		})
 	}
@@ -202,7 +268,8 @@ func TestConvertToolDefinition(t *testing.T) {
 
 	foundSimple := false
 	for _, p := range schema.Parameters {
-		if p.Name == "simple_str" {
+		switch p.Name {
+		case "simple_str":
 			foundSimple = true
 			if !p.Required {
 				t.Error("Expected simple_str to be required")
@@ -210,26 +277,26 @@ func TestConvertToolDefinition(t *testing.T) {
 			if len(p.AuthSources) != 1 || p.AuthSources[0] != "header:x-api-key" {
 				t.Errorf("Expected AuthSources=['header:x-api-key'], got %v", p.AuthSources)
 			}
-		} else if p.Name == "nested_obj" {
+		case "nested_obj":
 			if p.Type != "object" {
 				t.Errorf("Expected nested_obj type object, got %s", p.Type)
 			}
 			if p.AdditionalProperties == nil {
 				t.Error("Expected nested_obj to have AdditionalProperties schema")
 			}
-		} else if p.Name == "str_array" {
+		case "str_array":
 			if p.Type != "array" {
 				t.Errorf("Expected str_array type array, got %s", p.Type)
 			}
 			if p.Items == nil || p.Items.Type != "string" {
 				t.Error("Expected str_array items to be type string")
 			}
-		} else if p.Name == "missing_type_param" {
+		case "missing_type_param":
 			// Verifies the "type" defaults to "string"
 			if p.Type != "string" {
 				t.Errorf("Expected missing_type_param type string, got %s", p.Type)
 			}
-		} else if p.Name == "generic_array" {
+		case "generic_array":
 			// Verifies array parses correctly when Items are omitted
 			if p.Type != "array" {
 				t.Errorf("Expected generic_array type array, got %s", p.Type)
@@ -237,7 +304,7 @@ func TestConvertToolDefinition(t *testing.T) {
 			if p.Items != nil {
 				t.Error("Expected generic_array items to be nil")
 			}
-		} else if p.Name == "generic_object" {
+		case "generic_object":
 			// Verifies object parses correctly when additionalProperties are omitted
 			if p.Type != "object" {
 				t.Errorf("Expected generic_object type object, got %s", p.Type)

--- a/core/transport/mcp/v20241105/mcp.go
+++ b/core/transport/mcp/v20241105/mcp.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/google/uuid"
@@ -72,13 +71,9 @@ func (t *McpTransport) ListTools(ctx context.Context, toolsetName string, header
 		return nil, err
 	}
 
-	requestURL := t.BaseURL()
-	if toolsetName != "" {
-		var err error
-		requestURL, err = url.JoinPath(requestURL, toolsetName)
-		if err != nil {
-			return nil, fmt.Errorf("failed to construct toolset URL: %w", err)
-		}
+	requestURL, err := mcp.AppendToolsetPath(t.BaseURL(), toolsetName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct toolset URL: %w", err)
 	}
 
 	var result listToolsResult

--- a/core/transport/mcp/v20250326/mcp.go
+++ b/core/transport/mcp/v20250326/mcp.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/google/uuid"
@@ -75,13 +74,9 @@ func (t *McpTransport) ListTools(ctx context.Context, toolsetName string, header
 	}
 
 	// Append toolset name to base URL if provided
-	requestURL := t.BaseURL()
-	if toolsetName != "" {
-		var err error
-		requestURL, err = url.JoinPath(requestURL, toolsetName)
-		if err != nil {
-			return nil, fmt.Errorf("failed to construct toolset URL: %w", err)
-		}
+	requestURL, err := mcp.AppendToolsetPath(t.BaseURL(), toolsetName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct toolset URL: %w", err)
 	}
 
 	var result listToolsResult

--- a/core/transport/mcp/v20250618/mcp.go
+++ b/core/transport/mcp/v20250618/mcp.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/google/uuid"
@@ -73,13 +72,9 @@ func (t *McpTransport) ListTools(ctx context.Context, toolsetName string, header
 		return nil, err
 	}
 
-	requestURL := t.BaseURL()
-	if toolsetName != "" {
-		var err error
-		requestURL, err = url.JoinPath(requestURL, toolsetName)
-		if err != nil {
-			return nil, fmt.Errorf("failed to construct toolset URL: %w", err)
-		}
+	requestURL, err := mcp.AppendToolsetPath(t.BaseURL(), toolsetName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct toolset URL: %w", err)
 	}
 
 	var result listToolsResult

--- a/core/transport/mcp/v20251125/mcp.go
+++ b/core/transport/mcp/v20251125/mcp.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/google/uuid"
@@ -74,13 +73,9 @@ func (t *McpTransport) ListTools(ctx context.Context, toolsetName string, header
 		return nil, err
 	}
 
-	requestURL := t.BaseURL()
-	if toolsetName != "" {
-		var err error
-		requestURL, err = url.JoinPath(requestURL, toolsetName)
-		if err != nil {
-			return nil, fmt.Errorf("failed to construct toolset URL: %w", err)
-		}
+	requestURL, err := mcp.AppendToolsetPath(t.BaseURL(), toolsetName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct toolset URL: %w", err)
 	}
 
 	var result listToolsResult

--- a/core/transport/mcp/v20260618/mcp.go
+++ b/core/transport/mcp/v20260618/mcp.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport"
@@ -82,15 +81,9 @@ func (t *McpTransport) GetTool(ctx context.Context, toolName string, headers map
 
 // ListTools fetches available tools from the server.
 func (t *McpTransport) ListTools(ctx context.Context, toolsetName string, headers map[string]string) (*transport.ManifestSchema, error) {
-	var targetURL string
-	var err error
-	if toolsetName != "" {
-		targetURL, err = url.JoinPath(t.BaseURL(), toolsetName)
-		if err != nil {
-			return nil, fmt.Errorf("failed to build toolset URL: %w", err)
-		}
-	} else {
-		targetURL = t.BaseURL()
+	targetURL, err := mcp.AppendToolsetPath(t.BaseURL(), toolsetName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build toolset URL: %w", err)
 	}
 
 	reqPayload := ListToolsRequest{

--- a/tbadk/e2e_test.go
+++ b/tbadk/e2e_test.go
@@ -991,3 +991,33 @@ func TestE2E_MapParams(t *testing.T) {
 		})
 	}
 }
+
+func TestRunToolURLBinding(t *testing.T) {
+	for _, serverURL := range getTestServerURLs() {
+		t.Run("server_"+serverURL, func(t *testing.T) {
+			toolbox, err := tbadk.NewToolboxClient(serverURL + "?num_rows=2")
+			require.NoError(t, err)
+
+			tool, err := toolbox.LoadTool("get-n-rows", context.Background())
+			require.NoError(t, err)
+
+			testToolCtx := &mockToolContext{
+				mockAgentContext: &mockAgentContext{
+					ctx: context.Background(),
+				},
+			}
+
+			res, err := tool.Run(testToolCtx, map[string]any{})
+			require.NoError(t, err)
+
+			resStr, ok := res["output"].(string)
+			if !ok {
+				resStr, ok = res["content"].(string)
+			}
+			require.True(t, ok)
+			assert.Contains(t, resStr, "row1")
+			assert.Contains(t, resStr, "row2")
+			assert.NotContains(t, resStr, "row3")
+		})
+	}
+}

--- a/tbgenkit/tbgenkit_test.go
+++ b/tbgenkit/tbgenkit_test.go
@@ -926,3 +926,27 @@ func TestToGenkitTool_MapParams(t *testing.T) {
 		})
 	}
 }
+
+func TestRunToolURLBinding(t *testing.T) {
+	for _, serverURL := range getTestServerURLs() {
+		t.Run("server_"+serverURL, func(t *testing.T) {
+			client, err := core.NewToolboxClient(serverURL + "?num_rows=2")
+			require.NoError(t, err)
+			tool, err := client.LoadTool("get-n-rows", context.Background())
+			require.NoError(t, err)
+
+			g := genkit.Init(context.Background())
+			genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
+			require.NoError(t, err)
+
+			res, err := genkitTool.RunRaw(context.Background(), map[string]any{})
+			require.NoError(t, err)
+
+			resStr, ok := res.(string)
+			require.True(t, ok)
+			assert.Contains(t, resStr, "row1")
+			assert.Contains(t, resStr, "row2")
+			assert.NotContains(t, resStr, "row3")
+		})
+	}
+}


### PR DESCRIPTION
## Overview

Fixes URL construction when initializing client with query parameters (e.g. `http://localhost:5000?num_rows=2` for parameter binding). Previously, naive string template concatenation (`${baseUrl}/mcp/` and `${this._mcpBaseUrl}${toolsetName || ''}`) corrupted base URLs containing query strings (yielding invalid URLs like `http://localhost:5000?num_rows=2/mcp/`).

> [!NOTE]
> This PR is a mirror of Python's https://github.com/googleapis/mcp-toolbox-sdk-python/pull/717.
