### PR TITLE
feat(core): tool-level secure parameter binding, fast-fail and validation

### DIFF
--- a/core/options.go
+++ b/core/options.go
@@ -58,11 +58,12 @@ func WithSupportedProtocols(protocols []Protocol) ClientOption {
 	}
 }
 
-// Constructor for a newToolConfig which initializes the maps for auth token sources and bound parameters
+// Constructor for a newToolConfig which initializes the maps for auth token sources, bound parameters, and secure parameters
 func newToolConfig() *ToolConfig {
 	return &ToolConfig{
 		AuthTokenSources: make(map[string]oauth2.TokenSource),
 		BoundParams:      make(map[string]any),
+		SecureParams:     make(map[string]any),
 	}
 }
 
@@ -152,6 +153,7 @@ func WithDefaultToolOptions(opts ...ToolOption) ClientOption {
 type ToolConfig struct {
 	AuthTokenSources map[string]oauth2.TokenSource
 	BoundParams      map[string]any
+	SecureParams     map[string]any
 	Strict           bool
 	strictSet        bool
 }
@@ -209,7 +211,27 @@ func createBoundParamToolOption(name string, value any) ToolOption {
 		if _, exists := c.BoundParams[name]; exists {
 			return fmt.Errorf("duplicate parameter binding: parameter '%s' is already set", name)
 		}
+		if _, exists := c.SecureParams[name]; exists {
+			return fmt.Errorf("duplicate parameter binding: parameter '%s' is already set as a secure parameter", name)
+		}
 		c.BoundParams[name] = value
+		return nil
+	}
+}
+
+// Helper function for secure parameters
+func createBoundSecureParamToolOption(name string, value any) ToolOption {
+	return func(c *ToolConfig) error {
+		if c.SecureParams == nil {
+			c.SecureParams = make(map[string]any)
+		}
+		if _, exists := c.SecureParams[name]; exists {
+			return fmt.Errorf("duplicate secure parameter binding: parameter '%s' is already set", name)
+		}
+		if _, exists := c.BoundParams[name]; exists {
+			return fmt.Errorf("duplicate parameter binding: parameter '%s' is already set as a regular bound parameter", name)
+		}
+		c.SecureParams[name] = value
 		return nil
 	}
 }
@@ -408,4 +430,198 @@ func WithBindParamAnyMap(name string, value map[string]any) ToolOption {
 // WithBindParamAnyMapFunc binds a function that returns a generic map to a parameter.
 func WithBindParamAnyMapFunc(name string, fn func() (map[string]any, error)) ToolOption {
 	return createBoundParamToolOption(name, fn)
+}
+
+// ----- Secure Parameter Tool Options -----
+
+// WithBindSecureParamString binds a static string value to a secure parameter.
+func WithBindSecureParamString(name string, value string) ToolOption {
+	return createBoundSecureParamToolOption(name, value)
+}
+
+// WithBindSecureParamStringFunc binds a function that returns a string to a secure parameter.
+func WithBindSecureParamStringFunc(name string, fn func() (string, error)) ToolOption {
+	return createBoundSecureParamToolOption(name, fn)
+}
+
+// WithBindSecureParamInt binds a static integer value to a secure parameter.
+func WithBindSecureParamInt[T Integer](name string, value T) ToolOption {
+	return createBoundSecureParamToolOption(name, int(value))
+}
+
+// WithBindSecureParamIntFunc binds a function that returns an integer to a secure parameter.
+func WithBindSecureParamIntFunc[T Integer](name string, fn func() (T, error)) ToolOption {
+	return createBoundSecureParamToolOption(name, func() (int, error) {
+		v, err := fn()
+		return int(v), err
+	})
+}
+
+// WithBindSecureParamFloat binds a static float value to a secure parameter.
+func WithBindSecureParamFloat[T Float](name string, value T) ToolOption {
+	return createBoundSecureParamToolOption(name, float64(value))
+}
+
+// WithBindSecureParamFloatFunc binds a function that returns a float to a secure parameter.
+func WithBindSecureParamFloatFunc[T Float](name string, fn func() (T, error)) ToolOption {
+	return createBoundSecureParamToolOption(name, func() (float64, error) {
+		v, err := fn()
+		return float64(v), err
+	})
+}
+
+// WithBindSecureParamBool binds a static boolean value to a secure parameter.
+func WithBindSecureParamBool(name string, value bool) ToolOption {
+	return createBoundSecureParamToolOption(name, value)
+}
+
+// WithBindSecureParamBoolFunc binds a function that returns a boolean to a secure parameter.
+func WithBindSecureParamBoolFunc(name string, fn func() (bool, error)) ToolOption {
+	return createBoundSecureParamToolOption(name, fn)
+}
+
+// WithBindSecureParamStringArray binds a static slice of strings to a secure parameter.
+func WithBindSecureParamStringArray(name string, value []string) ToolOption {
+	return createBoundSecureParamToolOption(name, value)
+}
+
+// WithBindSecureParamStringArrayFunc binds a function that returns a slice of strings to a secure parameter.
+func WithBindSecureParamStringArrayFunc(name string, fn func() ([]string, error)) ToolOption {
+	return createBoundSecureParamToolOption(name, fn)
+}
+
+// WithBindSecureParamIntArray binds a static slice of integers to a secure parameter.
+func WithBindSecureParamIntArray[T Integer](name string, value []T) ToolOption {
+	normalized := make([]int, len(value))
+	for i, v := range value {
+		normalized[i] = int(v)
+	}
+	return createBoundSecureParamToolOption(name, normalized)
+}
+
+// WithBindSecureParamIntArrayFunc binds a function that returns a slice of integers to a secure parameter.
+func WithBindSecureParamIntArrayFunc[T Integer](name string, fn func() ([]T, error)) ToolOption {
+	return createBoundSecureParamToolOption(name, func() ([]int, error) {
+		val, err := fn()
+		if err != nil {
+			return nil, err
+		}
+		normalized := make([]int, len(val))
+		for i, v := range val {
+			normalized[i] = int(v)
+		}
+		return normalized, nil
+	})
+}
+
+// WithBindSecureParamFloatArray binds a static slice of floats to a secure parameter.
+func WithBindSecureParamFloatArray[T Float](name string, value []T) ToolOption {
+	normalized := make([]float64, len(value))
+	for i, v := range value {
+		normalized[i] = float64(v)
+	}
+	return createBoundSecureParamToolOption(name, normalized)
+}
+
+// WithBindSecureParamFloatArrayFunc binds a function that returns a slice of floats to a secure parameter.
+func WithBindSecureParamFloatArrayFunc[T Float](name string, fn func() ([]T, error)) ToolOption {
+	return createBoundSecureParamToolOption(name, func() ([]float64, error) {
+		val, err := fn()
+		if err != nil {
+			return nil, err
+		}
+		normalized := make([]float64, len(val))
+		for i, v := range val {
+			normalized[i] = float64(v)
+		}
+		return normalized, nil
+	})
+}
+
+// WithBindSecureParamBoolArray binds a static slice of booleans to a secure parameter.
+func WithBindSecureParamBoolArray(name string, value []bool) ToolOption {
+	return createBoundSecureParamToolOption(name, value)
+}
+
+// WithBindSecureParamBoolArrayFunc binds a function that returns a slice of booleans to a secure parameter.
+func WithBindSecureParamBoolArrayFunc(name string, fn func() ([]bool, error)) ToolOption {
+	return createBoundSecureParamToolOption(name, fn)
+}
+
+// WithBindSecureParamStringMap binds a static map of strings to a secure parameter.
+func WithBindSecureParamStringMap(name string, value map[string]string) ToolOption {
+	return createBoundSecureParamToolOption(name, value)
+}
+
+// WithBindSecureParamStringMapFunc binds a function that returns a map of strings to a secure parameter.
+func WithBindSecureParamStringMapFunc(name string, fn func() (map[string]string, error)) ToolOption {
+	return createBoundSecureParamToolOption(name, fn)
+}
+
+// WithBindSecureParamIntMap binds a static map of integers to a secure parameter.
+func WithBindSecureParamIntMap[T Integer](name string, value map[string]T) ToolOption {
+	normalized := make(map[string]int, len(value))
+	for k, v := range value {
+		normalized[k] = int(v)
+	}
+	return createBoundSecureParamToolOption(name, normalized)
+}
+
+// WithBindSecureParamIntMapFunc binds a function that returns a map of integers to a secure parameter.
+func WithBindSecureParamIntMapFunc[T Integer](name string, fn func() (map[string]T, error)) ToolOption {
+	return createBoundSecureParamToolOption(name, func() (map[string]int, error) {
+		val, err := fn()
+		if err != nil {
+			return nil, err
+		}
+		normalized := make(map[string]int, len(val))
+		for k, v := range val {
+			normalized[k] = int(v)
+		}
+		return normalized, nil
+	})
+}
+
+// WithBindSecureParamFloatMap binds a static map of floats to a secure parameter.
+func WithBindSecureParamFloatMap[T Float](name string, value map[string]T) ToolOption {
+	normalized := make(map[string]float64, len(value))
+	for k, v := range value {
+		normalized[k] = float64(v)
+	}
+	return createBoundSecureParamToolOption(name, normalized)
+}
+
+// WithBindSecureParamFloatMapFunc binds a function that returns a map of floats to a secure parameter.
+func WithBindSecureParamFloatMapFunc[T Float](name string, fn func() (map[string]T, error)) ToolOption {
+	return createBoundSecureParamToolOption(name, func() (map[string]float64, error) {
+		val, err := fn()
+		if err != nil {
+			return nil, err
+		}
+		normalized := make(map[string]float64, len(val))
+		for k, v := range val {
+			normalized[k] = float64(v)
+		}
+		return normalized, nil
+	})
+}
+
+// WithBindSecureParamBoolMap binds a static map of booleans to a secure parameter.
+func WithBindSecureParamBoolMap(name string, value map[string]bool) ToolOption {
+	return createBoundSecureParamToolOption(name, value)
+}
+
+// WithBindSecureParamBoolMapFunc binds a function that returns a map of booleans to a secure parameter.
+func WithBindSecureParamBoolMapFunc(name string, fn func() (map[string]bool, error)) ToolOption {
+	return createBoundSecureParamToolOption(name, fn)
+}
+
+// WithBindSecureParamAnyMap binds a generic map to a secure parameter.
+func WithBindSecureParamAnyMap(name string, value map[string]any) ToolOption {
+	return createBoundSecureParamToolOption(name, value)
+}
+
+// WithBindSecureParamAnyMapFunc binds a function that returns a generic map to a secure parameter.
+func WithBindSecureParamAnyMapFunc(name string, fn func() (map[string]any, error)) ToolOption {
+	return createBoundSecureParamToolOption(name, fn)
 }

--- a/core/options_test.go
+++ b/core/options_test.go
@@ -689,3 +689,36 @@ func TestWithSupportedProtocols(t *testing.T) {
 		}
 	})
 }
