### PR TITLE
feat(core): update vendor metadata prefixes for MCP 2026+ and add protocol version utilities

### DIFF
--- a/core/client_test.go
+++ b/core/client_test.go
@@ -62,8 +62,13 @@ type mcpTool struct {
 	Meta        map[string]any `json:"_meta,omitempty"`
 }
 
-// newMockMCPServer creates a server that simulates the MCP lifecycle (initialize -> list).
+// newMockMCPServer creates a server that simulates the MCP lifecycle (initialize -> list) defaulting to 2026-07-28 protocol version.
 func newMockMCPServer(t *testing.T, tools []mcpTool) *httptest.Server {
+	return newMockMCPServerWithVersion(t, tools, "2026-07-28")
+}
+
+// newMockMCPServerWithVersion creates a server that simulates the MCP lifecycle with a custom protocol version.
+func newMockMCPServerWithVersion(t *testing.T, tools []mcpTool, protocolVersion string) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		var req mcpRPCRequest
@@ -76,7 +81,7 @@ func newMockMCPServer(t *testing.T, tools []mcpTool) *httptest.Server {
 		switch req.Method {
 		case "initialize":
 			result = map[string]any{
-				"protocolVersion": "2025-06-18",
+				"protocolVersion": protocolVersion,
 				"capabilities":    map[string]any{"tools": map[string]any{}},
 				"serverInfo":      map[string]any{"name": "mock-server", "version": "1.0.0"},
 			}
@@ -348,7 +353,7 @@ func TestLoadToolAndLoadToolset(t *testing.T) {
 				},
 			},
 			Meta: map[string]any{
-				"toolbox/authParam": map[string]any{
+				"com.google.cloud/authParam": map[string]any{
 					"param2": []string{"google"},
 				},
 			},
@@ -358,7 +363,7 @@ func TestLoadToolAndLoadToolset(t *testing.T) {
 			Description: "Tool B",
 			InputSchema: map[string]any{"type": "object", "properties": map[string]any{}},
 			Meta: map[string]any{
-				"toolbox/authInvoke": []string{"github"},
+				"com.google.cloud/authInvoke": []string{"github"},
 			},
 		},
 	}
@@ -395,6 +400,44 @@ func TestLoadToolAndLoadToolset(t *testing.T) {
 		// Confirm the schema was captured for Invoke
 		assert.NotNil(t, tool.boundParamSchemas["param1"])
 		assert.Equal(t, "string", tool.boundParamSchemas["param1"].Type)
+	})
+
+	t.Run("LoadTool - Legacy Metadata Keys (pre-2026)", func(t *testing.T) {
+		legacyTools := []mcpTool{
+			{
+				Name:        "legacyTool",
+				Description: "Legacy tool",
+				InputSchema: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"param1": map[string]any{"type": "string"},
+						"param2": map[string]any{"type": "string"},
+					},
+				},
+				Meta: map[string]any{
+					"toolbox/authParam": map[string]any{
+						"param2": []any{"google"},
+					},
+					"toolbox/authInvoke": []any{"github"},
+				},
+			},
+		}
+
+		legacyServer := newMockMCPServerWithVersion(t, legacyTools, "2025-06-18")
+		defer legacyServer.Close()
+
+		client, _ := NewToolboxClient(legacyServer.URL,
+			WithHTTPClient(legacyServer.Client()),
+			WithProtocol(MCPv20250618),
+		)
+		tool, err := client.LoadTool("legacyTool",
+			context.Background(),
+			WithBindParamString("param1", "value1"),
+			WithAuthTokenString("google", "token-google"),
+			WithAuthTokenString("github", "token-github"),
+		)
+		require.NoError(t, err, "LoadTool should succeed for legacy protocol version 2025-06-18")
+		assert.Equal(t, "legacyTool", tool.name)
 	})
 
 	t.Run("LoadTool - Allows Nested Arrays", func(t *testing.T) {
@@ -600,7 +643,7 @@ func TestDefaultOptionOverwriting(t *testing.T) {
 				},
 			},
 			Meta: map[string]any{
-				"toolbox/authInvoke": []string{"google"},
+				"com.google.cloud/authInvoke": []string{"google"},
 			},
 		},
 	}
