### PR TITLE
fix(mcp): include tool output in error message on execution failure

### DIFF
--- a/core/integration.cloudbuild.yaml
+++ b/core/integration.cloudbuild.yaml
@@ -137,5 +137,5 @@ steps:
 options:
   logging: CLOUD_LOGGING_ONLY
 substitutions:
-  _TOOLBOX_VERSION: '1.8.0'
+  _TOOLBOX_VERSION: '1.9.0'
   _TOOLBOX_MANIFEST_VERSION: '34'

--- a/core/transport/mcp/v20241105/mcp.go
+++ b/core/transport/mcp/v20241105/mcp.go
@@ -147,10 +147,6 @@ func (t *McpTransport) InvokeTool(ctx context.Context, toolName string, payload 
 		return "", fmt.Errorf("failed to invoke tool '%s': %w", toolName, err)
 	}
 
-	if result.IsError {
-		return "", fmt.Errorf("tool execution resulted in error")
-	}
-
 	baseContent := make([]mcp.ToolContent, len(result.Content))
 	for i, item := range result.Content {
 		baseContent[i] = mcp.ToolContent{
@@ -160,6 +156,10 @@ func (t *McpTransport) InvokeTool(ctx context.Context, toolName string, payload 
 	}
 
 	output := t.ProcessToolResultContent(baseContent)
+
+	if result.IsError {
+		return "", fmt.Errorf("tool execution resulted in error: %s", output)
+	}
 
 	return output, nil
 }

--- a/core/transport/mcp/v20250326/mcp.go
+++ b/core/transport/mcp/v20250326/mcp.go
@@ -146,10 +146,6 @@ func (t *McpTransport) InvokeTool(ctx context.Context, toolName string, payload 
 		return "", fmt.Errorf("failed to invoke tool '%s': %w", toolName, err)
 	}
 
-	if result.IsError {
-		return "", fmt.Errorf("tool execution resulted in error")
-	}
-
 	baseContent := make([]mcp.ToolContent, len(result.Content))
 	for i, item := range result.Content {
 		baseContent[i] = mcp.ToolContent{
@@ -159,6 +155,10 @@ func (t *McpTransport) InvokeTool(ctx context.Context, toolName string, payload 
 	}
 
 	output := t.ProcessToolResultContent(baseContent)
+
+	if result.IsError {
+		return "", fmt.Errorf("tool execution resulted in error: %s", output)
+	}
 
 	return output, nil
 }

--- a/core/transport/mcp/v20250618/mcp.go
+++ b/core/transport/mcp/v20250618/mcp.go
@@ -146,10 +146,6 @@ func (t *McpTransport) InvokeTool(ctx context.Context, toolName string, payload 
 		return "", fmt.Errorf("failed to invoke tool '%s': %w", toolName, err)
 	}
 
-	if result.IsError {
-		return "", fmt.Errorf("tool execution resulted in error")
-	}
-
 	baseContent := make([]mcp.ToolContent, len(result.Content))
 	for i, item := range result.Content {
 		baseContent[i] = mcp.ToolContent{
@@ -159,6 +155,10 @@ func (t *McpTransport) InvokeTool(ctx context.Context, toolName string, payload 
 	}
 
 	output := t.ProcessToolResultContent(baseContent)
+
+	if result.IsError {
+		return "", fmt.Errorf("tool execution resulted in error: %s", output)
+	}
 
 	return output, nil
 }

--- a/core/transport/mcp/v20251125/mcp.go
+++ b/core/transport/mcp/v20251125/mcp.go
@@ -147,10 +147,6 @@ func (t *McpTransport) InvokeTool(ctx context.Context, toolName string, payload 
 		return "", fmt.Errorf("failed to invoke tool '%s': %w", toolName, err)
 	}
 
-	if result.IsError {
-		return "", fmt.Errorf("tool execution resulted in error")
-	}
-
 	baseContent := make([]mcp.ToolContent, len(result.Content))
 	for i, item := range result.Content {
 		baseContent[i] = mcp.ToolContent{
@@ -160,6 +156,10 @@ func (t *McpTransport) InvokeTool(ctx context.Context, toolName string, payload 
 	}
 
 	output := t.ProcessToolResultContent(baseContent)
+
+	if result.IsError {
+		return "", fmt.Errorf("tool execution resulted in error: %s", output)
+	}
 
 	return output, nil
 }

--- a/core/transport/mcp/v20260728/mcp.go
+++ b/core/transport/mcp/v20260728/mcp.go
@@ -155,11 +155,11 @@ func (t *McpTransport) InvokeTool(ctx context.Context, toolName string, payload 
 		return "", fmt.Errorf("failed to invoke tool '%s': %w", toolName, err)
 	}
 
-	if result.IsError {
-		return "", fmt.Errorf("tool execution resulted in error")
-	}
-
 	output := t.ProcessToolResultContent(result.Content)
+
+	if result.IsError {
+		return "", fmt.Errorf("tool execution resulted in error: %s", output)
+	}
 
 	return output, nil
 }

--- a/tbadk/integration.cloudbuild.yaml
+++ b/tbadk/integration.cloudbuild.yaml
@@ -98,5 +98,5 @@ steps:
 options:
   logging: CLOUD_LOGGING_ONLY
 substitutions:
-  _TOOLBOX_VERSION: '1.8.0'
+  _TOOLBOX_VERSION: '1.9.0'
   _TOOLBOX_MANIFEST_VERSION: '34'

--- a/tbgenkit/integration.cloudbuild.yaml
+++ b/tbgenkit/integration.cloudbuild.yaml
@@ -44,5 +44,5 @@ steps:
 options:
   logging: CLOUD_LOGGING_ONLY
 substitutions:
-  _TOOLBOX_VERSION: '1.8.0'
+  _TOOLBOX_VERSION: '1.9.0'
   _TOOLBOX_MANIFEST_VERSION: '34'


### PR DESCRIPTION
## Description
Preserves and includes the server's detailed error content in the returned `error` when a tool execution fails (`isError: true`) across all MCP transport protocol versions.

### Context
When the MCP server returns a tool execution error (`result.IsError == true`), the Go SDK's MCP transport previously returned a hardcoded generic error:
```go
return "", fmt.Errorf("tool execution resulted in error")
```
This dropped `result.Content`, hiding the actual failure reason from callers and LLMs.

Starting in MCP Toolbox Server `v1.9.0`, parameter parsing errors are returned as tool execution results (`isError: true`). Preserving `result.Content` ensures users and downstream agents receive the exact failure reason from the server.

### Changes
  * Updated `InvokeTool` in all supported MCP versions (`v20241105`, `v20250326`, `v20250618`, `v20251125`, `v20260728`) to process `result.Content` and format it into the error:
    ```go
    return "", fmt.Errorf("tool execution resulted in error: %s", output)
    ```
  * Updated `core/e2e_mcp_test.go`, `tbadk/e2e_test.go`, and `tbgenkit/tbgenkit_test.go` to assert that the error contains `"no field named row_data in claims"`.
* **CI Configuration:**
  * Bumped `_TOOLBOX_VERSION` to `1.9.0` in `core/integration.cloudbuild.yaml`, `tbadk/integration.cloudbuild.yaml`, and `tbgenkit/integration.cloudbuild.yaml`.
