### PR TITLE
feat(core): support response _meta serverInfo and resultType in draft protocol

### DIFF
--- a/core/transport/mcp/v20260618/mcp.go
+++ b/core/transport/mcp/v20260618/mcp.go
@@ -107,6 +107,10 @@ func (t *McpTransport) ListTools(ctx context.Context, toolsetName string, header
 		return nil, err
 	}
 
+	if result.ResultType == "" {
+		result.ResultType = "complete"
+	}
+
 	toolsMap := make(map[string]transport.ToolSchema)
 	for _, toolRaw := range result.Tools {
 		toolSchema, err := t.ConvertToolDefinition(toolRaw)
@@ -118,8 +122,13 @@ func (t *McpTransport) ListTools(ctx context.Context, toolsetName string, header
 		}
 	}
 
+	serverVersion := "0.0.0"
+	if result.Meta != nil && result.Meta.ServerInfo != nil && result.Meta.ServerInfo.Version != "" {
+		serverVersion = result.Meta.ServerInfo.Version
+	}
+
 	return &transport.ManifestSchema{
-		ServerVersion: "1.0.0",
+		ServerVersion: serverVersion,
 		Tools:         toolsMap,
 	}, nil
 }
@@ -152,6 +161,10 @@ func (t *McpTransport) InvokeTool(ctx context.Context, toolName string, payload 
 	var result CallToolResult
 	if err := t.sendRequest(ctx, t.BaseURL(), reqPayload, &result, headers, "tools/call", toolName); err != nil {
 		return nil, err
+	}
+
+	if result.ResultType == "" {
+		result.ResultType = "complete"
 	}
 
 	if result.IsError {

--- a/core/transport/mcp/v20260618/mcp_test.go
+++ b/core/transport/mcp/v20260618/mcp_test.go
@@ -161,6 +161,57 @@ func TestPrepareHeadersMcpName(t *testing.T) {
 	assert.Equal(t, "ok", res)
 }
 
+func TestToolsList_UsesServerInfoFromMeta(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"jsonrpc": "2.0",
+			"id": "1",
+			"result": {
+				"resultType": "complete",
+				"tools": [{"name": "sample_tool", "description": "Sample"}],
+				"_meta": {
+					"io.modelcontextprotocol/serverInfo": {
+						"name": "ToolboxServer",
+						"version": "2.5.0"
+					}
+				}
+			}
+		}`))
+	}))
+	defer ts.Close()
+
+	tr, err := New(ts.URL, ts.Client(), "test-client", "1.0.0")
+	require.NoError(t, err)
+
+	manifest, err := tr.ListTools(context.Background(), "", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "2.5.0", manifest.ServerVersion)
+	assert.Contains(t, manifest.Tools, "sample_tool")
+}
+
+func TestToolsList_ResultMetaOptionalServerInfo(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"jsonrpc": "2.0",
+			"id": "1",
+			"result": {
+				"tools": [{"name": "sample_tool", "description": "Sample"}]
+			}
+		}`))
+	}))
+	defer ts.Close()
+
+	tr, err := New(ts.URL, ts.Client(), "test-client", "1.0.0")
+	require.NoError(t, err)
+
+	manifest, err := tr.ListTools(context.Background(), "", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "0.0.0", manifest.ServerVersion)
+	assert.Contains(t, manifest.Tools, "sample_tool")
+}
+
 func TestResultTypeParsingAndFallback(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/core/transport/mcp/v20260618/types.go
+++ b/core/transport/mcp/v20260618/types.go
@@ -70,11 +70,22 @@ type jsonRPCError struct {
 	Data    any    `json:"data,omitempty"`
 }
 
+type MCPResultMeta struct {
+	ServerInfo *Implementation `json:"io.modelcontextprotocol/serverInfo,omitempty"`
+}
+
+type MCPResult struct {
+	ResultType string         `json:"resultType,omitempty"`
+	Meta       *MCPResultMeta `json:"_meta,omitempty"`
+}
+
 type ListToolsResult struct {
+	MCPResult
 	Tools []map[string]any `json:"tools"`
 }
 
 type CallToolResult struct {
+	MCPResult
 	Content []mcp.ToolContent `json:"content"`
 	IsError bool              `json:"isError,omitempty"`
 }


### PR DESCRIPTION
## Overview

Adds support for parsing response `_meta` (`io.modelcontextprotocol/serverInfo`) and `resultType` in the 2026 stateless protocol.

> [!NOTE]
> This PR is a mirror of Python SDK's https://github.com/googleapis/mcp-toolbox-sdk-python/pull/730.

Previously, `v20260728/mcp.ts` returned `serverVersion: 'unknown'` in `toolsList()`. With this PR, the transport dynamically extracts `serverVersion` from `_meta.['io.modelcontextprotocol/serverInfo'].version` (falling back to `"0.0.0"` if missing).