@@ -773,7 +816,7 @@ func TestLoadToolAndLoadToolset_ErrorPaths(t *testing.T) {
 				},
 			},
 			Meta: map[string]any{
-				"toolbox/authParam": map[string]any{
+				"com.google.cloud/authParam": map[string]any{
 					"auth_param": []string{"google"},
 				},
 			},

--- a/core/protocol.go
+++ b/core/protocol.go
@@ -14,18 +14,20 @@
 
 package core
 
-import "github.com/googleapis/mcp-toolbox-sdk-go/core/transport"
+import (
+	"github.com/googleapis/mcp-toolbox-sdk-go/core/transport"
+)
 
 // Protocol defines underlying transport protocols.
 type Protocol string
 
 const (
 	// MCP Version Constants
-	MCPv20260728 Protocol = "2026-07-28"
-	MCPv20251125 Protocol = "2025-11-25"
-	MCPv20250618 Protocol = "2025-06-18"
-	MCPv20250326 Protocol = "2025-03-26"
-	MCPv20241105 Protocol = "2024-11-05"
+	MCPv20260728 Protocol = transport.MCPv20260728
+	MCPv20251125 Protocol = transport.MCPv20251125
+	MCPv20250618 Protocol = transport.MCPv20250618
+	MCPv20250326 Protocol = transport.MCPv20250326
+	MCPv20241105 Protocol = transport.MCPv20241105
 
 	// MCP is the default alias pointing to the newest supported version.
 	MCP = MCPv20260728
@@ -36,13 +38,7 @@ const (
 
 // GetSupportedMcpVersions returns a list of supported MCP protocol versions.
 func GetSupportedMcpVersions() []string {
-	return []string{
-		string(MCPv20260728),
-		string(MCPv20251125),
-		string(MCPv20250618),
-		string(MCPv20250326),
-		string(MCPv20241105),
-	}
+	return transport.GetSupportedMcpVersions()
 }
 
 type ManifestSchema = transport.ManifestSchema

--- a/core/transport/mcp/base.go
+++ b/core/transport/mcp/base.go
@@ -34,11 +34,12 @@ type ToolContent struct {
 
 // BaseMcpTransport holds the common state and logic for MCP HTTP transports.
 type BaseMcpTransport struct {
-	baseURL       string
-	HTTPClient    *http.Client
-	ServerVersion string
-	initOnce      sync.Once
-	initErr       error
+	baseURL         string
+	HTTPClient      *http.Client
+	ServerVersion   string
+	ProtocolVersion string
+	initOnce        sync.Once
+	initErr         error
 
 	// HandshakeHook is the abstract method _initialize_session.
 	// The specific version implementation will assign this function.
@@ -144,15 +145,38 @@ func (b *BaseMcpTransport) ConvertToolDefinition(toolData map[string]any) (trans
 	var paramAuth map[string]any
 	var invokeAuth []string
 
+	version := b.ProtocolVersion
+	if version == "" {
+		version = transport.MCPv20260728
+	}
+	is2026OrNewer, err := transport.IsVersionAtLeast(version, transport.MCPv20260728)
+	if err != nil {
+		return transport.ToolSchema{}, fmt.Errorf("invalid protocol version check: %w", err)
+	}
+
 	if meta, ok := toolData["_meta"].(map[string]any); ok {
-		if pa, ok := meta["toolbox/authParam"].(map[string]any); ok {
-			paramAuth = pa
-		}
-		if ia, ok := meta["toolbox/authInvoke"].([]any); ok {
-			invokeAuth = make([]string, 0, len(ia))
-			for _, v := range ia {
-				if s, ok := v.(string); ok {
-					invokeAuth = append(invokeAuth, s)
+		if is2026OrNewer {
+			if pa, ok := meta["com.google.cloud/authParam"].(map[string]any); ok {
+				paramAuth = pa
+			}
+			if ia, ok := meta["com.google.cloud/authInvoke"].([]any); ok {
+				invokeAuth = make([]string, 0, len(ia))
+				for _, v := range ia {
+					if s, ok := v.(string); ok {
+						invokeAuth = append(invokeAuth, s)
+					}
+				}
+			}
+		} else {
+			if pa, ok := meta["toolbox/authParam"].(map[string]any); ok {
+				paramAuth = pa
+			}
+			if ia, ok := meta["toolbox/authInvoke"].([]any); ok {
+				invokeAuth = make([]string, 0, len(ia))
+				for _, v := range ia {
+					if s, ok := v.(string); ok {
+						invokeAuth = append(invokeAuth, s)
+					}
 				}
 			}
 		}

--- a/core/transport/mcp/base_test.go
+++ b/core/transport/mcp/base_test.go
@@ -193,260 +193,276 @@ func TestEnsureInitialized(t *testing.T) {
 }
 
 func TestConvertToolDefinition(t *testing.T) {
-	tr, _ := NewBaseTransport("http://example.com", nil)
+	t.Run("ComplexSchema", func(t *testing.T) {
+		tr, _ := NewBaseTransport("http://example.com", nil)
 
-	rawTool := map[string]any{
-		"name":        "complex_tool",
-		"description": "A test tool",
-		"inputSchema": map[string]any{
-			"type": "object",
-			"properties": map[string]any{
-				"simple_str": map[string]any{
-					"type":        "string",
-					"description": "Simple string param",
-				},
-				"nested_obj": map[string]any{
-					"type": "object",
-					"properties": map[string]any{
-						"inner_int": map[string]any{"type": "integer"},
+		rawTool := map[string]any{
+			"name":        "complex_tool",
+			"description": "A test tool",
+			"inputSchema": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"simple_str": map[string]any{
+						"type":        "string",
+						"description": "Simple string param",
 					},
-					"additionalProperties": map[string]any{
-						"type": "string",
+					"nested_obj": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"inner_int": map[string]any{"type": "integer"},
+						},
+						"additionalProperties": map[string]any{
+							"type": "string",
+						},
+					},
+					"str_array": map[string]any{
+						"type": "array",
+						"items": map[string]any{
+							"type": "string",
+						},
+					},
+					"missing_type_param": map[string]any{
+						"description": "Should default to string",
+					},
+					"generic_array": map[string]any{
+						"type": "array",
+					},
+					"generic_object": map[string]any{
+						"type": "object",
 					},
 				},
-				"str_array": map[string]any{
-					"type": "array",
-					"items": map[string]any{
-						"type": "string",
-					},
-				},
-				"missing_type_param": map[string]any{
-					"description": "Should default to string",
-				},
-				"generic_array": map[string]any{
-					"type": "array",
-				},
-				"generic_object": map[string]any{
-					"type": "object",
-				},
+				"required": []any{"simple_str"},
 			},
-			"required": []any{"simple_str"},
-		},
-		"_meta": map[string]any{
-			"toolbox/authParam": map[string]any{
-				"simple_str": []any{"header:x-api-key"},
+			"_meta": map[string]any{
+				"com.google.cloud/authParam": map[string]any{
+					"simple_str": []any{"header:x-api-key"},
+				},
+				"com.google.cloud/authInvoke": []any{"oauth2"},
 			},
-			"toolbox/authInvoke": []any{"oauth2"},
-		},
-	}
+		}
 
-	schema, err := tr.ConvertToolDefinition(rawTool)
-	if err != nil {
-		t.Fatalf("ConvertToolDefinition failed: %v", err)
-	}
+		schema, err := tr.ConvertToolDefinition(rawTool)
+		if err != nil {
+			t.Fatalf("ConvertToolDefinition failed: %v", err)
+		}
 
-	// Check Top-Level Metadata
-	if schema.Description != "A test tool" {
-		t.Errorf("Expected description 'A test tool', got '%s'", schema.Description)
-	}
+		if schema.Description != "A test tool" {
+			t.Errorf("Expected description 'A test tool', got '%s'", schema.Description)
+		}
 
-	// Check Auth Requirements
-	if len(schema.AuthRequired) != 1 || schema.AuthRequired[0] != "oauth2" {
-		t.Errorf("Expected AuthRequired=['oauth2'], got %v", schema.AuthRequired)
-	}
+		if len(schema.AuthRequired) != 1 || schema.AuthRequired[0] != "oauth2" {
+			t.Errorf("Expected AuthRequired=['oauth2'], got %v", schema.AuthRequired)
+		}
 
-	// Check Parameters
-	if len(schema.Parameters) != 6 {
-		t.Fatalf("Expected 6 parameters, got %d", len(schema.Parameters))
-	}
+		if len(schema.Parameters) != 6 {
+			t.Fatalf("Expected 6 parameters, got %d", len(schema.Parameters))
+		}
 
-	// Helper map to find params by name easily
-	params := make(map[string]any)
-	for _, p := range schema.Parameters {
-		params[p.Name] = p
-	}
-
-	foundSimple := false
-	for _, p := range schema.Parameters {
-		switch p.Name {
-		case "simple_str":
-			foundSimple = true
-			if !p.Required {
-				t.Error("Expected simple_str to be required")
-			}
-			if len(p.AuthSources) != 1 || p.AuthSources[0] != "header:x-api-key" {
-				t.Errorf("Expected AuthSources=['header:x-api-key'], got %v", p.AuthSources)
-			}
-		case "nested_obj":
-			if p.Type != "object" {
-				t.Errorf("Expected nested_obj type object, got %s", p.Type)
-			}
-			if p.AdditionalProperties == nil {
-				t.Error("Expected nested_obj to have AdditionalProperties schema")
-			}
-		case "str_array":
-			if p.Type != "array" {
-				t.Errorf("Expected str_array type array, got %s", p.Type)
-			}
-			if p.Items == nil || p.Items.Type != "string" {
-				t.Error("Expected str_array items to be type string")
-			}
-		case "missing_type_param":
-			// Verifies the "type" defaults to "string"
-			if p.Type != "string" {
-				t.Errorf("Expected missing_type_param type string, got %s", p.Type)
-			}
-		case "generic_array":
-			// Verifies array parses correctly when Items are omitted
-			if p.Type != "array" {
-				t.Errorf("Expected generic_array type array, got %s", p.Type)
-			}
-			if p.Items != nil {
-				t.Error("Expected generic_array items to be nil")
-			}
-		case "generic_object":
-			// Verifies object parses correctly when additionalProperties are omitted
-			if p.Type != "object" {
-				t.Errorf("Expected generic_object type object, got %s", p.Type)
-			}
-			if p.AdditionalProperties != nil {
-				t.Error("Expected generic_object AdditionalProperties to be nil")
+		foundSimple := false
+		for _, p := range schema.Parameters {
+			switch p.Name {
+			case "simple_str":
+				foundSimple = true
+				if !p.Required {
+					t.Error("Expected simple_str to be required")
+				}
+				if len(p.AuthSources) != 1 || p.AuthSources[0] != "header:x-api-key" {
+					t.Errorf("Expected AuthSources=['header:x-api-key'], got %v", p.AuthSources)
+				}
+			case "nested_obj":
+				if p.Type != "object" {
+					t.Errorf("Expected nested_obj type object, got %s", p.Type)
+				}
+				if p.AdditionalProperties == nil {
+					t.Error("Expected nested_obj to have AdditionalProperties schema")
+				}
+			case "str_array":
+				if p.Type != "array" {
+					t.Errorf("Expected str_array type array, got %s", p.Type)
+				}
+				if p.Items == nil || p.Items.Type != "string" {
+					t.Error("Expected str_array items to be type string")
+				}
+			case "missing_type_param":
+				if p.Type != "string" {
+					t.Errorf("Expected missing_type_param type string, got %s", p.Type)
+				}
+			case "generic_array":
+				if p.Type != "array" {
+					t.Errorf("Expected generic_array type array, got %s", p.Type)
+				}
+				if p.Items != nil {
+					t.Error("Expected generic_array items to be nil")
+				}
+			case "generic_object":
+				if p.Type != "object" {
+					t.Errorf("Expected generic_object type object, got %s", p.Type)
+				}
+				if p.AdditionalProperties != nil {
+					t.Error("Expected generic_object AdditionalProperties to be nil")
+				}
 			}
 		}
-	}
 
-	if !foundSimple {
-		t.Error("Parameter 'simple_str' not found in converted schema")
-	}
-}
+		if !foundSimple {
+			t.Error("Parameter 'simple_str' not found in converted schema")
+		}
+	})
 
-func TestConvertToolDefinitionWithDefaults(t *testing.T) {
-	tr, _ := NewBaseTransport("http://example.com", nil)
+	t.Run("WithDefaults", func(t *testing.T) {
+		tr, _ := NewBaseTransport("http://example.com", nil)
 
-	rawTool := map[string]any{
-		"name": "default_tool",
-		"inputSchema": map[string]any{
-			"type": "object",
-			"properties": map[string]any{
-				"count": map[string]any{
-					"type":    "integer",
-					"default": 10,
-				},
-				"text": map[string]any{
-					"type":    "string",
-					"default": "hello",
+		rawTool := map[string]any{
+			"name": "default_tool",
+			"inputSchema": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"count": map[string]any{
+						"type":    "integer",
+						"default": 10,
+					},
+					"text": map[string]any{
+						"type":    "string",
+						"default": "hello",
+					},
 				},
 			},
-		},
-	}
+		}
 
-	schema, err := tr.ConvertToolDefinition(rawTool)
-	if err != nil {
-		t.Fatalf("ConvertToolDefinition failed: %v", err)
-	}
+		schema, err := tr.ConvertToolDefinition(rawTool)
+		if err != nil {
+			t.Fatalf("ConvertToolDefinition failed: %v", err)
+		}
 
-	if len(schema.Parameters) != 2 {
-		t.Fatalf("Expected 2 parameters, got %d", len(schema.Parameters))
-	}
+		if len(schema.Parameters) != 2 {
+			t.Fatalf("Expected 2 parameters, got %d", len(schema.Parameters))
+		}
 
-	foundCount := false
-	foundText := false
+		foundCount := false
+		foundText := false
 
-	for _, p := range schema.Parameters {
-		switch p.Name {
-		case "count":
-			foundCount = true
-			if p.Default == nil {
-				t.Error("Expected count to have a default value, got nil")
-			} else if val, ok := p.Default.(int); !ok || val != 10 {
-				t.Errorf("Expected count default 10, got %v (%T)", p.Default, p.Default)
-			}
-		case "text":
-			foundText = true
-			if p.Default == nil {
-				t.Error("Expected text to have a default value, got nil")
-			} else if val, ok := p.Default.(string); !ok || val != "hello" {
-				t.Errorf("Expected text default 'hello', got %v (%T)", p.Default, p.Default)
+		for _, p := range schema.Parameters {
+			switch p.Name {
+			case "count":
+				foundCount = true
+				if p.Default == nil {
+					t.Error("Expected count to have a default value, got nil")
+				} else if val, ok := p.Default.(int); !ok || val != 10 {
+					t.Errorf("Expected count default 10, got %v (%T)", p.Default, p.Default)
+				}
+			case "text":
+				foundText = true
+				if p.Default == nil {
+					t.Error("Expected text to have a default value, got nil")
+				} else if val, ok := p.Default.(string); !ok || val != "hello" {
+					t.Errorf("Expected text default 'hello', got %v (%T)", p.Default, p.Default)
+				}
 			}
 		}
-	}
 
-	if !foundCount || !foundText {
-		t.Errorf("Missing expected parameters: foundCount=%v, foundText=%v", foundCount, foundText)
-	}
-}
+		if !foundCount || !foundText {
+			t.Errorf("Missing expected parameters: foundCount=%v, foundText=%v", foundCount, foundText)
+		}
+	})
 
-func TestProcessToolResultContent(t *testing.T) {
-	// Setup a dummy transport (ProcessToolResultContent is a pure function, so state doesn't matter)
-	tr, _ := NewBaseTransport("http://example.com", nil)
+	t.Run("Pre2026", func(t *testing.T) {
+		tr, _ := NewBaseTransport("http://example.com", nil)
+		tr.ProtocolVersion = "2025-11-25"
 
-	tests := []struct {
-		name     string
-		content  []ToolContent
-		expected string
-	}{
-		{
-			// Single text
-			name: "Single text",
-			content: []ToolContent{
-				{Type: "text", Text: "hello"},
+		rawTool := map[string]any{
+			"name":        "legacyTool",
+			"description": "Legacy tool test",
+			"inputSchema": map[string]any{
+				"properties": map[string]any{
+					"param": map[string]any{"type": "string"},
+				},
 			},
-			expected: "hello",
-		},
-		{
-			// Multiple valid JSON objects
-			// Should be merged into a JSON array string
-			name: "Multiple valid JSON objects",
-			content: []ToolContent{
-				{Type: "text", Text: `{"a": 1}`},
-				{Type: "text", Text: `{"b": 2}`},
+			"_meta": map[string]any{
+				"toolbox/authParam": map[string]any{
+					"param": []any{"legacy-auth"},
+				},
+				"toolbox/authInvoke": []any{"legacy-invoke"},
 			},
-			expected: `[{"a": 1},{"b": 2}]`,
-		},
-		{
-			// Invalid JSON fallback
-			// One chunk is valid JSON, the other is not -> Fall back to concatenation
-			name: "Invalid JSON fallback",
-			content: []ToolContent{
-				{Type: "text", Text: `{"a": 1}`},
-				{Type: "text", Text: "invalid"},
-			},
-			expected: `{"a": 1}invalid`,
-		},
-		{
-			// Valid JSON but not objects (heuristic check)
-			// Numbers are valid JSON, but not "dictionaries", so they should be concatenated
-			name: "Valid JSON but not objects",
-			content: []ToolContent{
-				{Type: "text", Text: "1"},
-				{Type: "text", Text: "2"},
-			},
-			expected: "12",
-		},
-		{
-			// Empty
-			name:     "Empty",
-			content:  []ToolContent{},
-			expected: "null",
-		},
-		{
-			// Non-text ignored
-			// Image type should be skipped, leaving only "kept"
-			name: "Non-text ignored",
-			content: []ToolContent{
-				{Type: "image", Text: "ignored"},
-				{Type: "text", Text: "kept"},
-			},
-			expected: "kept",
-		},
-	}
+		}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			result := tr.ProcessToolResultContent(tc.content)
-			if result != tc.expected {
-				t.Errorf("\nExpected: %s\nGot:      %s", tc.expected, result)
-			}
-		})
-	}
+		schema, err := tr.ConvertToolDefinition(rawTool)
+		if err != nil {
+			t.Fatalf("ConvertToolDefinition failed: %v", err)
+		}
+
+		if len(schema.AuthRequired) != 1 || schema.AuthRequired[0] != "legacy-invoke" {
+			t.Errorf("Expected AuthRequired=['legacy-invoke'], got %v", schema.AuthRequired)
+		}
+		if len(schema.Parameters) != 1 || len(schema.Parameters[0].AuthSources) != 1 || schema.Parameters[0].AuthSources[0] != "legacy-auth" {
+			t.Errorf("Expected AuthSources=['legacy-auth'], got %v", schema.Parameters[0].AuthSources)
+		}
+	})
+
+	t.Run("LegacyIgnoredOn2026", func(t *testing.T) {
+		tr, _ := NewBaseTransport("http://example.com", nil)
+		tr.ProtocolVersion = "2026-07-28"
+
+		rawTool := map[string]any{
+			"name":        "legacyToolOn2026",
+			"description": "Legacy tool on 2026 version test",
+			"inputSchema": map[string]any{
+				"properties": map[string]any{
+					"param": map[string]any{"type": "string"},
+				},
+			},
+			"_meta": map[string]any{
+				"toolbox/authParam": map[string]any{
+					"param": []any{"legacy-auth"},
+				},
+				"toolbox/authInvoke":  []any{"legacy-invoke"},
+			},
+		}
+
+		schema, err := tr.ConvertToolDefinition(rawTool)
+		if err != nil {
+			t.Fatalf("ConvertToolDefinition failed: %v", err)
+		}
+
+		if len(schema.AuthRequired) != 0 {
+			t.Errorf("Expected empty AuthRequired, got %v", schema.AuthRequired)
+		}
+		if len(schema.Parameters) != 1 || len(schema.Parameters[0].AuthSources) != 0 {
+			t.Errorf("Expected empty AuthSources, got %v", schema.Parameters[0].AuthSources)
+		}
+	})
+
+	t.Run("MalformedMeta", func(t *testing.T) {
+		tr, _ := NewBaseTransport("http://example.com", nil)
+		tr.ProtocolVersion = "2026-07-28"
+
+		rawToolMalformed := map[string]any{
+			"name": "toolMalformed",
+			"_meta": map[string]any{
+				"com.google.cloud/authParam":  "invalid_string_instead_of_dict",
+				"com.google.cloud/authInvoke": 12345,
+			},
+		}
+
+		schema, err := tr.ConvertToolDefinition(rawToolMalformed)
+		if err != nil {
+			t.Fatalf("ConvertToolDefinition should handle malformed _meta without error, got: %v", err)
+		}
+		if len(schema.AuthRequired) != 0 {
+			t.Errorf("Expected empty AuthRequired, got %v", schema.AuthRequired)
+		}
+	})
+
+	t.Run("InvalidProtocolVersion", func(t *testing.T) {
+		tr, _ := NewBaseTransport("http://example.com", nil)
+		tr.ProtocolVersion = "invalid-version-string"
+
+		rawTool := map[string]any{
+			"name": "testTool",
+		}
+
+		_, err := tr.ConvertToolDefinition(rawTool)
+		if err == nil {
+			t.Fatal("Expected ConvertToolDefinition to fail with invalid protocol version, got nil error")
+		}
+	})
 }

--- a/core/transport/mcp/v20241105/mcp.go
+++ b/core/transport/mcp/v20241105/mcp.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	ProtocolVersion = "2024-11-05"
+	ProtocolVersion = transport.MCPv20241105
 )
 
 // Ensure that McpTransport implements the Transport interface.
@@ -49,6 +49,7 @@ func New(baseURL string, client *http.Client, clientName string, clientVersion s
 	if err != nil {
 		return nil, err
 	}
+	baseTransport.ProtocolVersion = ProtocolVersion
 
 	if clientVersion == "" {
 		clientVersion = mcp.SDKVersion

--- a/core/transport/mcp/v20250326/mcp.go
+++ b/core/transport/mcp/v20250326/mcp.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	ProtocolVersion = "2025-03-26"
+	ProtocolVersion = transport.MCPv20250326
 )
 
 // Ensure that McpTransport implements the Transport interface.
@@ -52,6 +52,7 @@ func New(baseURL string, client *http.Client, clientName string, clientVersion s
 	if err != nil {
 		return nil, err
 	}
+	baseTransport.ProtocolVersion = ProtocolVersion
 	if clientVersion == "" {
 		clientVersion = mcp.SDKVersion
 	}

--- a/core/transport/mcp/v20250618/mcp.go
+++ b/core/transport/mcp/v20250618/mcp.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	ProtocolVersion = "2025-06-18"
+	ProtocolVersion = transport.MCPv20250618
 )
 
 // Ensure that McpTransport implements the Transport interface.
@@ -51,6 +51,7 @@ func New(baseURL string, client *http.Client, clientName string, clientVersion s
 	if err != nil {
 		return nil, err
 	}
+	baseTransport.ProtocolVersion = ProtocolVersion
 	if clientVersion == "" {
 		clientVersion = mcp.SDKVersion
 	}

--- a/core/transport/mcp/v20251125/mcp.go
+++ b/core/transport/mcp/v20251125/mcp.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	ProtocolVersion = "2025-11-25"
+	ProtocolVersion = transport.MCPv20251125
 )
 
 // Ensure that McpTransport implements the Transport interface.
@@ -52,6 +52,7 @@ func New(baseURL string, client *http.Client, clientName string, clientVersion s
 	if err != nil {
 		return nil, err
 	}
+	baseTransport.ProtocolVersion = ProtocolVersion
 	if clientVersion == "" {
 		clientVersion = mcp.SDKVersion
 	}

--- a/core/transport/mcp/v20260728/mcp.go
+++ b/core/transport/mcp/v20260728/mcp.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	ProtocolVersion = "2026-07-28"
+	ProtocolVersion = transport.MCPv20260728
 )
 
 // Ensure that McpTransport implements the Transport interface.
@@ -53,6 +53,7 @@ func New(baseURL string, client *http.Client, clientName string, clientVersion s
 	if err != nil {
 		return nil, err
 	}
+	baseTransport.ProtocolVersion = ProtocolVersion
 	if clientVersion == "" {
 		clientVersion = mcp.SDKVersion
 	}

--- a/core/transport/types.go
+++ b/core/transport/types.go
@@ -174,6 +174,47 @@ func (p *ParameterSchema) ValidateDefinition() error {
 	return nil
 }
 
+const (
+	MCPv20260728 = "2026-07-28"
+	MCPv20251125 = "2025-11-25"
+	MCPv20250618 = "2025-06-18"
+	MCPv20250326 = "2025-03-26"
+	MCPv20241105 = "2024-11-05"
+)
+
+// GetSupportedMcpVersions returns a list of supported MCP protocol versions in descending preference order.
+func GetSupportedMcpVersions() []string {
+	return []string{
+		MCPv20260728,
+		MCPv20251125,
+		MCPv20250618,
+		MCPv20250326,
+		MCPv20241105,
+	}
+}
+
+// IsVersionAtLeast determines if currentVersion is greater than or equal to minVersion based on supported version hierarchy.
+func IsVersionAtLeast(currentVersion, minVersion string) (bool, error) {
+	supported := GetSupportedMcpVersions()
+	currentIndex := -1
+	minIndex := -1
+	for i, v := range supported {
+		if v == currentVersion {
+			currentIndex = i
+		}
+		if v == minVersion {
+			minIndex = i
+		}
+	}
+	if currentIndex == -1 {
+		return false, fmt.Errorf("unrecognized protocol version: %s", currentVersion)
+	}
+	if minIndex == -1 {
+		return false, fmt.Errorf("unrecognized target protocol version: %s", minVersion)
+	}
+	return currentIndex <= minIndex, nil
+}
+
 // Schema for a tool.
 type ToolSchema struct {
 	Description  string            `json:"description"`

--- a/core/transport/types_test.go
+++ b/core/transport/types_test.go
@@ -772,3 +772,83 @@ func TestParameterSchema_NumberType(t *testing.T) {
 		}
 	})
 }
+
+func TestIsVersionAtLeast(t *testing.T) {
+	tests := []struct {
+		name           string
+		currentVersion string
+		minVersion     string
+		wantResult     bool
+		wantErr        bool
+	}{
+		{
+			name:           "Equal version",
+			currentVersion: "2026-07-28",
+			minVersion:     "2026-07-28",
+			wantResult:     true,
+			wantErr:        false,
+		},
+		{
+			name:           "Newer current version vs older min version",
+			currentVersion: "2026-07-28",
+			minVersion:     "2025-11-25",
+			wantResult:     true,
+			wantErr:        false,
+		},
+		{
+			name:           "Older current version vs newer min version",
+			currentVersion: "2025-03-26",
+			minVersion:     "2026-07-28",
+			wantResult:     false,
+			wantErr:        false,
+		},
+		{
+			name:           "Unrecognized current version",
+			currentVersion: "invalid-version",
+			minVersion:     "2026-07-28",
+			wantResult:     false,
+			wantErr:        true,
+		},
+		{
+			name:           "Unrecognized min version",
+			currentVersion: "2026-07-28",
+			minVersion:     "unknown-target",
+			wantResult:     false,
+			wantErr:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := IsVersionAtLeast(tt.currentVersion, tt.minVersion)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("IsVersionAtLeast(%q, %q) error = %v, wantErr %v", tt.currentVersion, tt.minVersion, err, tt.wantErr)
+				return
+			}
+			if got != tt.wantResult {
+				t.Errorf("IsVersionAtLeast(%q, %q) = %v, want %v", tt.currentVersion, tt.minVersion, got, tt.wantResult)
+			}
+		})
+	}
+}
+
+func TestGetSupportedMcpVersions(t *testing.T) {
+	versions := GetSupportedMcpVersions()
+	expected := []string{
+		MCPv20260728,
+		MCPv20251125,
+		MCPv20250618,
+		MCPv20250326,
+		MCPv20241105,
+	}
+
+	if len(versions) != len(expected) {
+		t.Fatalf("Expected %d supported versions, got %d", len(expected), len(versions))
+	}
+
+	for i, v := range versions {
+		if v != expected[i] {
+			t.Errorf("Index %d: expected version %s, got %s", i, expected[i], v)
+		}
+	}
+}


### PR DESCRIPTION
## Overview

Updates the Go SDK to support the `com.google.cloud/*` vendor namespace prefix introduced in MCP protocol version `2026-07-28` while maintaining backwards compatibility with `toolbox/*` vendor prefixes for legacy protocol versions ($< 2026-07-28$).

## Changes

  - Updated `ConvertToolDefinition` in `BaseMcpTransport` to conditionally parse `com.google.cloud/` vendor metadata keys (`authParam` and `authInvoke`) for protocol versions $\ge 2026-07-28$, falling back to `toolbox/` keys for pre-2026 versions.
  - Added `GetSupportedMcpVersions()` to return supported MCP version strings in descending order of preference.
  - Added `IsVersionAtLeast(currentVersion, minVersion string) (bool, error)` to check version precedence against supported versions.
  - Replaced temporary `MCPv20260618` constant with official `MCPv20260728`.
  - Explicitly set `ProtocolVersion` on `BaseMcpTransport` within version-specific constructors (`v20241105`, `v20250326`, `v20250618`, `v20251125`, `v20260728`).
  - Added unit test cases for `IsVersionAtLeast`, vendor prefix resolution (`com.google.cloud/*` vs `toolbox/*`), and handling of malformed `_meta` payloads in `client_test.go`, `protocol_test.go`, and `base_test.go`.