+
+func TestWithBindSecureParam_TypedFunctions(t *testing.T) {
+	t.Run("String and StringFunc", func(t *testing.T) {
+		cfg := newToolConfig()
+		err := WithBindSecureParamString("s1", "val")(cfg)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		err = WithBindSecureParamStringFunc("s2", func() (string, error) {
+			return "fn_val", nil
+		})(cfg)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.SecureParams["s1"] != "val" {
+			t.Errorf("expected s1=val, got: %v", cfg.SecureParams["s1"])
+		}
+	})
+
+	t.Run("Int, Float, Bool and Array/Map bindings", func(t *testing.T) {
+		cfg := newToolConfig()
+		_ = WithBindSecureParamInt("i", 42)(cfg)
+		_ = WithBindSecureParamFloat("f", 3.14)(cfg)
+		_ = WithBindSecureParamBool("b", true)(cfg)
+		_ = WithBindSecureParamStringArray("arr", []string{"a", "b"})(cfg)
+		_ = WithBindSecureParamStringMap("m", map[string]string{"k": "v"})(cfg)
+
+		if cfg.SecureParams["i"] != 42 || cfg.SecureParams["f"] != 3.14 || cfg.SecureParams["b"] != true {
+			t.Errorf("unexpected values in SecureParams: %+v", cfg.SecureParams)
+		}
+	})
+}
+

