### PR TITLE
feat(core): protocol and wire transport support for secure parameters

### DIFF
--- a/core/protocol.go
+++ b/core/protocol.go
@@ -34,6 +34,8 @@ const (
 
 	MCPLatest Protocol = MCPv20260728
 	MCPDraft  Protocol = MCPv20260728
+
+	ExtensionSecureParams = transport.ExtensionSecureParams
 )
 
 // GetSupportedMcpVersions returns a list of supported MCP protocol versions.

--- a/core/tool.go
+++ b/core/tool.go
@@ -320,7 +320,7 @@ func (tt *ToolboxTool) Invoke(ctx context.Context, input map[string]any) (any, e
 
 	checkSecureHeaders(tt.transport.BaseURL(), len(tt.authTokenSources) > 0)
 
-	response, err := tt.transport.InvokeTool(ctx, tt.name, finalPayload, resolvedHeaders)
+	response, err := tt.transport.InvokeTool(ctx, tt.name, finalPayload, nil, resolvedHeaders)
 	if err != nil {
 		return nil, err
 	}

--- a/core/tool_test.go
+++ b/core/tool_test.go
@@ -47,7 +47,7 @@ func (d *dummyTransport) GetTool(ctx context.Context, name string, h map[string]
 func (d *dummyTransport) ListTools(ctx context.Context, set string, h map[string]string) (*transport.ManifestSchema, error) {
 	return nil, nil
 }
-func (d *dummyTransport) InvokeTool(ctx context.Context, name string, p map[string]any, h map[string]string) (any, error) {
+func (d *dummyTransport) InvokeTool(ctx context.Context, name string, p map[string]any, sp map[string]any, h map[string]string) (any, error) {
 	return nil, nil
 }
 

--- a/core/transport/interface.go
+++ b/core/transport/interface.go
@@ -28,5 +28,5 @@ type Transport interface {
 	ListTools(ctx context.Context, toolsetName string, headers map[string]string) (*ManifestSchema, error)
 
 	// InvokeTool executes a tool.
-	InvokeTool(ctx context.Context, toolName string, payload map[string]any, headers map[string]string) (any, error)
+	InvokeTool(ctx context.Context, toolName string, payload map[string]any, securePayload map[string]any, headers map[string]string) (any, error)
 }

--- a/core/transport/mcp/base.go
+++ b/core/transport/mcp/base.go
@@ -227,10 +227,33 @@ func (b *BaseMcpTransport) ConvertToolDefinition(toolData map[string]any) (trans
 		parameters = append(parameters, param)
 	}
 
+	var secureParameters []transport.ParameterSchema
+	if secureInputSchema, ok := toolData["secureInputSchema"].(map[string]any); ok {
+		secProperties, _ := secureInputSchema["properties"].(map[string]any)
+		secRequiredSet := make(map[string]bool)
+		if reqList, ok := secureInputSchema["required"].([]any); ok {
+			for _, r := range reqList {
+				if s, ok := r.(string); ok {
+					secRequiredSet[s] = true
+				}
+			}
+		}
+		secureParameters = make([]transport.ParameterSchema, 0, len(secProperties))
+		for propertyName, definition := range secProperties {
+			definitionMap, ok := definition.(map[string]any)
+			if !ok {
+				continue
+			}
+			param := parseProperty(propertyName, definitionMap, secRequiredSet[propertyName])
+			secureParameters = append(secureParameters, param)
+		}
+	}
+
 	return transport.ToolSchema{
-		Description:  description,
-		Parameters:   parameters,
-		AuthRequired: invokeAuth,
+		Description:      description,
+		Parameters:       parameters,
+		SecureParameters: secureParameters,
+		AuthRequired:     invokeAuth,
 	}, nil
 }
 

--- a/core/transport/mcp/v20241105/mcp.go
+++ b/core/transport/mcp/v20241105/mcp.go
@@ -132,7 +132,10 @@ func (t *McpTransport) GetTool(ctx context.Context, toolName string, headers map
 }
 
 // InvokeTool executes a tool
-func (t *McpTransport) InvokeTool(ctx context.Context, toolName string, payload map[string]any, headers map[string]string) (any, error) {
+func (t *McpTransport) InvokeTool(ctx context.Context, toolName string, payload map[string]any, securePayload map[string]any, headers map[string]string) (any, error) {
+	if len(securePayload) > 0 {
+		return "", fmt.Errorf("secure parameters are not supported in MCP protocol version %q. Please use protocol version '2026-07-28' or newer", t.protocolVersion)
+	}
 	if err := t.EnsureInitialized(ctx, headers); err != nil {
 		return "", err
 	}

--- a/core/transport/mcp/v20241105/mcp_test.go
+++ b/core/transport/mcp/v20241105/mcp_test.go
@@ -244,7 +244,7 @@ func TestInvokeTool(t *testing.T) {
 
 	t.Run("Success", func(t *testing.T) {
 		args := map[string]any{"message": "Hello MCP"}
-		result, err := client.InvokeTool(ctx, "echo", args, nil)
+		result, err := client.InvokeTool(ctx, "echo", args, nil, nil)
 		require.NoError(t, err)
 
 		resStr, ok := result.(string)
@@ -407,9 +407,17 @@ func TestRequest_MarshalError(t *testing.T) {
 
 	// Pass a type that cannot be marshaled to JSON (e.g. channel)
 	badPayload := map[string]any{"bad": make(chan int)}
-	_, err := client.InvokeTool(context.Background(), "tool", badPayload, nil)
+	_, err := client.InvokeTool(context.Background(), "tool", badPayload, nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "marshal failed")
+}
+
+func TestInvokeTool_SecureParams_NotSupported(t *testing.T) {
+	client, _ := New("http://example.com", nil, "custom-client", "1.0.0")
+	_, err := client.InvokeTool(context.Background(), "tool", map[string]any{}, map[string]any{"secret": "val"}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secure parameters are not supported in MCP protocol version \"2024-11-05\"")
+	assert.Contains(t, err.Error(), "Please use protocol version '2026-07-28' or newer")
 }
 
 func TestInvokeTool_ErrorResult(t *testing.T) {
@@ -424,7 +432,7 @@ func TestInvokeTool_ErrorResult(t *testing.T) {
 	}
 
 	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0")
-	_, err := client.InvokeTool(context.Background(), "tool", nil, nil)
+	_, err := client.InvokeTool(context.Background(), "tool", nil, nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "tool execution resulted in error")
 }
@@ -438,7 +446,7 @@ func TestInvokeTool_RPCError(t *testing.T) {
 	}
 
 	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0")
-	_, err := client.InvokeTool(context.Background(), "tool", nil, nil)
+	_, err := client.InvokeTool(context.Background(), "tool", nil, nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "internal server error")
 }
@@ -458,7 +466,7 @@ func TestInvokeTool_ComplexContent(t *testing.T) {
 	}
 
 	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0")
-	res, err := client.InvokeTool(context.Background(), "t", nil, nil)
+	res, err := client.InvokeTool(context.Background(), "t", nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "Part 1 Part 2", res)
 }
@@ -474,7 +482,7 @@ func TestInvokeTool_EmptyResult(t *testing.T) {
 	}
 
 	client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0")
-	res, err := client.InvokeTool(context.Background(), "t", nil, nil)
+	res, err := client.InvokeTool(context.Background(), "t", nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "null", res)
 }
@@ -496,7 +504,7 @@ func TestInvokeTool_ContentProcessing_Scenarios(t *testing.T) {
 		}
 
 		client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0")
-		result, err := client.InvokeTool(context.Background(), "tool", nil, nil)
+		result, err := client.InvokeTool(context.Background(), "tool", nil, nil, nil)
 		require.NoError(t, err)
 
 		// Expectation: The transport should merge these into a single JSON array string
@@ -520,7 +528,7 @@ func TestInvokeTool_ContentProcessing_Scenarios(t *testing.T) {
 		}
 
 		client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0")
-		result, err := client.InvokeTool(context.Background(), "tool", nil, nil)
+		result, err := client.InvokeTool(context.Background(), "tool", nil, nil, nil)
 		require.NoError(t, err)
 
 		// Expectation: Simple concatenation
@@ -544,7 +552,7 @@ func TestInvokeTool_ContentProcessing_Scenarios(t *testing.T) {
 		}
 
 		client, _ := New(server.URL, server.Client(), "custom-client", "1.0.0")
-		result, err := client.InvokeTool(context.Background(), "tool", nil, nil)
+		result, err := client.InvokeTool(context.Background(), "tool", nil, nil, nil)
 		require.NoError(t, err)
 
 		// Expectation: Concatenated to form the valid JSON string

--- a/core/transport/mcp/v20250326/mcp.go
+++ b/core/transport/mcp/v20250326/mcp.go
@@ -132,7 +132,10 @@ func (t *McpTransport) GetTool(ctx context.Context, toolName string, headers map
 }
 
 // InvokeTool executes a tool
-func (t *McpTransport) InvokeTool(ctx context.Context, toolName string, payload map[string]any, headers map[string]string) (any, error) {
+func (t *McpTransport) InvokeTool(ctx context.Context, toolName string, payload map[string]any, securePayload map[string]any, headers map[string]string) (any, error) {
+	if len(securePayload) > 0 {
+		return "", fmt.Errorf("secure parameters are not supported in MCP protocol version %q. Please use protocol version '2026-07-28' or newer", t.protocolVersion)
+	}
 	if err := t.EnsureInitialized(ctx, headers); err != nil {
 		return "", err
 	}

--- a/core/transport/mcp/v20250326/mcp_test.go
+++ b/core/transport/mcp/v20250326/mcp_test.go
@@ -191,7 +191,7 @@ func TestSessionId_Injection_InvokeTool(t *testing.T) {
 	}
 
 	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
-	_, err := client.InvokeTool(context.Background(), "test-tool", map[string]any{"a": 1}, nil)
+	_, err := client.InvokeTool(context.Background(), "test-tool", map[string]any{"a": 1}, nil, nil)
 	require.NoError(t, err)
 
 	// Verify requests
@@ -290,7 +290,7 @@ func TestInvokeTool_ErrorResult(t *testing.T) {
 	}
 
 	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
-	_, err := client.InvokeTool(context.Background(), "tool", nil, nil)
+	_, err := client.InvokeTool(context.Background(), "tool", nil, nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "tool execution resulted in error")
 }
@@ -304,9 +304,17 @@ func TestInvokeTool_RPCError(t *testing.T) {
 	}
 
 	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
-	_, err := client.InvokeTool(context.Background(), "tool", nil, nil)
+	_, err := client.InvokeTool(context.Background(), "tool", nil, nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "internal server error")
+}
+
+func TestInvokeTool_SecureParams_NotSupported(t *testing.T) {
+	client, _ := New("http://example.com", nil, "test-client", "1.0.0")
+	_, err := client.InvokeTool(context.Background(), "tool", map[string]any{}, map[string]any{"secret": "val"}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secure parameters are not supported in MCP protocol version \"2025-03-26\"")
+	assert.Contains(t, err.Error(), "Please use protocol version '2026-07-28' or newer")
 }
 
 func TestListTools_WithAuthHeaders(t *testing.T) {
@@ -414,7 +422,7 @@ func TestRequest_MarshalError(t *testing.T) {
 	_ = client.EnsureInitialized(context.Background(), nil)
 
 	badPayload := map[string]any{"bad": make(chan int)}
-	_, err := client.InvokeTool(context.Background(), "tool", badPayload, nil)
+	_, err := client.InvokeTool(context.Background(), "tool", badPayload, nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "marshal failed")
 }
@@ -494,7 +502,7 @@ func TestInvokeTool_ComplexContent(t *testing.T) {
 	}
 
 	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
-	res, err := client.InvokeTool(context.Background(), "t", nil, nil)
+	res, err := client.InvokeTool(context.Background(), "t", nil, nil, nil)
 	require.NoError(t, err)
 	// Only text types should be concatenated
 	assert.Equal(t, "Part 1 Part 2", res)
@@ -511,7 +519,7 @@ func TestInvokeTool_EmptyResult(t *testing.T) {
 	}
 
 	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
-	res, err := client.InvokeTool(context.Background(), "t", nil, nil)
+	res, err := client.InvokeTool(context.Background(), "t", nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "null", res)
 }
@@ -565,7 +573,7 @@ func TestInvokeTool_ContentProcessing_Scenarios(t *testing.T) {
 		}
 
 		client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
-		result, err := client.InvokeTool(context.Background(), "tool", nil, nil)
+		result, err := client.InvokeTool(context.Background(), "tool", nil, nil, nil)
 		require.NoError(t, err)
 
 		// Expectation: The transport should merge these into a single JSON array string
@@ -589,7 +597,7 @@ func TestInvokeTool_ContentProcessing_Scenarios(t *testing.T) {
 		}
 
 		client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
-		result, err := client.InvokeTool(context.Background(), "tool", nil, nil)
+		result, err := client.InvokeTool(context.Background(), "tool", nil, nil, nil)
 		require.NoError(t, err)
 
 		// Expectation: Simple concatenation
@@ -601,6 +609,7 @@ func TestInvokeTool_ContentProcessing_Scenarios(t *testing.T) {
 		defer server.Close()
 
 		// Mock response where a single JSON object is split across chunks.
+		// Since individual chunks are NOT valid JSON objects, it falls back to concatenation.
 		server.handlers["tools/call"] = func(params json.RawMessage) (any, map[string]string, error) {
 			return callToolResult{
 				Content: []textContent{
@@ -612,7 +621,7 @@ func TestInvokeTool_ContentProcessing_Scenarios(t *testing.T) {
 		}
 
 		client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
-		result, err := client.InvokeTool(context.Background(), "tool", nil, nil)
+		result, err := client.InvokeTool(context.Background(), "tool", nil, nil, nil)
 		require.NoError(t, err)
 
 		// Expectation: Concatenated to form the valid JSON string

--- a/core/transport/mcp/v20250618/mcp.go
+++ b/core/transport/mcp/v20250618/mcp.go
@@ -132,7 +132,10 @@ func (t *McpTransport) GetTool(ctx context.Context, toolName string, headers map
 }
 
 // InvokeTool executes a tool
-func (t *McpTransport) InvokeTool(ctx context.Context, toolName string, payload map[string]any, headers map[string]string) (any, error) {
+func (t *McpTransport) InvokeTool(ctx context.Context, toolName string, payload map[string]any, securePayload map[string]any, headers map[string]string) (any, error) {
+	if len(securePayload) > 0 {
+		return "", fmt.Errorf("secure parameters are not supported in MCP protocol version %q. Please use protocol version '2026-07-28' or newer", t.protocolVersion)
+	}
 	if err := t.EnsureInitialized(ctx, headers); err != nil {
 		return "", err
 	}

--- a/core/transport/mcp/v20250618/mcp_test.go
+++ b/core/transport/mcp/v20250618/mcp_test.go
@@ -276,7 +276,7 @@ func TestInvokeTool(t *testing.T) {
 
 	t.Run("Success", func(t *testing.T) {
 		args := map[string]any{"message": "Hello MCP"}
-		result, err := client.InvokeTool(ctx, "echo", args, nil)
+		result, err := client.InvokeTool(ctx, "echo", args, nil, nil)
 		require.NoError(t, err)
 
 		resStr, ok := result.(string)
@@ -446,9 +446,17 @@ func TestRequest_MarshalError(t *testing.T) {
 
 	// Pass a type that cannot be marshaled to JSON (e.g. channel)
 	badPayload := map[string]any{"bad": make(chan int)}
-	_, err := client.InvokeTool(context.Background(), "tool", badPayload, nil)
+	_, err := client.InvokeTool(context.Background(), "tool", badPayload, nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "marshal failed")
+}
+
+func TestInvokeTool_SecureParams_NotSupported(t *testing.T) {
+	client, _ := New("http://example.com", nil, "test-client", "1.0.0")
+	_, err := client.InvokeTool(context.Background(), "tool", map[string]any{}, map[string]any{"secret": "val"}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secure parameters are not supported in MCP protocol version \"2025-06-18\"")
+	assert.Contains(t, err.Error(), "Please use protocol version '2026-07-28' or newer")
 }
 
 func TestInvokeTool_ErrorResult(t *testing.T) {
@@ -463,7 +471,7 @@ func TestInvokeTool_ErrorResult(t *testing.T) {
 	}
 
 	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
-	_, err := client.InvokeTool(context.Background(), "tool", nil, nil)
+	_, err := client.InvokeTool(context.Background(), "tool", nil, nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "tool execution resulted in error")
 }
@@ -477,7 +485,7 @@ func TestInvokeTool_RPCError(t *testing.T) {
 	}
 
 	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
-	_, err := client.InvokeTool(context.Background(), "tool", nil, nil)
+	_, err := client.InvokeTool(context.Background(), "tool", nil, nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "internal server error")
 }
@@ -497,7 +505,7 @@ func TestInvokeTool_ComplexContent(t *testing.T) {
 	}
 
 	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
-	res, err := client.InvokeTool(context.Background(), "t", nil, nil)
+	res, err := client.InvokeTool(context.Background(), "t", nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "Part 1 Part 2", res)
 }
@@ -513,7 +521,7 @@ func TestInvokeTool_EmptyResult(t *testing.T) {
 	}
 
 	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
-	res, err := client.InvokeTool(context.Background(), "t", nil, nil)
+	res, err := client.InvokeTool(context.Background(), "t", nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "null", res)
 }
@@ -534,7 +542,7 @@ func TestInvokeTool_ContentProcessing_Scenarios(t *testing.T) {
 		}
 
 		client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
-		result, err := client.InvokeTool(context.Background(), "tool", nil, nil)
+		result, err := client.InvokeTool(context.Background(), "tool", nil, nil, nil)
 		require.NoError(t, err)
 
 		// Expectation: The transport should merge these into a single JSON array string
@@ -558,7 +566,7 @@ func TestInvokeTool_ContentProcessing_Scenarios(t *testing.T) {
 		}
 
 		client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
-		result, err := client.InvokeTool(context.Background(), "tool", nil, nil)
+		result, err := client.InvokeTool(context.Background(), "tool", nil, nil, nil)
 		require.NoError(t, err)
 
 		// Expectation: Simple concatenation
@@ -581,7 +589,7 @@ func TestInvokeTool_ContentProcessing_Scenarios(t *testing.T) {
 		}
 
 		client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
-		result, err := client.InvokeTool(context.Background(), "tool", nil, nil)
+		result, err := client.InvokeTool(context.Background(), "tool", nil, nil, nil)
 		require.NoError(t, err)
 
 		// Expectation: Concatenated to form the valid JSON string

--- a/core/transport/mcp/v20251125/mcp.go
+++ b/core/transport/mcp/v20251125/mcp.go
@@ -133,7 +133,10 @@ func (t *McpTransport) GetTool(ctx context.Context, toolName string, headers map
 }
 
 // InvokeTool executes a tool
-func (t *McpTransport) InvokeTool(ctx context.Context, toolName string, payload map[string]any, headers map[string]string) (any, error) {
+func (t *McpTransport) InvokeTool(ctx context.Context, toolName string, payload map[string]any, securePayload map[string]any, headers map[string]string) (any, error) {
+	if len(securePayload) > 0 {
+		return "", fmt.Errorf("secure parameters are not supported in MCP protocol version %q. Please use protocol version '2026-07-28' or newer", t.protocolVersion)
+	}
 	if err := t.EnsureInitialized(ctx, headers); err != nil {
 		return "", err
 	}

--- a/core/transport/mcp/v20251125/mcp_test.go
+++ b/core/transport/mcp/v20251125/mcp_test.go
@@ -276,7 +276,7 @@ func TestInvokeTool(t *testing.T) {
 
 	t.Run("Success", func(t *testing.T) {
 		args := map[string]any{"message": "Hello MCP"}
-		result, err := client.InvokeTool(ctx, "echo", args, nil)
+		result, err := client.InvokeTool(ctx, "echo", args, nil, nil)
 		require.NoError(t, err)
 
 		resStr, ok := result.(string)
@@ -445,9 +445,17 @@ func TestRequest_MarshalError(t *testing.T) {
 
 	// Pass a type that cannot be marshaled to JSON (e.g. channel)
 	badPayload := map[string]any{"bad": make(chan int)}
-	_, err := client.InvokeTool(context.Background(), "tool", badPayload, nil)
+	_, err := client.InvokeTool(context.Background(), "tool", badPayload, nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "marshal failed")
+}
+
+func TestInvokeTool_SecureParams_NotSupported(t *testing.T) {
+	client, _ := New("http://example.com", nil, "test-client", "1.0.0")
+	_, err := client.InvokeTool(context.Background(), "tool", map[string]any{}, map[string]any{"secret": "val"}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secure parameters are not supported in MCP protocol version \"2025-11-25\"")
+	assert.Contains(t, err.Error(), "Please use protocol version '2026-07-28' or newer")
 }
 
 func TestInvokeTool_ErrorResult(t *testing.T) {
@@ -462,7 +470,7 @@ func TestInvokeTool_ErrorResult(t *testing.T) {
 	}
 
 	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
-	_, err := client.InvokeTool(context.Background(), "tool", nil, nil)
+	_, err := client.InvokeTool(context.Background(), "tool", nil, nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "tool execution resulted in error")
 }
@@ -476,7 +484,7 @@ func TestInvokeTool_RPCError(t *testing.T) {
 	}
 
 	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
-	_, err := client.InvokeTool(context.Background(), "tool", nil, nil)
+	_, err := client.InvokeTool(context.Background(), "tool", nil, nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "internal server error")
 }
@@ -496,7 +504,7 @@ func TestInvokeTool_ComplexContent(t *testing.T) {
 	}
 
 	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
-	res, err := client.InvokeTool(context.Background(), "t", nil, nil)
+	res, err := client.InvokeTool(context.Background(), "t", nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "Part 1 Part 2", res)
 }
@@ -512,7 +520,7 @@ func TestInvokeTool_EmptyResult(t *testing.T) {
 	}
 
 	client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
-	res, err := client.InvokeTool(context.Background(), "t", nil, nil)
+	res, err := client.InvokeTool(context.Background(), "t", nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "null", res)
 }
@@ -533,7 +541,7 @@ func TestInvokeTool_ContentProcessing_Scenarios(t *testing.T) {
 		}
 
 		client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
-		result, err := client.InvokeTool(context.Background(), "tool", nil, nil)
+		result, err := client.InvokeTool(context.Background(), "tool", nil, nil, nil)
 		require.NoError(t, err)
 
 		// Expectation: The transport should merge these into a single JSON array string
@@ -557,7 +565,7 @@ func TestInvokeTool_ContentProcessing_Scenarios(t *testing.T) {
 		}
 
 		client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
-		result, err := client.InvokeTool(context.Background(), "tool", nil, nil)
+		result, err := client.InvokeTool(context.Background(), "tool", nil, nil, nil)
 		require.NoError(t, err)
 
 		// Expectation: Simple concatenation
@@ -580,7 +588,7 @@ func TestInvokeTool_ContentProcessing_Scenarios(t *testing.T) {
 		}
 
 		client, _ := New(server.URL, server.Client(), "test-client", "1.0.0")
-		result, err := client.InvokeTool(context.Background(), "tool", nil, nil)
+		result, err := client.InvokeTool(context.Background(), "tool", nil, nil, nil)
 		require.NoError(t, err)
 
 		// Expectation: Concatenated to form the valid JSON string

--- a/core/transport/mcp/v20260728/mcp.go
+++ b/core/transport/mcp/v20260728/mcp.go
@@ -107,6 +107,9 @@ func (t *McpTransport) ListTools(ctx context.Context, toolsetName string, header
 			"description": tool.Description,
 			"inputSchema": tool.InputSchema,
 		}
+		if tool.SecureInputSchema != nil {
+			rawTool["secureInputSchema"] = tool.SecureInputSchema
+		}
 		if tool.Meta != nil {
 			rawTool["_meta"] = tool.Meta
 		}
@@ -141,13 +144,17 @@ func (t *McpTransport) GetTool(ctx context.Context, toolName string, headers map
 }
 
 // InvokeTool executes a tool
-func (t *McpTransport) InvokeTool(ctx context.Context, toolName string, payload map[string]any, headers map[string]string) (any, error) {
+func (t *McpTransport) InvokeTool(ctx context.Context, toolName string, payload map[string]any, securePayload map[string]any, headers map[string]string) (any, error) {
 	if payload == nil {
 		payload = make(map[string]any)
 	}
+	if len(securePayload) == 0 {
+		securePayload = nil
+	}
 	params := callToolRequestParams{
-		Name:      toolName,
-		Arguments: payload,
+		Name:            toolName,
+		Arguments:       payload,
+		SecureArguments: securePayload,
 	}
 
 	var result callToolResult
@@ -196,7 +203,11 @@ func (t *McpTransport) doRPC(ctx context.Context, url string, reqBody any, heade
 			Name:    t.clientName,
 			Version: t.clientVersion,
 		},
-		ClientCapabilities: clientCapabilities{},
+		ClientCapabilities: clientCapabilities{
+			"extensions": map[string]any{
+				transport.ExtensionSecureParams: map[string]any{},
+			},
+		},
 	}
 
 	toolName := extractMcpName(reqBody)

--- a/core/transport/mcp/v20260728/mcp_test.go
+++ b/core/transport/mcp/v20260728/mcp_test.go
@@ -101,7 +101,6 @@ func TestListTools_ServerVersionFromMetadata(t *testing.T) {
 	assert.Equal(t, "1.2.3", tr.ServerVersion)
 }
 
-
 func TestInvokeToolAndHeaders(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "2026-07-28", r.Header.Get("MCP-Protocol-Version"))
@@ -129,7 +128,7 @@ func TestInvokeToolAndHeaders(t *testing.T) {
 	tr, err := New(ts.URL, ts.Client(), "test-client", "1.0.0")
 	require.NoError(t, err)
 
-	res, err := tr.InvokeTool(context.Background(), "test_tool", nil, nil)
+	res, err := tr.InvokeTool(context.Background(), "test_tool", nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "hello", res)
 }
@@ -163,7 +162,7 @@ func TestInvokeTool_NilArgumentsSerializedAsObject(t *testing.T) {
 	tr, err := New(ts.URL, ts.Client(), "test-client", "1.0.0")
 	require.NoError(t, err)
 
-	res, err := tr.InvokeTool(context.Background(), "test_tool", nil, nil)
+	res, err := tr.InvokeTool(context.Background(), "test_tool", nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "ok", res)
 }
@@ -190,7 +189,7 @@ func TestPrepareHeadersMcpName(t *testing.T) {
 	tr, err := New(ts.URL, ts.Client(), "test-client", "1.0.0")
 	require.NoError(t, err)
 
-	res, err := tr.InvokeTool(context.Background(), "my_tool", nil, nil)
+	res, err := tr.InvokeTool(context.Background(), "my_tool", nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "ok", res)
 }
@@ -262,7 +261,7 @@ func TestResultTypeParsingAndFallback(t *testing.T) {
 	tr, err := New(ts.URL, ts.Client(), "test-client", "1.0.0")
 	require.NoError(t, err)
 
-	res, err := tr.InvokeTool(context.Background(), "test_tool", nil, nil)
+	res, err := tr.InvokeTool(context.Background(), "test_tool", nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "test output", res)
 }
@@ -359,7 +358,6 @@ func TestSendRequest_AddsMcpNameHeaderForPromptsGet(t *testing.T) {
 	require.NoError(t, err)
 }
 
-
 func TestRequestID_GeneratesUniqueUUIDs(t *testing.T) {
 	var capturedIDs []string
 
@@ -435,7 +433,7 @@ func TestInvokeTool_ErrorResult(t *testing.T) {
 	tr, err := New(ts.URL, ts.Client(), "test-client", "1.0.0")
 	require.NoError(t, err)
 
-	_, err = tr.InvokeTool(context.Background(), "tool", nil, nil)
+	_, err = tr.InvokeTool(context.Background(), "tool", nil, nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "tool execution resulted in error")
 }
@@ -450,7 +448,7 @@ func TestInvokeTool_RPCError(t *testing.T) {
 	tr, err := New(ts.URL, ts.Client(), "test-client", "1.0.0")
 	require.NoError(t, err)
 
-	_, err = tr.InvokeTool(context.Background(), "tool", nil, nil)
+	_, err = tr.InvokeTool(context.Background(), "tool", nil, nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to invoke tool 'tool':")
 }
@@ -543,7 +541,7 @@ func TestInvokeTool_ComplexContent(t *testing.T) {
 	tr, err := New(ts.URL, ts.Client(), "test-client", "1.0.0")
 	require.NoError(t, err)
 
-	res, err := tr.InvokeTool(context.Background(), "t", nil, nil)
+	res, err := tr.InvokeTool(context.Background(), "t", nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "Part 1 Part 2", res)
 }
@@ -564,7 +562,7 @@ func TestInvokeTool_EmptyResult(t *testing.T) {
 	tr, err := New(ts.URL, ts.Client(), "test-client", "1.0.0")
 	require.NoError(t, err)
 
-	res, err := tr.InvokeTool(context.Background(), "t", nil, nil)
+	res, err := tr.InvokeTool(context.Background(), "t", nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "null", res)
 }
@@ -589,7 +587,7 @@ func TestInvokeTool_ContentProcessing_Scenarios(t *testing.T) {
 		tr, err := New(ts.URL, ts.Client(), "test-client", "1.0.0")
 		require.NoError(t, err)
 
-		res, err := tr.InvokeTool(context.Background(), "tool", nil, nil)
+		res, err := tr.InvokeTool(context.Background(), "tool", nil, nil, nil)
 		require.NoError(t, err)
 		assert.Equal(t, `[{"foo":"bar"},{"foo":"quux"}]`, res)
 	})
@@ -750,6 +748,307 @@ func TestJSONRPCError_ProtocolNegotiation(t *testing.T) {
 	}
 }
 
+func TestClientCapabilities_AdvertisesSecureParamsExtension(t *testing.T) {
+	testCases := []struct {
+		name string
+		call func(ctx context.Context, tr *McpTransport) error
+	}{
+		{
+			name: "tools/list",
+			call: func(ctx context.Context, tr *McpTransport) error {
+				_, err := tr.ListTools(ctx, "", nil)
+				return err
+			},
+		},
+		{
+			name: "tools/call",
+			call: func(ctx context.Context, tr *McpTransport) error {
+				_, err := tr.InvokeTool(ctx, "test_tool", nil, nil, nil)
+				return err
+			},
+		},
+	}
 
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var capturedMeta map[string]any
 
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
 
+				var req map[string]any
+				require.NoError(t, json.Unmarshal(body, &req))
+				if params, ok := req["params"].(map[string]any); ok {
+					capturedMeta, _ = params["_meta"].(map[string]any)
+				}
+
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{
+					"jsonrpc": "2.0",
+					"id": "1",
+					"result": {
+						"tools": [],
+						"content": [{"type": "text", "text": "ok"}]
+					}
+				}`))
+			}))
+			defer ts.Close()
+
+			tr, err := New(ts.URL, ts.Client(), "test-client", "1.0.0")
+			require.NoError(t, err)
+
+			err = tc.call(context.Background(), tr)
+			require.NoError(t, err)
+
+			require.NotNil(t, capturedMeta)
+			caps, ok := capturedMeta["io.modelcontextprotocol/clientCapabilities"].(map[string]any)
+			require.True(t, ok, "clientCapabilities must be present in _meta")
+			exts, ok := caps["extensions"].(map[string]any)
+			require.True(t, ok, "extensions must be present in clientCapabilities")
+			_, exists := exts[transport.ExtensionSecureParams]
+			assert.True(t, exists, "ExtensionSecureParams ('com.google.cloud/toolbox.v1') must be advertised")
+		})
+	}
+}
+
+func TestListTools_ParsesSecureInputSchema(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"jsonrpc": "2.0",
+			"id": "1",
+			"result": {
+				"tools": [
+					{
+						"name": "tool-with-both-schemas",
+						"description": "Tool with public and secure params",
+						"inputSchema": {
+							"type": "object",
+							"properties": {
+								"id": {
+									"type": "integer",
+									"description": "User ID"
+								}
+							},
+							"required": ["id"]
+						},
+						"secureInputSchema": {
+							"type": "object",
+							"properties": {
+								"api_key": {
+									"type": "string",
+									"description": "Secret API Key"
+								}
+							},
+							"required": ["api_key"]
+						}
+					},
+					{
+						"name": "tool-with-multiple-secure-params",
+						"description": "Tool with multiple secure params",
+						"inputSchema": {
+							"type": "object"
+						},
+						"secureInputSchema": {
+							"type": "object",
+							"properties": {
+								"secret_token": {
+									"type": "string",
+									"description": "Auth token"
+								},
+								"cluster_id": {
+									"type": "string",
+									"description": "Optional cluster ID"
+								}
+							},
+							"required": ["secret_token"]
+						}
+					},
+					{
+						"name": "tool-without-secure-schema",
+						"description": "Tool without secure schema",
+						"inputSchema": {
+							"type": "object",
+							"properties": {
+								"query": {
+									"type": "string",
+									"description": "Search query"
+								}
+							},
+							"required": ["query"]
+						}
+					},
+					{
+						"name": "tool-with-empty-secure-schema",
+						"description": "Tool with empty secure schema",
+						"inputSchema": {
+							"type": "object"
+						},
+						"secureInputSchema": {
+							"type": "object",
+							"properties": {}
+						}
+					}
+				]
+			}
+		}`))
+	}))
+	defer ts.Close()
+
+	tr, err := New(ts.URL, ts.Client(), "test-client", "1.0.0")
+	require.NoError(t, err)
+
+	manifest, err := tr.ListTools(context.Background(), "", nil)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		toolName         string
+		wantDescription  string
+		wantPublicParams map[string]transport.ParameterSchema
+		wantSecureParams map[string]transport.ParameterSchema
+	}{
+		{
+			toolName:        "tool-with-both-schemas",
+			wantDescription: "Tool with public and secure params",
+			wantPublicParams: map[string]transport.ParameterSchema{
+				"id": {Name: "id", Type: "integer", Description: "User ID", Required: true},
+			},
+			wantSecureParams: map[string]transport.ParameterSchema{
+				"api_key": {Name: "api_key", Type: "string", Description: "Secret API Key", Required: true},
+			},
+		},
+		{
+			toolName:         "tool-with-multiple-secure-params",
+			wantDescription:  "Tool with multiple secure params",
+			wantPublicParams: map[string]transport.ParameterSchema{},
+			wantSecureParams: map[string]transport.ParameterSchema{
+				"secret_token": {Name: "secret_token", Type: "string", Description: "Auth token", Required: true},
+				"cluster_id":   {Name: "cluster_id", Type: "string", Description: "Optional cluster ID", Required: false},
+			},
+		},
+		{
+			toolName:        "tool-without-secure-schema",
+			wantDescription: "Tool without secure schema",
+			wantPublicParams: map[string]transport.ParameterSchema{
+				"query": {Name: "query", Type: "string", Description: "Search query", Required: true},
+			},
+			wantSecureParams: map[string]transport.ParameterSchema{},
+		},
+		{
+			toolName:         "tool-with-empty-secure-schema",
+			wantDescription:  "Tool with empty secure schema",
+			wantPublicParams: map[string]transport.ParameterSchema{},
+			wantSecureParams: map[string]transport.ParameterSchema{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.toolName, func(t *testing.T) {
+			tool, exists := manifest.Tools[tc.toolName]
+			require.True(t, exists, "tool %q must exist in manifest", tc.toolName)
+			assert.Equal(t, tc.wantDescription, tool.Description)
+
+			require.Len(t, tool.Parameters, len(tc.wantPublicParams))
+			for _, p := range tool.Parameters {
+				expected, ok := tc.wantPublicParams[p.Name]
+				require.True(t, ok, "unexpected public parameter %q", p.Name)
+				assert.Equal(t, expected.Type, p.Type)
+				assert.Equal(t, expected.Description, p.Description)
+				assert.Equal(t, expected.Required, p.Required)
+			}
+
+			require.Len(t, tool.SecureParameters, len(tc.wantSecureParams))
+			for _, p := range tool.SecureParameters {
+				expected, ok := tc.wantSecureParams[p.Name]
+				require.True(t, ok, "unexpected secure parameter %q", p.Name)
+				assert.Equal(t, expected.Type, p.Type)
+				assert.Equal(t, expected.Description, p.Description)
+				assert.Equal(t, expected.Required, p.Required)
+			}
+		})
+	}
+}
+
+func TestInvokeTool_SecureArguments_Serialization(t *testing.T) {
+	testCases := []struct {
+		name               string
+		toolName           string
+		payload            map[string]any
+		securePayload      map[string]any
+		wantSecureArgs     bool
+		expectedSecureArgs map[string]any
+	}{
+		{
+			name:               "Includes secureArguments when non-empty",
+			toolName:           "my-secure-tool",
+			payload:            map[string]any{"id": 42},
+			securePayload:      map[string]any{"api_key": "secret-token-123"},
+			wantSecureArgs:     true,
+			expectedSecureArgs: map[string]any{"api_key": "secret-token-123"},
+		},
+		{
+			name:           "Omits secureArguments when nil",
+			toolName:       "my-tool",
+			payload:        map[string]any{"id": 42},
+			securePayload:  nil,
+			wantSecureArgs: false,
+		},
+		{
+			name:           "Omits secureArguments when empty map",
+			toolName:       "my-tool",
+			payload:        map[string]any{"id": 42},
+			securePayload:  map[string]any{},
+			wantSecureArgs: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var capturedParams map[string]any
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+
+				var req map[string]any
+				require.NoError(t, json.Unmarshal(body, &req))
+				capturedParams, _ = req["params"].(map[string]any)
+
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{
+					"jsonrpc": "2.0",
+					"id": "1",
+					"result": {
+						"content": [{"type": "text", "text": "success"}]
+					}
+				}`))
+			}))
+			defer ts.Close()
+
+			tr, err := New(ts.URL, ts.Client(), "test-client", "1.0.0")
+			require.NoError(t, err)
+
+			res, err := tr.InvokeTool(context.Background(), tc.toolName, tc.payload, tc.securePayload, nil)
+			require.NoError(t, err)
+			assert.Equal(t, "success", res)
+
+			require.NotNil(t, capturedParams)
+			assert.Equal(t, tc.toolName, capturedParams["name"])
+
+			if tc.payload != nil {
+				args, ok := capturedParams["arguments"].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, float64(42), args["id"])
+			}
+
+			secArgs, exists := capturedParams["secureArguments"]
+			if tc.wantSecureArgs {
+				require.True(t, exists, "secureArguments must be serialized")
+				assert.Equal(t, tc.expectedSecureArgs, secArgs)
+			} else {
+				assert.False(t, exists, "secureArguments must be omitted")
+			}
+		})
+	}
+}

--- a/core/transport/mcp/v20260728/types.go
+++ b/core/transport/mcp/v20260728/types.go
@@ -79,10 +79,11 @@ type mcpResult struct {
 
 // mcpTool represents a single tool definition from the server.
 type mcpTool struct {
-	Name        string         `json:"name"`
-	Description string         `json:"description,omitempty"`
-	InputSchema map[string]any `json:"inputSchema"`
-	Meta        map[string]any `json:"_meta,omitempty"`
+	Name              string         `json:"name"`
+	Description       string         `json:"description,omitempty"`
+	InputSchema       map[string]any `json:"inputSchema"`
+	SecureInputSchema map[string]any `json:"secureInputSchema,omitempty"`
+	Meta              map[string]any `json:"_meta,omitempty"`
 }
 
 // listToolsResult holds the response from the 'tools/list' method.
@@ -93,8 +94,9 @@ type listToolsResult struct {
 
 // callToolRequestParams holds the parameters for the 'tools/call' method.
 type callToolRequestParams struct {
-	Name      string         `json:"name"`
-	Arguments map[string]any `json:"arguments"`
+	Name            string         `json:"name"`
+	Arguments       map[string]any `json:"arguments"`
+	SecureArguments map[string]any `json:"secureArguments,omitempty"`
 }
 
 // callToolResult holds the response from the 'tools/call' method.

--- a/core/transport/types.go
+++ b/core/transport/types.go
@@ -175,6 +175,10 @@ func (p *ParameterSchema) ValidateDefinition() error {
 }
 
 const (
+	ExtensionSecureParams = "com.google.cloud/toolbox.v1"
+)
+
+const (
 	MCPv20260728 = "2026-07-28"
 	MCPv20251125 = "2025-11-25"
 	MCPv20250618 = "2025-06-18"
@@ -217,9 +221,10 @@ func IsVersionAtLeast(currentVersion, minVersion string) (bool, error) {
 
 // Schema for a tool.
 type ToolSchema struct {
-	Description  string            `json:"description"`
-	Parameters   []ParameterSchema `json:"parameters"`
-	AuthRequired []string          `json:"authRequired,omitempty"`
+	Description      string            `json:"description"`
+	Parameters       []ParameterSchema `json:"parameters"`
+	SecureParameters []ParameterSchema `json:"secureParameters,omitempty"`
+	AuthRequired     []string          `json:"authRequired,omitempty"`
 }
 
 // Schema for the Toolbox manifest.


### PR DESCRIPTION
# Summary
Implements wire protocol and transport support for MCP Secure Parameters (`com.google.cloud/toolbox.v1`) in the Go SDK core.

# Changes
- Advertise extension `"com.google.cloud/toolbox.v1": map[string]any{}` in JSON-RPC request `_meta.clientCapabilities.extensions` for MCP protocol version `2026-07-28`.
- Add `ExtensionSecureParams = "com.google.cloud/toolbox.v1"` constant to `transport` and export in `core`.
- Add `SecureParameters []ParameterSchema` to `transport.ToolSchema`.
- Update `ConvertToolDefinition` in `core/transport/mcp/base.go` to parse server `secureInputSchema` into `SecureParameters []ParameterSchema`.
- Update `Transport.InvokeTool` interface and `v20260728.McpTransport` to accept `securePayload map[string]any` and serialize it as `secureArguments` (`json:"secureArguments,omitempty"`).
- Fast-fail with a descriptive protocol version error when non-empty `securePayload` is passed to older transport versions (`v20241105`, `v20250326`, `v20250618`, `v20251125`).

# Testing
- Added unit tests in `v20260728/mcp_test.go` verifying capability advertising, `secureInputSchema` parsing, and `secureArguments` wire serialization.
- Added negative unit tests across all legacy transport packages verifying rejection of secure arguments.
