### PR TITLE
fix(ci): queue pending api-docs deploys instead of dropping them

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -20,9 +20,13 @@ on:
     tags: [ '**' ]
   workflow_dispatch:
 
+# One group: runs share the site root and each package's releases/latest files,
+# and the deploy action pushes without retrying. queue: max holds 100 pending
+# runs instead of the default 1, which cancels a queued run on a third push.
 concurrency:
   group: api-docs-deploy
   cancel-in-progress: false
+  queue: max
 
 jobs:
   deploy:


### PR DESCRIPTION
Replicates https://github.com/googleapis/mcp-toolbox-sdk-js/pull/444

## Why

The `api-docs-deploy` concurrency group uses the default queue, which holds only **one** pending run — so a third push cancels the second before it starts, with no failed job and no red check. That silently dropped two released versions in the JS repo and seven in Python.

This repo is **not currently affected** — every `core/`, `tbadk/` and `tbgenkit/` tag is published and there are zero cancelled `api-docs` runs. The reason is that it pushes only two refs per release (no `release-please-*` tags), and with two the pending run always survives. Three packages means a third contender is one simultaneous release away.

## What

- **`queue: max`** — queues up to 100 pending runs in FIFO instead of 1.
- **Keep the shared group** — the deploy action pushes without retrying, and runs share the site root and the per-package `releases.releases` / `latest/` files.

The `tags-ignore: release-please-*` change from the JS PR is **omitted here** — this repo has no such tags, so it would be dead config. Say the word if you'd rather keep the three repos byte-identical.

Verified on the JS repo with a live A/B test: under three pushes 20s apart, `queue: max` ran 3/3 while the default `single` cancelled the middle run.