--- a/core/tool.go
+++ b/core/tool.go
@@ -29,19 +29,22 @@ import (
 
 // ToolboxTool represents an immutable, universal definition of a Toolbox tool.
 type ToolboxTool struct {
-	name                string
-	description         string
-	parameters          []ParameterSchema
-	transport           transport.Transport
-	authTokenSources    map[string]oauth2.TokenSource
-	boundParams         map[string]any
-	boundParamSchemas   map[string]ParameterSchema
-	requiredAuthnParams map[string][]string
-	requiredAuthzTokens []string
-	clientHeaderSources map[string]oauth2.TokenSource
-	clientName          string
-	clientVersion       string
-	supportedProtocols  []string
+	name                    string
+	description             string
+	parameters              []ParameterSchema
+	secureParameters        []ParameterSchema
+	transport               transport.Transport
+	authTokenSources        map[string]oauth2.TokenSource
+	boundParams             map[string]any
+	boundParamSchemas       map[string]ParameterSchema
+	boundSecureParams       map[string]any
+	boundSecureParamSchemas map[string]ParameterSchema
+	requiredAuthnParams     map[string][]string
+	requiredAuthzTokens     []string
+	clientHeaderSources     map[string]oauth2.TokenSource
+	clientName              string
+	clientVersion           string
+	supportedProtocols      []string
 }
 
 // Name returns the tool's name.
@@ -62,7 +65,15 @@ func (tt *ToolboxTool) Parameters() []ParameterSchema {
 	return paramsCopy
 }
 
+// SecureParameters returns the list of unbound secure parameters for the tool.
+func (tt *ToolboxTool) SecureParameters() []ParameterSchema {
+	secCopy := make([]ParameterSchema, len(tt.secureParameters))
+	copy(secCopy, tt.secureParameters)
+	return secCopy
+}
+
 // InputSchema generates an OpenAPI JSON Schema for the tool's input parameters and returns it as raw bytes.
+// Secure parameters are strictly isolated and never included in InputSchema.
 func (tt *ToolboxTool) InputSchema() ([]byte, error) {
 	properties := make(map[string]any)
 	required := make([]string, 0)
@@ -97,7 +108,7 @@ func (tt *ToolboxTool) InputSchema() ([]byte, error) {
 
 // DescribeParameters returns a single, human-readable string that describes all
 // of the tool's unbound parameters, including their names, types, and
-// descriptions.
+// descriptions. Secure parameters are strictly isolated and excluded.
 //
 // Returns:
 //
@@ -116,12 +127,13 @@ func (tt *ToolboxTool) DescribeParameters() string {
 
 // ToolFrom creates a new, more specialized tool from an existing one by applying
 // additional options. This is useful for creating variations of a tool with
-// different bound parameters without modifying the original and
-// all provided options must be applicable.
+// different bound parameters or secure parameters without modifying the original,
+// and all provided options must be applicable.
 //
 // Inputs:
 //   - opts: A variadic list of ToolOption functions to further configure the
-//     new tool, such as binding more parameters.
+//     new tool, such as binding parameters, binding secure parameters, or
+//     providing auth tokens.
 //
 // Returns:
 //
@@ -131,6 +143,9 @@ func (tt *ToolboxTool) ToolFrom(opts ...ToolOption) (*ToolboxTool, error) {
 	// Create a config and apply the new options, checking for internal duplicates.
 	config := newToolConfig()
 	for _, opt := range opts {
+		if opt == nil {
+			return nil, fmt.Errorf("ToolFrom: received a nil ToolOption in options list")
+		}
 		if err := opt(config); err != nil {
 			return nil, err
 		}
@@ -150,26 +165,38 @@ func (tt *ToolboxTool) ToolFrom(opts ...ToolOption) (*ToolboxTool, error) {
 			if _, exists := newTt.authTokenSources[name]; exists {
 				return nil, fmt.Errorf("cannot override existing auth token source: '%s'", name)
 			}
+			if newTt.authTokenSources == nil {
+				newTt.authTokenSources = make(map[string]oauth2.TokenSource)
+			}
 			newTt.authTokenSources[name] = source
 		}
 	}
 
-	// Validate and merge new BoundParams, preventing overrides.
 	paramNames := make(map[string]ParameterSchema)
 	for _, p := range tt.parameters {
 		paramNames[p.Name] = p
 	}
 
+	secParamNames := make(map[string]ParameterSchema)
+	for _, p := range tt.secureParameters {
+		secParamNames[p.Name] = p
+	}
+
+	// Validate and merge new BoundParams
 	for name, val := range config.BoundParams {
-		// A parameter is valid to bind if it exists in the unbound parameters list.
+		if _, exists := secParamNames[name]; exists {
+			return nil, fmt.Errorf("parameter %q is a secure parameter; use WithBindSecureParam* instead", name)
+		}
+		if _, exists := tt.boundSecureParams[name]; exists {
+			return nil, fmt.Errorf("parameter %q is a secure parameter; use WithBindSecureParam* instead", name)
+		}
+
 		schema, exists := paramNames[name]
 		if !exists {
-			// If it's not in the unbound list, check if it was already bound on the parent.
-			if _, existsInParent := tt.boundParams[name]; !existsInParent {
-				return nil, fmt.Errorf("unable to bind parameter: no parameter named '%s' on the tool", name)
+			if _, existsInParent := tt.boundParams[name]; existsInParent {
+				return nil, fmt.Errorf("cannot override existing bound parameter: '%s'", name)
 			}
-			// If it exists in the parent's bound params, it's an attempt to override.
-			return nil, fmt.Errorf("cannot override existing bound parameter: '%s'", name)
+			return nil, fmt.Errorf("unable to bind parameter: no parameter named '%s' on the tool", name)
 		}
 
 		if newTt.boundParamSchemas == nil {
@@ -184,13 +211,50 @@ func (tt *ToolboxTool) ToolFrom(opts ...ToolOption) (*ToolboxTool, error) {
 	}
 
 	// Recalculate the remaining unbound parameters for the new tool.
-	var newParams []ParameterSchema
+	newParams := make([]ParameterSchema, 0)
 	for _, p := range tt.parameters {
 		if _, exists := newTt.boundParams[p.Name]; !exists {
 			newParams = append(newParams, p)
 		}
 	}
 	newTt.parameters = newParams
+
+	// Validate and merge new SecureParams
+	for name, val := range config.SecureParams {
+		if _, exists := paramNames[name]; exists {
+			return nil, fmt.Errorf("parameter %q is a regular parameter; use WithBindParam* instead", name)
+		}
+		if _, exists := tt.boundParams[name]; exists {
+			return nil, fmt.Errorf("parameter %q is a regular parameter; use WithBindParam* instead", name)
+		}
+
+		schema, exists := secParamNames[name]
+		if !exists {
+			if _, existsInParent := tt.boundSecureParams[name]; existsInParent {
+				return nil, fmt.Errorf("cannot override existing bound secure parameter: %q", name)
+			}
+			return nil, fmt.Errorf("unable to bind secure parameter: no secure parameter named %q on the tool", name)
+		}
+
+		if newTt.boundSecureParamSchemas == nil {
+			newTt.boundSecureParamSchemas = make(map[string]ParameterSchema)
+		}
+		if newTt.boundSecureParams == nil {
+			newTt.boundSecureParams = make(map[string]any)
+		}
+
+		newTt.boundSecureParamSchemas[name] = schema
+		newTt.boundSecureParams[name] = val
+	}
+
+	// Recalculate remaining unbound secure parameters
+	newSecParams := make([]ParameterSchema, 0)
+	for _, p := range tt.secureParameters {
+		if _, exists := newTt.boundSecureParams[p.Name]; !exists {
+			newSecParams = append(newSecParams, p)
+		}
+	}
+	newTt.secureParameters = newSecParams
 
 	return newTt, nil
 }
@@ -199,58 +263,78 @@ func (tt *ToolboxTool) ToolFrom(opts ...ToolOption) (*ToolboxTool, error) {
 // that derivative tools created with ToolFrom cannot mutate the parent.
 func (tt *ToolboxTool) cloneToolboxTool() *ToolboxTool {
 	newTt := &ToolboxTool{
-		name:                tt.name,
-		description:         tt.description,
-		transport:           tt.transport,
-		parameters:          make([]ParameterSchema, len(tt.parameters)),
-		authTokenSources:    make(map[string]oauth2.TokenSource, len(tt.authTokenSources)),
-		boundParams:         make(map[string]any, len(tt.boundParams)),
-		boundParamSchemas:   make(map[string]ParameterSchema, len(tt.boundParamSchemas)),
-		requiredAuthnParams: make(map[string][]string, len(tt.requiredAuthnParams)),
-		requiredAuthzTokens: make([]string, len(tt.requiredAuthzTokens)),
-		clientHeaderSources: make(map[string]oauth2.TokenSource, len(tt.clientHeaderSources)),
-		clientName:          tt.clientName,
-		clientVersion:       tt.clientVersion,
+		name:          tt.name,
+		description:   tt.description,
+		transport:     tt.transport,
+		clientName:    tt.clientName,
+		clientVersion: tt.clientVersion,
 	}
 
-	if tt.supportedProtocols != nil {
-		newTt.supportedProtocols = make([]string, len(tt.supportedProtocols))
-		copy(newTt.supportedProtocols, tt.supportedProtocols)
+	if tt.parameters != nil {
+		newTt.parameters = make([]ParameterSchema, len(tt.parameters))
+		copy(newTt.parameters, tt.parameters)
 	}
-
+	if tt.secureParameters != nil {
+		newTt.secureParameters = make([]ParameterSchema, len(tt.secureParameters))
+		copy(newTt.secureParameters, tt.secureParameters)
+	}
+	if tt.authTokenSources != nil {
+		newTt.authTokenSources = make(map[string]oauth2.TokenSource, len(tt.authTokenSources))
+		maps.Copy(newTt.authTokenSources, tt.authTokenSources)
+	}
+	if tt.boundParams != nil {
+		newTt.boundParams = make(map[string]any, len(tt.boundParams))
+		for k, v := range tt.boundParams {
+			val := reflect.ValueOf(v)
+			if val.Kind() == reflect.Slice {
+				newSlice := reflect.MakeSlice(val.Type(), val.Len(), val.Cap())
+				reflect.Copy(newSlice, val)
+				newTt.boundParams[k] = newSlice.Interface()
+			} else {
+				newTt.boundParams[k] = v
+			}
+		}
+	}
 	if tt.boundParamSchemas != nil {
 		newTt.boundParamSchemas = make(map[string]ParameterSchema, len(tt.boundParamSchemas))
 		maps.Copy(newTt.boundParamSchemas, tt.boundParamSchemas)
 	}
-
-	// Perform deep copies for slices and maps to prevent shared state.
-	copy(newTt.parameters, tt.parameters)
-	copy(newTt.requiredAuthzTokens, tt.requiredAuthzTokens)
-
-	maps.Copy(newTt.authTokenSources, tt.authTokenSources)
-	maps.Copy(newTt.clientHeaderSources, tt.clientHeaderSources)
-	maps.Copy(newTt.boundParamSchemas, tt.boundParamSchemas)
-
-	for k, v := range tt.boundParams {
-		val := reflect.ValueOf(v)
-		if val.Kind() == reflect.Slice {
-			// If it's a slice, create a new slice of the same type and length.
-			newSlice := reflect.MakeSlice(val.Type(), val.Len(), val.Cap())
-			// Copy the elements from the old slice to the new one.
-			reflect.Copy(newSlice, val)
-			// Assign the new, independent slice to the clone's map.
-			newTt.boundParams[k] = newSlice.Interface()
-		} else {
-			// If it's not a slice, just copy the value directly.
-			newTt.boundParams[k] = v
+	if tt.boundSecureParams != nil {
+		newTt.boundSecureParams = make(map[string]any, len(tt.boundSecureParams))
+		for k, v := range tt.boundSecureParams {
+			val := reflect.ValueOf(v)
+			if val.Kind() == reflect.Slice {
+				newSlice := reflect.MakeSlice(val.Type(), val.Len(), val.Cap())
+				reflect.Copy(newSlice, val)
+				newTt.boundSecureParams[k] = newSlice.Interface()
+			} else {
+				newTt.boundSecureParams[k] = v
+			}
 		}
 	}
-
-	// Manually deep copy the map of string slices.
-	for k, v := range tt.requiredAuthnParams {
-		newSlice := make([]string, len(v))
-		copy(newSlice, v)
-		newTt.requiredAuthnParams[k] = newSlice
+	if tt.boundSecureParamSchemas != nil {
+		newTt.boundSecureParamSchemas = make(map[string]ParameterSchema, len(tt.boundSecureParamSchemas))
+		maps.Copy(newTt.boundSecureParamSchemas, tt.boundSecureParamSchemas)
+	}
+	if tt.requiredAuthnParams != nil {
+		newTt.requiredAuthnParams = make(map[string][]string, len(tt.requiredAuthnParams))
+		for k, v := range tt.requiredAuthnParams {
+			newSlice := make([]string, len(v))
+			copy(newSlice, v)
+			newTt.requiredAuthnParams[k] = newSlice
+		}
+	}
+	if tt.requiredAuthzTokens != nil {
+		newTt.requiredAuthzTokens = make([]string, len(tt.requiredAuthzTokens))
+		copy(newTt.requiredAuthzTokens, tt.requiredAuthzTokens)
+	}
+	if tt.clientHeaderSources != nil {
+		newTt.clientHeaderSources = make(map[string]oauth2.TokenSource, len(tt.clientHeaderSources))
+		maps.Copy(newTt.clientHeaderSources, tt.clientHeaderSources)
+	}
+	if tt.supportedProtocols != nil {
+		newTt.supportedProtocols = make([]string, len(tt.supportedProtocols))
+		copy(newTt.supportedProtocols, tt.supportedProtocols)
 	}
 
 	return newTt
@@ -261,16 +345,29 @@ func (tt *ToolboxTool) cloneToolboxTool() *ToolboxTool {
 // Inputs:
 //   - ctx: The context to control the lifecycle of the API request.
 //   - input: A map of parameter names to values provided by the user for this
-//     specific invocation.
+//     specific invocation. Secure parameters cannot be passed in input and
+//     must be pre-configured on the tool.
 //
 // Returns:
 //
 //	The result from the API call, which can be a structured object (from a JSON
 //	'result' field) or a raw string. Returns an error if any step of the
-//	process fails.
+//	process fails, including if required secure parameters are missing.
 func (tt *ToolboxTool) Invoke(ctx context.Context, input map[string]any) (any, error) {
+	// 1. Fast-fail: validate missing required secure parameters before anything else
+	var missingSecure []string
+	for _, p := range tt.secureParameters {
+		if p.Required && p.Default == nil {
+			if _, isBound := tt.boundSecureParams[p.Name]; !isBound {
+				missingSecure = append(missingSecure, p.Name)
+			}
+		}
+	}
+	if len(missingSecure) > 0 {
+		return nil, fmt.Errorf("missing required secure parameter(s) [%s] for tool %q", strings.Join(missingSecure, ", "), tt.name)
+	}
 
-	// Ensure all authentication tokens required by the tool are available.
+	// 2. Ensure all authentication tokens required by the tool are available.
 	if len(tt.requiredAuthnParams) > 0 || len(tt.requiredAuthzTokens) > 0 {
 		reqAuthServices := make(map[string]struct{})
 		for _, services := range tt.requiredAuthnParams {
@@ -282,7 +379,6 @@ func (tt *ToolboxTool) Invoke(ctx context.Context, input map[string]any) (any, e
 			reqAuthServices[service] = struct{}{}
 		}
 
-		// Check if each required service has a corresponding token source.
 		for service := range reqAuthServices {
 			if _, ok := tt.authTokenSources[service]; !ok {
 				return nil, fmt.Errorf("permission error: auth service '%s' is required to invoke this tool but was not provided", service)
@@ -290,15 +386,21 @@ func (tt *ToolboxTool) Invoke(ctx context.Context, input map[string]any) (any, e
 		}
 	}
 
-	// Validate the user's input and merge it with pre-configured bound parameters.
+	// 3. Validate user input and build finalPayload.
 	finalPayload, err := tt.validateAndBuildPayload(input)
 	if err != nil {
 		return nil, fmt.Errorf("tool payload processing failed: %w", err)
 	}
 
+	// 4. Resolve and build securePayload.
+	securePayload, err := tt.resolveAndBuildSecurePayload()
+	if err != nil {
+		return nil, err
+	}
+
+	// 5. Headers.
 	resolvedHeaders := make(map[string]string)
 
-	// Resolve Client Headers
 	for k, source := range tt.clientHeaderSources {
 		token, err := source.Token()
 		if err != nil {
@@ -307,25 +409,59 @@ func (tt *ToolboxTool) Invoke(ctx context.Context, input map[string]any) (any, e
 		resolvedHeaders[k] = token.AccessToken
 	}
 
-	// Resolve Auth Headers
 	for name, source := range tt.authTokenSources {
 		token, err := source.Token()
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve auth token %s: %w", name, err)
 		}
-		// Toolbox HTTP protocol expects the suffix "_token"
 		headerName := fmt.Sprintf("%s_token", name)
 		resolvedHeaders[headerName] = token.AccessToken
 	}
 
 	checkSecureHeaders(tt.transport.BaseURL(), len(tt.authTokenSources) > 0)
 
-	response, err := tt.transport.InvokeTool(ctx, tt.name, finalPayload, nil, resolvedHeaders)
+	response, err := tt.transport.InvokeTool(ctx, tt.name, finalPayload, securePayload, resolvedHeaders)
 	if err != nil {
 		return nil, err
 	}
 
 	return response, nil
+}
+
+// resolveValue resolves a static value or a dynamic function getter.
+func resolveValue(boundVal any) (any, error) {
+	switch v := boundVal.(type) {
+	case func() (string, error):
+		return v()
+	case func() (int, error):
+		return v()
+	case func() (float64, error):
+		return v()
+	case func() (bool, error):
+		return v()
+	case func() ([]string, error):
+		return v()
+	case func() ([]int, error):
+		return v()
+	case func() ([]float64, error):
+		return v()
+	case func() ([]bool, error):
+		return v()
+	case func() (map[string]string, error):
+		return v()
+	case func() (map[string]int, error):
+		return v()
+	case func() (map[string]float64, error):
+		return v()
+	case func() (map[string]bool, error):
+		return v()
+	case func() (map[string]any, error):
+		return v()
+	case func() (any, error):
+		return v()
+	default:
+		return boundVal, nil
+	}
 }
 
 // validateAndBuildPayload performs manual type validation and applies bound parameters.
@@ -338,24 +474,20 @@ func (tt *ToolboxTool) Invoke(ctx context.Context, input map[string]any) (any, e
 //	A map representing the final, validated JSON payload, or an error if
 //	validation or parameter resolution fails.
 func (tt *ToolboxTool) validateAndBuildPayload(input map[string]any) (map[string]any, error) {
-	// Create a map of the parameter schema for efficient lookups by name
 	paramSchema := make(map[string]ParameterSchema)
 	for _, p := range tt.parameters {
 		paramSchema[p.Name] = p
 	}
 
-	// Validate user input against the schema.
+	// Validate user input against the public parameter schema.
 	for key, value := range input {
 		param, isUnbound := paramSchema[key]
 		_, isBound := tt.boundParams[key]
 
-		// An input key is invalid if it's neither an expected unbound parameter
-		// nor a parameter that has been pre-configured (bound).
 		if !isUnbound || isBound {
 			return nil, fmt.Errorf("unexpected parameter '%s' provided", key)
 		}
 
-		// If the parameter is a valid unbound parameter, validate its type.
 		if isUnbound {
 			if err := param.ValidateType(value); err != nil {
 				return nil, err
@@ -363,7 +495,6 @@ func (tt *ToolboxTool) validateAndBuildPayload(input map[string]any) (map[string
 		}
 	}
 
-	// Initialize the final payload with the validated user input.
 	finalPayload := make(map[string]any, len(input)+len(tt.boundParams))
 	for k, v := range input {
 		if _, ok := paramSchema[k]; ok && v != nil {
@@ -386,40 +517,7 @@ func (tt *ToolboxTool) validateAndBuildPayload(input map[string]any) (map[string
 
 	// Loop through the bound parameters and add them to the payload.
 	for paramName, boundVal := range tt.boundParams {
-		var resolvedValue any
-		var resolveErr error
-		// A bound parameter can be a static value or a function that must be
-		// executed at invocation time to resolve the value.
-		switch v := boundVal.(type) {
-		case func() (string, error):
-			resolvedValue, resolveErr = v()
-		case func() (int, error):
-			resolvedValue, resolveErr = v()
-		case func() (float64, error):
-			resolvedValue, resolveErr = v()
-		case func() (bool, error):
-			resolvedValue, resolveErr = v()
-		case func() ([]string, error):
-			resolvedValue, resolveErr = v()
-		case func() ([]int, error):
-			resolvedValue, resolveErr = v()
-		case func() ([]float64, error):
-			resolvedValue, resolveErr = v()
-		case func() ([]bool, error):
-			resolvedValue, resolveErr = v()
-		case func() (map[string]string, error):
-			resolvedValue, resolveErr = v()
-		case func() (map[string]int, error):
-			resolvedValue, resolveErr = v()
-		case func() (map[string]float64, error):
-			resolvedValue, resolveErr = v()
-		case func() (map[string]bool, error):
-			resolvedValue, resolveErr = v()
-		case func() (map[string]any, error):
-			resolvedValue, resolveErr = v()
-		default:
-			resolvedValue = boundVal
-		}
+		resolvedValue, resolveErr := resolveValue(boundVal)
 		if resolveErr != nil {
 			return nil, fmt.Errorf("failed to resolve bound parameter function for '%s': %w", paramName, resolveErr)
 		}
@@ -431,8 +529,58 @@ func (tt *ToolboxTool) validateAndBuildPayload(input map[string]any) (map[string
 			}
 		}
 
-		finalPayload[paramName] = resolvedValue
+		if resolvedValue != nil {
+			finalPayload[paramName] = resolvedValue
+		}
 	}
 
 	return finalPayload, nil
+}
+
+// resolveAndBuildSecurePayload resolves bound secure parameter values, validates their types,
+// and applies defaults for unbound secure parameters.
+//
+// Returns:
+//
+//	A map representing the final, validated secure parameter payload, or an error if
+//	validation or parameter resolution fails. Returns nil if there are no secure parameters.
+func (tt *ToolboxTool) resolveAndBuildSecurePayload() (map[string]any, error) {
+	if len(tt.boundSecureParams) == 0 && len(tt.secureParameters) == 0 {
+		return nil, nil
+	}
+
+	var securePayload map[string]any
+	if len(tt.boundSecureParams) > 0 {
+		securePayload = make(map[string]any, len(tt.boundSecureParams))
+		for paramName, boundVal := range tt.boundSecureParams {
+			resolvedValue, resolveErr := resolveValue(boundVal)
+			if resolveErr != nil {
+				return nil, fmt.Errorf("failed to resolve bound secure parameter function for '%s': %w", paramName, resolveErr)
+			}
+			if schema, ok := tt.boundSecureParamSchemas[paramName]; ok {
+				if err := schema.ValidateType(resolvedValue); err != nil {
+					return nil, fmt.Errorf("resolved bound secure parameter '%s' failed validation: %w", paramName, err)
+				}
+			}
+			if resolvedValue != nil {
+				securePayload[paramName] = resolvedValue
+			}
+		}
+	}
+
+	// Apply defaults for unbound secure parameters
+	for _, p := range tt.secureParameters {
+		if _, isBound := tt.boundSecureParams[p.Name]; !isBound && p.Default != nil {
+			if securePayload == nil {
+				securePayload = make(map[string]any)
+			}
+			securePayload[p.Name] = p.Default
+		}
+	}
+
+	if len(securePayload) == 0 {
+		securePayload = nil
+	}
+
+	return securePayload, nil
 }

--- a/core/tool_test.go
+++ b/core/tool_test.go
@@ -1331,3 +1331,414 @@ func TestInputSchema(t *testing.T) {
 		})
 	}
 }
+
+type recordingTransport struct {
+	baseURL         string
+	capturedPayload map[string]any
+	capturedSecure  map[string]any
+	capturedHeaders map[string]string
+}
+
+func (r *recordingTransport) BaseURL() string { return r.baseURL }
+func (r *recordingTransport) GetTool(ctx context.Context, name string, h map[string]string) (*transport.ManifestSchema, error) {
+	return nil, nil
+}
+func (r *recordingTransport) ListTools(ctx context.Context, set string, h map[string]string) (*transport.ManifestSchema, error) {
+	return nil, nil
+}
+func (r *recordingTransport) InvokeTool(ctx context.Context, name string, p map[string]any, sp map[string]any, h map[string]string) (any, error) {
+	r.capturedPayload = p
+	r.capturedSecure = sp
+	r.capturedHeaders = h
+	return "ok", nil
+}
+
+func TestToolboxTool_SecureParams_GettersAndInputSchema(t *testing.T) {
+	tool := &ToolboxTool{
+		name:        "secure-tool",
+		description: "A tool with secure parameters",
+		parameters: []ParameterSchema{
+			{Name: "public_arg", Type: "string", Required: true},
+		},
+		secureParameters: []ParameterSchema{
+			{Name: "api_key", Type: "string", Required: true, Description: "Secret API Key"},
+			{Name: "opt_sec", Type: "string", Required: false, Description: "Optional Secret"},
+		},
+		transport: &dummyTransport{baseURL: "http://example.com"},
+	}
+
+	t.Run("SecureParameters returns safe copy of unbound secure params", func(t *testing.T) {
+		secParams := tool.SecureParameters()
+		if len(secParams) != 2 {
+			t.Fatalf("expected 2 secure parameters, got %d", len(secParams))
+		}
+		if secParams[0].Name != "api_key" || secParams[1].Name != "opt_sec" {
+			t.Errorf("unexpected secure parameter names: %+v", secParams)
+		}
+		secParams[0].Name = "MUTATED"
+		if tool.secureParameters[0].Name == "MUTATED" {
+			t.Fatalf("SecureParameters did not return a safe copy")
+		}
+	})
+
+	t.Run("SecureParameters handles nil or empty secure parameters", func(t *testing.T) {
+		nilTool := &ToolboxTool{
+			transport: &dummyTransport{baseURL: "http://example.com"},
+		}
+		nilParams := nilTool.SecureParameters()
+		if nilParams == nil {
+			t.Fatalf("SecureParameters() should return a non-nil, empty slice for a tool with nil secure parameters, but got nil")
+		}
+		if len(nilParams) != 0 {
+			t.Fatalf("expected 0 secure parameters, got %d", len(nilParams))
+		}
+	})
+
+	t.Run("InputSchema strictly excludes secure parameters", func(t *testing.T) {
+		schemaBytes, err := tool.InputSchema()
+		if err != nil {
+			t.Fatalf("InputSchema error: %v", err)
+		}
+		var schemaMap map[string]any
+		if err := json.Unmarshal(schemaBytes, &schemaMap); err != nil {
+			t.Fatalf("Unmarshal error: %v", err)
+		}
+		props, ok := schemaMap["properties"].(map[string]any)
+		if !ok {
+			t.Fatalf("missing properties in schema")
+		}
+		if _, exists := props["public_arg"]; !exists {
+			t.Errorf("expected public_arg in InputSchema properties")
+		}
+		if _, exists := props["api_key"]; exists {
+			t.Errorf("CRITICAL: secure parameter 'api_key' leaked in InputSchema properties")
+		}
+		if _, exists := props["opt_sec"]; exists {
+			t.Errorf("CRITICAL: secure parameter 'opt_sec' leaked in InputSchema properties")
+		}
+	})
+}
+
+func TestToolboxTool_BindSecureParam_And_Validation(t *testing.T) {
+	baseTool := &ToolboxTool{
+		name: "my-secure-tool",
+		parameters: []ParameterSchema{
+			{Name: "query", Type: "string", Required: true},
+		},
+		secureParameters: []ParameterSchema{
+			{Name: "token", Type: "string", Required: true},
+			{Name: "opt_token", Type: "string", Required: false},
+		},
+		transport: &dummyTransport{baseURL: "http://example.com"},
+	}
+
+	t.Run("BindSecureParam binds static and dynamic values", func(t *testing.T) {
+		boundTool, err := baseTool.ToolFrom(WithBindSecureParamString("token", "secret-xyz"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(boundTool.SecureParameters()) != 1 {
+			t.Fatalf("expected 1 remaining unbound secure param, got %d", len(boundTool.SecureParameters()))
+		}
+		if boundTool.boundSecureParams["token"] != "secret-xyz" {
+			t.Fatalf("expected bound secure param 'token' to be 'secret-xyz'")
+		}
+
+		// Dynamic func binding
+		dynamicTool, err := baseTool.ToolFrom(WithBindSecureParamStringFunc("token", func() (string, error) {
+			return "dynamic-token", nil
+		}))
+		if err != nil {
+			t.Fatalf("unexpected error binding func: %v", err)
+		}
+		if dynamicTool.boundSecureParams["token"] == nil {
+			t.Fatalf("expected bound secure param function")
+		}
+	})
+
+	t.Run("Mutual exclusivity: WithBindParamString on secure param fails", func(t *testing.T) {
+		_, err := baseTool.ToolFrom(WithBindParamString("token", "val"))
+		if err == nil {
+			t.Fatalf("expected error binding secure param via WithBindParamString, got nil")
+		}
+		if !strings.Contains(err.Error(), "is a secure parameter; use WithBindSecureParam* instead") {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
+
+	t.Run("Mutual exclusivity: WithBindSecureParamString on regular param fails", func(t *testing.T) {
+		_, err := baseTool.ToolFrom(WithBindSecureParamString("query", "val"))
+		if err == nil {
+			t.Fatalf("expected error binding regular param via WithBindSecureParamString, got nil")
+		}
+		if !strings.Contains(err.Error(), "is a regular parameter; use WithBindParam* instead") {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
+
+	t.Run("WithBindSecureParamString on unknown parameter fails", func(t *testing.T) {
+		_, err := baseTool.ToolFrom(WithBindSecureParamString("unknown", "val"))
+		if err == nil {
+			t.Fatalf("expected error on unknown parameter, got nil")
+		}
+		if !strings.Contains(err.Error(), "no secure parameter named \"unknown\" on the tool") {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
+
+	t.Run("Re-binding an already bound secure parameter fails", func(t *testing.T) {
+		boundTool, err := baseTool.ToolFrom(WithBindSecureParamString("token", "val1"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		_, err = boundTool.ToolFrom(WithBindSecureParamString("token", "val2"))
+		if err == nil {
+			t.Fatalf("expected error re-binding already bound secure param, got nil")
+		}
+		if !strings.Contains(err.Error(), "cannot override existing bound secure parameter") {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
+
+	t.Run("ToolFrom with nil option returns error", func(t *testing.T) {
+		_, err := baseTool.ToolFrom(nil)
+		if err == nil {
+			t.Fatalf("expected error on nil ToolOption, got nil")
+		}
+		if !strings.Contains(err.Error(), "received a nil ToolOption in options list") {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
+}
+
+func TestToolboxTool_Invoke_FastFail_And_PromptInjectionDefense(t *testing.T) {
+	recTr := &recordingTransport{baseURL: "http://example.com"}
+	tool := &ToolboxTool{
+		name: "payment-tool",
+		parameters: []ParameterSchema{
+			{Name: "amount", Type: "integer", Required: true},
+		},
+		secureParameters: []ParameterSchema{
+			{Name: "api_key", Type: "string", Required: true},
+		},
+		transport: recTr,
+	}
+
+	t.Run("Fast-fail on missing required secure parameter before transport", func(t *testing.T) {
+		_, err := tool.Invoke(context.Background(), map[string]any{"amount": 100})
+		if err == nil {
+			t.Fatalf("expected fast-fail error on missing required secure parameter, got nil")
+		}
+		if !strings.Contains(err.Error(), "missing required secure parameter(s) [api_key] for tool \"payment-tool\"") {
+			t.Errorf("unexpected error message: %v", err)
+		}
+		if recTr.capturedPayload != nil || recTr.capturedSecure != nil {
+			t.Errorf("transport was invoked despite fast-fail condition!")
+		}
+	})
+
+	t.Run("Prompt-injection defense: Passing secure parameter in input is rejected", func(t *testing.T) {
+		boundTool, err := tool.ToolFrom(WithBindSecureParamString("api_key", "secret-key"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// User/LLM tries to inject api_key in invocation input
+		_, err = boundTool.Invoke(context.Background(), map[string]any{
+			"amount":  100,
+			"api_key": "attacker-injected-key",
+		})
+		if err == nil {
+			t.Fatalf("expected prompt injection to be rejected, got nil")
+		}
+		if !strings.Contains(err.Error(), "unexpected parameter 'api_key' provided") {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
+
+	t.Run("Successful invocation sends separate payload and securePayload", func(t *testing.T) {
+		recTr.capturedPayload = nil
+		recTr.capturedSecure = nil
+
+		boundTool, err := tool.ToolFrom(WithBindSecureParamStringFunc("api_key", func() (string, error) {
+			return "dynamic-vault-token", nil
+		}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		res, err := boundTool.Invoke(context.Background(), map[string]any{"amount": 100})
+		if err != nil {
+			t.Fatalf("unexpected invoke error: %v", err)
+		}
+		if res != "ok" {
+			t.Errorf("unexpected result: %v", res)
+		}
+
+		if recTr.capturedPayload["amount"] != 100 {
+			t.Errorf("expected payload amount=100, got: %v", recTr.capturedPayload["amount"])
+		}
+		if recTr.capturedSecure["api_key"] != "dynamic-vault-token" {
+			t.Errorf("expected securePayload api_key='dynamic-vault-token', got: %v", recTr.capturedSecure["api_key"])
+		}
+	})
+
+	t.Run("Unbound secure parameter with default is injected into securePayload", func(t *testing.T) {
+		recTr.capturedPayload = nil
+		recTr.capturedSecure = nil
+
+		toolWithDefault := &ToolboxTool{
+			name: "default-secure-tool",
+			parameters: []ParameterSchema{
+				{Name: "data", Type: "string", Required: true},
+			},
+			secureParameters: []ParameterSchema{
+				{Name: "region", Type: "string", Required: true, Default: "us-central1"},
+			},
+			transport: recTr,
+		}
+
+		res, err := toolWithDefault.Invoke(context.Background(), map[string]any{"data": "hello"})
+		if err != nil {
+			t.Fatalf("unexpected invoke error: %v", err)
+		}
+		if res != "ok" {
+			t.Errorf("unexpected result: %v", res)
+		}
+		if recTr.capturedSecure == nil || recTr.capturedSecure["region"] != "us-central1" {
+			t.Errorf("expected securePayload region='us-central1', got: %v", recTr.capturedSecure)
+		}
+	})
+
+	t.Run("Binding auth token to tool with nil authTokenSources succeeds without panic", func(t *testing.T) {
+		toolWithoutAuth := &ToolboxTool{
+			name: "unauth-tool",
+			parameters: []ParameterSchema{
+				{Name: "query", Type: "string"},
+			},
+		}
+		boundTool, err := toolWithoutAuth.ToolFrom(WithAuthTokenString("service_x", "tok123"))
+		if err != nil {
+			t.Fatalf("unexpected error binding auth token to tool with nil authTokenSources: %v", err)
+		}
+		if boundTool.authTokenSources["service_x"] == nil {
+			t.Fatalf("expected auth token source for service_x to be bound")
+		}
+	})
+
+	t.Run("Binding all secure parameters leaves non-nil empty slice", func(t *testing.T) {
+		baseSecure := &ToolboxTool{
+			name: "base-sec",
+			secureParameters: []ParameterSchema{
+				{Name: "sec1", Type: "string", Required: true},
+			},
+		}
+		boundAll, err := baseSecure.ToolFrom(WithBindSecureParamString("sec1", "val1"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if boundAll.SecureParameters() == nil || len(boundAll.SecureParameters()) != 0 {
+			t.Errorf("expected non-nil empty slice for SecureParameters, got %v", boundAll.SecureParameters())
+		}
+	})
+}
+
+func TestToolboxTool_ResolveAndBuildSecurePayload(t *testing.T) {
+	testCases := []struct {
+		name        string
+		tool        *ToolboxTool
+		expected    map[string]any
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "returns nil when no secure parameters exist",
+			tool: &ToolboxTool{
+				name: "plain-tool",
+			},
+			expected: nil,
+		},
+		{
+			name: "resolves static, dynamic, and default secure parameters",
+			tool: &ToolboxTool{
+				name: "sec-tool",
+				secureParameters: []ParameterSchema{
+					{Name: "token", Type: "string", Required: true},
+					{Name: "account", Type: "string", Required: true},
+					{Name: "region", Type: "string", Default: "us-east-1"},
+				},
+				boundSecureParams: map[string]any{
+					"token": "static-token",
+					"account": func() (string, error) {
+						return "acc-12345", nil
+					},
+				},
+				boundSecureParamSchemas: map[string]ParameterSchema{
+					"token":   {Name: "token", Type: "string"},
+					"account": {Name: "account", Type: "string"},
+				},
+			},
+			expected: map[string]any{
+				"token":   "static-token",
+				"account": "acc-12345",
+				"region":  "us-east-1",
+			},
+		},
+		{
+			name: "fails when dynamic secure parameter function returns an error",
+			tool: &ToolboxTool{
+				name: "failing-sec-tool",
+				secureParameters: []ParameterSchema{
+					{Name: "token", Type: "string"},
+				},
+				boundSecureParams: map[string]any{
+					"token": func() (string, error) {
+						return "", errors.New("vault connection timed out")
+					},
+				},
+			},
+			wantErr:     true,
+			errContains: "failed to resolve bound secure parameter function for 'token'",
+		},
+		{
+			name: "fails when resolved value fails schema validation",
+			tool: &ToolboxTool{
+				name: "type-mismatch-tool",
+				secureParameters: []ParameterSchema{
+					{Name: "port", Type: "integer"},
+				},
+				boundSecureParams: map[string]any{
+					"port": "not-an-integer",
+				},
+				boundSecureParamSchemas: map[string]ParameterSchema{
+					"port": {Name: "port", Type: "integer"},
+				},
+			},
+			wantErr:     true,
+			errContains: "resolved bound secure parameter 'port' failed validation",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload, err := tc.tool.resolveAndBuildSecurePayload()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.errContains)
+				}
+				if !strings.Contains(err.Error(), tc.errContains) {
+					t.Errorf("expected error containing %q, got %q", tc.errContains, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(payload, tc.expected) {
+				t.Errorf("payload mismatch:\nExpected: %v\nGot:      %v", tc.expected, payload)
+			}
+		})
+	}
+}
+


### PR DESCRIPTION
# Summary
Adds tool-level model support, functional binding options, host-side fast-fail validation, dynamic value resolution, and prompt injection defense for Secure Parameters in the Go SDK core.

# Changes
- Add `SecureParameters()` getter to `ToolboxTool` returning a defensive copy of unbound secure parameters.
- Add `SecureParams map[string]any` to `ToolConfig` and implement `createBoundSecureParamToolOption`.
- Add 26 strongly-typed functional options in `options.go` for static values and dynamic getters.
- Update `cloneToolboxTool()` and `ToolFrom()` to deep copy and manage `boundSecureParams` and `boundSecureParamSchemas` immutably.
- Add defensive nil check in `ToolFrom` for `ToolOption` arguments.
- Enforce mutual exclusivity between regular and secure parameters in `ToolFrom`:
  - Binding a secure parameter with `WithBindParam*` returns: `parameter %q is a secure parameter; use WithBindSecureParam* instead`.
  - Binding a regular parameter with `WithBindSecureParam*` returns: `parameter %q is a regular parameter; use WithBindParam* instead`.
  - Binding an unknown secure parameter returns: `unable to bind secure parameter: no secure parameter named %q on the tool`.
  - Overriding an existing bound secure parameter returns: `cannot override existing bound secure parameter: %q`.
- Validate missing required secure parameters locally in `Invoke()` prior to token resolution or network requests (`missing required secure parameter(s) [%s] for tool %q`).
- Detect and reject unexpected parameters in user input that attempt to target secure parameter names (`unexpected parameter '%s' provided`).
- Dynamically evaluate function getters (`func() (T, error)`) and validate resolved types against `ParameterSchema.ValidateType()` at invocation time.
- Inject server-defined defaults for unbound secure parameters into `securePayload`.
- Ensure `tool.Parameters()` and `tool.InputSchema()` contain only public parameters, hiding secure parameters from LLM prompt generation.

# Testing
- Added unit tests in `options_test.go` for typed secure parameter options.
- Added comprehensive unit tests in `tool_test.go` covering `SecureParameters()` getter, `ToolFrom()` binding, mutual exclusivity, override rejection, nil option handling, fast-fail on missing required parameters, prompt injection defense, dynamic getters, and default value injection.
