### PR TITLE
feat(core): client options and tool/set loading with secure parameters

### DIFF
--- a/core/client.go
+++ b/core/client.go
@@ -112,13 +112,14 @@ func NewToolboxClient(url string, opts ...ClientOption) (*ToolboxClient, error) 
 //   - name: The name of the tool being created.
 //   - schema: The definition of the tool from the server manifest.
 //   - finalConfig: The combined default and user-provided tool options.
-//   - isStrict: A flag that, if true, errors if a bound parameter
-//     config does not exist in the tool's schema.
+//   - isStrict: A flag that, if true, errors if a bound parameter or
+//     secure parameter config does not exist in the tool's schema.
 //
 // Returns:
 //   - *ToolboxTool: The fully constructed tool, ready for invocation.
 //   - []string: A slice of authentication source keys that were used by the tool.
 //   - []string: A slice of bound parameter keys that were used by the tool.
+//   - []string: A slice of bound secure parameter keys that were used by the tool.
 //   - error: An error if validation fails (e.g., in strict mode).
 func (tc *ToolboxClient) newToolboxTool(
 	name string,
@@ -126,18 +127,24 @@ func (tc *ToolboxClient) newToolboxTool(
 	finalConfig *ToolConfig,
 	isStrict bool,
 	tr transport.Transport,
-) (*ToolboxTool, []string, []string, error) {
+) (*ToolboxTool, []string, []string, []string, error) {
 
 	// These will be the parameters that the end-user must provide at invocation time.
 	finalParameters := make([]ParameterSchema, 0)
 	// This map collects parameters that require an auth token to be fulfilled.
 	authnParams := make(map[string][]string)
-	// This set tracks all parameter names defined in the schema for validation.
-	paramSchema := make(map[string]struct{})
+	// This map tracks all parameter schemas defined in the schema.
+	allParamSchemas := make(map[string]ParameterSchema)
 	// This map stores bound parameters that are applicable to this specific tool.
 	localBoundParams := make(map[string]any)
 	// This map stores the schemas of the bound parameters for validation during invocation.
 	localBoundSchemas := make(map[string]ParameterSchema)
+
+	// Build lookup maps for validation.
+	secSchemaMap := make(map[string]ParameterSchema)
+	for _, sp := range schema.SecureParameters {
+		secSchemaMap[sp.Name] = sp
+	}
 
 	// Iterate over the tool's parameters from the schema to categorize them.
 	for _, p := range schema.Parameters {
@@ -145,16 +152,16 @@ func (tc *ToolboxClient) newToolboxTool(
 		if ap, ok := p.AdditionalProperties.(map[string]any); ok {
 			apParam, err := mapToSchema(ap)
 			if err != nil {
-				return nil, nil, nil, err
+				return nil, nil, nil, nil, err
 			}
 			p.AdditionalProperties = apParam
 		}
 		// Validate parameter schema
 		if err := p.ValidateDefinition(); err != nil {
 			// Return a detailed error indicating which tool failed validation.
-			return nil, nil, nil, fmt.Errorf("invalid schema for tool '%s': %w", name, err)
+			return nil, nil, nil, nil, fmt.Errorf("invalid schema for tool '%s': %w", name, err)
 		}
-		paramSchema[p.Name] = struct{}{}
+		allParamSchemas[p.Name] = p
 
 		if len(p.AuthSources) > 0 {
 			// The parameter is satisfied by an authentication source.
@@ -170,12 +177,40 @@ func (tc *ToolboxClient) newToolboxTool(
 		}
 	}
 
-	// In strict mode, ensure that all provided bound parameters actually exist
-	// on the tool's schema.
+	// Process secure parameters from the schema.
+	finalSecureParameters := make([]ParameterSchema, 0)
+	localBoundSecureParams := make(map[string]any)
+	localBoundSecureSchemas := make(map[string]ParameterSchema)
+
+	for _, sp := range schema.SecureParameters {
+		if err := sp.ValidateDefinition(); err != nil {
+			return nil, nil, nil, nil, fmt.Errorf("invalid secure parameter schema for tool '%s': %w", name, err)
+		}
+
+		if val, isBound := finalConfig.SecureParams[sp.Name]; isBound {
+			localBoundSecureParams[sp.Name] = val
+			localBoundSecureSchemas[sp.Name] = sp
+		} else {
+			finalSecureParameters = append(finalSecureParameters, sp)
+		}
+	}
+
+	// In strict mode, validate that all provided bound parameters and secure parameters exist.
 	if isStrict {
 		for boundName := range finalConfig.BoundParams {
-			if _, exists := paramSchema[boundName]; !exists {
-				return nil, nil, nil, fmt.Errorf("unable to bind parameter: no parameter named '%s' found on tool '%s'", boundName, name)
+			if _, isSec := secSchemaMap[boundName]; isSec {
+				return nil, nil, nil, nil, fmt.Errorf("parameter %q is a secure parameter; use WithBindSecureParam* instead", boundName)
+			}
+			if _, exists := allParamSchemas[boundName]; !exists {
+				return nil, nil, nil, nil, fmt.Errorf("unable to bind parameter: no parameter named '%s' found on tool '%s'", boundName, name)
+			}
+		}
+		for secName := range finalConfig.SecureParams {
+			if _, isReg := allParamSchemas[secName]; isReg {
+				return nil, nil, nil, nil, fmt.Errorf("parameter %q is a regular parameter; use WithBindParam* instead", secName)
+			}
+			if _, exists := secSchemaMap[secName]; !exists {
+				return nil, nil, nil, nil, fmt.Errorf("unable to bind secure parameter: no secure parameter named %q found on tool %q", secName, name)
 			}
 		}
 	}
@@ -184,6 +219,12 @@ func (tc *ToolboxClient) newToolboxTool(
 	var usedBoundKeys []string
 	for k := range localBoundParams {
 		usedBoundKeys = append(usedBoundKeys, k)
+	}
+
+	// Collect the keys of the bound secure parameters that were actually used.
+	var usedSecureKeys []string
+	for k := range localBoundSecureParams {
+		usedSecureKeys = append(usedSecureKeys, k)
 	}
 
 	// Determine which auth requirements are still unmet after applying the provided tokens.
@@ -195,21 +236,24 @@ func (tc *ToolboxClient) newToolboxTool(
 
 	// Construct the final tool object.
 	tt := &ToolboxTool{
-		name:                name,
-		description:         schema.Description,
-		parameters:          finalParameters,
-		transport:           tr,
-		authTokenSources:    finalConfig.AuthTokenSources,
-		boundParams:         localBoundParams,
-		boundParamSchemas:   localBoundSchemas,
-		requiredAuthnParams: remainingAuthnParams,
-		requiredAuthzTokens: remainingAuthzTokens,
-		clientHeaderSources: tc.clientHeaderSources,
-		clientName:          tc.clientName,
-		clientVersion:       tc.clientVersion,
+		name:                    name,
+		description:             schema.Description,
+		parameters:              finalParameters,
+		secureParameters:        finalSecureParameters,
+		transport:               tr,
+		authTokenSources:        finalConfig.AuthTokenSources,
+		boundParams:             localBoundParams,
+		boundParamSchemas:       localBoundSchemas,
+		boundSecureParams:       localBoundSecureParams,
+		boundSecureParamSchemas: localBoundSecureSchemas,
+		requiredAuthnParams:     remainingAuthnParams,
+		requiredAuthzTokens:     remainingAuthzTokens,
+		clientHeaderSources:     tc.clientHeaderSources,
+		clientName:              tc.clientName,
+		clientVersion:           tc.clientVersion,
 	}
 
-	return tt, usedAuthKeys, usedBoundKeys, nil
+	return tt, usedAuthKeys, usedBoundKeys, usedSecureKeys, nil
 }
 
 // LoadTool fetches a manifest for a single tool
@@ -217,8 +261,8 @@ func (tc *ToolboxClient) newToolboxTool(
 // Inputs:
 //   - name: The specific name of the tool to load.
 //   - ctx: The context to control the lifecycle of the request.
-//   - opts: A variadic list of ToolOption functions to configure auth tokens
-//     or bind parameters for this tool.
+//   - opts: A variadic list of ToolOption functions to configure auth tokens,
+//     bind parameters, or bind secure parameters for this tool.
 //
 // Returns:
 //
@@ -274,7 +318,7 @@ func (tc *ToolboxClient) LoadTool(name string, ctx context.Context, opts ...Tool
 	activeTransport := tc.transport
 	tc.mu.RUnlock()
 
-	tool, usedAuthKeys, usedBoundKeys, err := tc.newToolboxTool(name, schema, finalConfig, true, activeTransport)
+	tool, usedAuthKeys, usedBoundKeys, usedSecureKeys, err := tc.newToolboxTool(name, schema, finalConfig, true, activeTransport)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create toolbox tool from schema for '%s': %w", name, err)
 	}
@@ -288,6 +332,11 @@ func (tc *ToolboxClient) LoadTool(name string, ctx context.Context, opts ...Tool
 	for k := range finalConfig.BoundParams {
 		providedBoundKeys[k] = struct{}{}
 	}
+	providedSecureKeys := make(map[string]struct{})
+	for k := range finalConfig.SecureParams {
+		providedSecureKeys[k] = struct{}{}
+	}
+
 	usedAuthSet := make(map[string]struct{})
 	for _, k := range usedAuthKeys {
 		usedAuthSet[k] = struct{}{}
@@ -296,17 +345,25 @@ func (tc *ToolboxClient) LoadTool(name string, ctx context.Context, opts ...Tool
 	for _, k := range usedBoundKeys {
 		usedBoundSet[k] = struct{}{}
 	}
+	usedSecureSet := make(map[string]struct{})
+	for _, k := range usedSecureKeys {
+		usedSecureSet[k] = struct{}{}
+	}
 
 	// Find any provided options that were not consumed during tool creation.
 	var errorMessages []string
 	unusedAuth := findUnusedKeys(providedAuthKeys, usedAuthSet)
 	unusedBound := findUnusedKeys(providedBoundKeys, usedBoundSet)
+	unusedSecure := findUnusedKeys(providedSecureKeys, usedSecureSet)
 
 	if len(unusedAuth) > 0 {
 		errorMessages = append(errorMessages, fmt.Sprintf("unused auth tokens: %s", strings.Join(unusedAuth, ", ")))
 	}
 	if len(unusedBound) > 0 {
 		errorMessages = append(errorMessages, fmt.Sprintf("unused bound parameters: %s", strings.Join(unusedBound, ", ")))
+	}
+	if len(unusedSecure) > 0 {
+		errorMessages = append(errorMessages, fmt.Sprintf("unused secure parameters: %s", strings.Join(unusedSecure, ", ")))
 	}
 	if len(errorMessages) > 0 {
 		return nil, fmt.Errorf("validation failed for tool '%s': %s", name, strings.Join(errorMessages, "; "))
@@ -318,10 +375,10 @@ func (tc *ToolboxClient) LoadTool(name string, ctx context.Context, opts ...Tool
 // LoadToolset fetches a manifest for a collection of tools.
 //
 // Inputs:
-//   - name: Name of the toolset to be loaded.Set this arg to "" to load the default toolset
+//   - name: Name of the toolset to be loaded. Set this arg to "" to load the default toolset.
 //   - ctx: The context to control the lifecycle of the request.
 //   - opts: A variadic list of ToolOption functions. These can include WithStrict
-//     and options for auth or bound params that may apply to tools in the set.
+//     and options for auth, bound params, or secure params that may apply to tools in the set.
 //
 // Returns:
 //
@@ -370,6 +427,7 @@ func (tc *ToolboxClient) LoadToolset(name string, ctx context.Context, opts ...T
 	var tools []*ToolboxTool
 	overallUsedAuthKeys := make(map[string]struct{})
 	overallUsedBoundParams := make(map[string]struct{})
+	overallUsedSecureParams := make(map[string]struct{})
 
 	providedAuthKeys := make(map[string]struct{})
 	for k := range finalConfig.AuthTokenSources {
@@ -379,6 +437,10 @@ func (tc *ToolboxClient) LoadToolset(name string, ctx context.Context, opts ...T
 	for k := range finalConfig.BoundParams {
 		providedBoundKeys[k] = struct{}{}
 	}
+	providedSecureKeys := make(map[string]struct{})
+	for k := range finalConfig.SecureParams {
+		providedSecureKeys[k] = struct{}{}
+	}
 
 	tc.mu.RLock()
 	activeTransport := tc.transport
@@ -386,7 +448,7 @@ func (tc *ToolboxClient) LoadToolset(name string, ctx context.Context, opts ...T
 
 	for toolName, schema := range manifest.Tools {
 		// Construct each tool from its schema and the shared configuration.
-		tool, usedAuthKeys, usedBoundKeys, err := tc.newToolboxTool(toolName, schema, finalConfig, finalConfig.Strict, activeTransport)
+		tool, usedAuthKeys, usedBoundKeys, usedSecureKeys, err := tc.newToolboxTool(toolName, schema, finalConfig, finalConfig.Strict, activeTransport)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create tool '%s': %w", toolName, err)
 		}
@@ -403,9 +465,14 @@ func (tc *ToolboxClient) LoadToolset(name string, ctx context.Context, opts ...T
 			for _, k := range usedBoundKeys {
 				usedBoundSet[k] = struct{}{}
 			}
+			usedSecureSet := make(map[string]struct{})
+			for _, k := range usedSecureKeys {
+				usedSecureSet[k] = struct{}{}
+			}
 
 			unusedAuth := findUnusedKeys(providedAuthKeys, usedAuthSet)
 			unusedBound := findUnusedKeys(providedBoundKeys, usedBoundSet)
+			unusedSecure := findUnusedKeys(providedSecureKeys, usedSecureSet)
 
 			var errorMessages []string
 			if len(unusedAuth) > 0 {
@@ -413,6 +480,9 @@ func (tc *ToolboxClient) LoadToolset(name string, ctx context.Context, opts ...T
 			}
 			if len(unusedBound) > 0 {
 				errorMessages = append(errorMessages, fmt.Sprintf("unused bound parameters: %s", strings.Join(unusedBound, ", ")))
+			}
+			if len(unusedSecure) > 0 {
+				errorMessages = append(errorMessages, fmt.Sprintf("unused secure parameters: %s", strings.Join(unusedSecure, ", ")))
 			}
 			if len(errorMessages) > 0 {
 				return nil, fmt.Errorf("validation failed for tool '%s': %s", toolName, strings.Join(errorMessages, "; "))
@@ -426,6 +496,9 @@ func (tc *ToolboxClient) LoadToolset(name string, ctx context.Context, opts ...T
 			for _, k := range usedBoundKeys {
 				overallUsedBoundParams[k] = struct{}{}
 			}
+			for _, k := range usedSecureKeys {
+				overallUsedSecureParams[k] = struct{}{}
+			}
 		}
 	}
 
@@ -434,6 +507,7 @@ func (tc *ToolboxClient) LoadToolset(name string, ctx context.Context, opts ...T
 	if !finalConfig.Strict {
 		unusedAuth := findUnusedKeys(providedAuthKeys, overallUsedAuthKeys)
 		unusedBound := findUnusedKeys(providedBoundKeys, overallUsedBoundParams)
+		unusedSecure := findUnusedKeys(providedSecureKeys, overallUsedSecureParams)
 
 		var errorMessages []string
 		if len(unusedAuth) > 0 {
@@ -441,6 +515,9 @@ func (tc *ToolboxClient) LoadToolset(name string, ctx context.Context, opts ...T
 		}
 		if len(unusedBound) > 0 {
 			errorMessages = append(errorMessages, fmt.Sprintf("unused bound parameters could not be applied to any tool: %s", strings.Join(unusedBound, ", ")))
+		}
+		if len(unusedSecure) > 0 {
+			errorMessages = append(errorMessages, fmt.Sprintf("unused secure parameters could not be applied to any tool: %s", strings.Join(unusedSecure, ", ")))
 		}
 		if len(errorMessages) > 0 {
 			if name == "" {

--- a/core/client_test.go
+++ b/core/client_test.go
@@ -56,10 +56,11 @@ type mcpRPCResponse struct {
 
 // mcpTool represents a single tool definition in an MCP list response.
 type mcpTool struct {
-	Name        string         `json:"name"`
-	Description string         `json:"description,omitempty"`
-	InputSchema map[string]any `json:"inputSchema"`
-	Meta        map[string]any `json:"_meta,omitempty"`
+	Name              string         `json:"name"`
+	Description       string         `json:"description,omitempty"`
+	InputSchema       map[string]any `json:"inputSchema"`
+	SecureInputSchema map[string]any `json:"secureInputSchema,omitempty"`
+	Meta              map[string]any `json:"_meta,omitempty"`
 }
 
 // newMockMCPServer creates a server that simulates the MCP lifecycle (initialize -> list) defaulting to 2026-07-28 protocol version.
@@ -1411,3 +1412,117 @@ func TestToolInvocation_PreservesURLQueryParams(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "foo=bar&baz=123", requestedRawQuery)
 }
+
+func TestLoadTool_WithBindSecureParam(t *testing.T) {
+	mcpTools := []mcpTool{
+		{
+			Name:        "secure-tool",
+			Description: "A test secure tool",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"public_arg": map[string]any{"type": "string"},
+				},
+				"required": []string{"public_arg"},
+			},
+			SecureInputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"api_key": map[string]any{"type": "string"},
+				},
+				"required": []string{"api_key"},
+			},
+		},
+	}
+	server := newMockMCPServer(t, mcpTools)
+	defer server.Close()
+
+	client, err := NewToolboxClient(server.URL, WithHTTPClient(server.Client()))
+	require.NoError(t, err)
+
+	t.Run("Successfully loads and binds secure parameters", func(t *testing.T) {
+		tool, err := client.LoadTool("secure-tool", context.Background(), WithBindSecureParamString("api_key", "my-secret-key"))
+		require.NoError(t, err)
+		assert.Equal(t, "my-secret-key", tool.boundSecureParams["api_key"])
+		assert.Empty(t, tool.SecureParameters(), "bound secure parameter should be removed from unbound list")
+	})
+
+	t.Run("Validation failure on unused secure parameter", func(t *testing.T) {
+		_, err := client.LoadTool("secure-tool", context.Background(),
+			WithBindSecureParamString("api_key", "my-secret-key"),
+			WithBindSecureParamString("unused", "extra"),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no secure parameter named \"unused\" found on tool \"secure-tool\"")
+	})
+
+	t.Run("Validation failure when regular param passed via WithBindSecureParam", func(t *testing.T) {
+		_, err := client.LoadTool("secure-tool", context.Background(), WithBindSecureParamString("public_arg", "val"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "parameter \"public_arg\" is a regular parameter; use WithBindParam* instead")
+	})
+}
+
+func TestLoadToolset_WithBindSecureParam(t *testing.T) {
+	mcpTools := []mcpTool{
+		{
+			Name: "tool1",
+			InputSchema: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{},
+			},
+			SecureInputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"key1": map[string]any{"type": "string"},
+				},
+			},
+		},
+		{
+			Name: "tool2",
+			InputSchema: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{},
+			},
+			SecureInputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"key2": map[string]any{"type": "string"},
+				},
+			},
+		},
+	}
+	server := newMockMCPServer(t, mcpTools)
+	defer server.Close()
+
+	client, err := NewToolboxClient(server.URL, WithHTTPClient(server.Client()))
+	require.NoError(t, err)
+
+	t.Run("Non-strict mode succeeds if secure params are used across toolset", func(t *testing.T) {
+		tools, err := client.LoadToolset("", context.Background(),
+			WithBindSecureParamString("key1", "val1"),
+			WithBindSecureParamString("key2", "val2"),
+		)
+		require.NoError(t, err)
+		assert.Len(t, tools, 2)
+	})
+
+	t.Run("Non-strict mode fails if secure param is not used by any tool", func(t *testing.T) {
+		_, err := client.LoadToolset("", context.Background(),
+			WithBindSecureParamString("key1", "val1"),
+			WithBindSecureParamString("completely_unused", "val"),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unused secure parameters could not be applied to any tool: completely_unused")
+	})
+
+	t.Run("Strict mode fails if any tool does not use all secure params", func(t *testing.T) {
+		_, err := client.LoadToolset("", context.Background(),
+			WithStrict(true),
+			WithBindSecureParamString("key1", "val1"),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no secure parameter named \"key1\" found on tool \"tool2\"")
+	})
+}
+


### PR DESCRIPTION
# Summary
Adds client loading and validation support for Secure Parameters across individual tools and toolsets in the Go SDK core.

# Changes
- Update `newToolboxTool` in `client.go` to parse `schema.SecureParameters`, apply `finalConfig.SecureParams`, validate schemas via `ValidateDefinition()`, and track used secure parameter keys.
- Enforce mutual exclusivity and parameter existence during `newToolboxTool` in strict mode:
  - Binding a secure parameter with `WithBindParam*` returns: `parameter %q is a secure parameter; use WithBindSecureParam* instead`.
  - Binding a regular parameter with `WithBindSecureParam*` returns: `parameter %q is a regular parameter; use WithBindParam* instead`.
  - Binding an unknown secure parameter returns: `unable to bind secure parameter: no secure parameter named %q found on tool %q`.
- Support secure parameter options in `LoadTool` and validate unused secure parameters (`validation failed for tool '%s': unused secure parameters: %s`).
- Support secure parameter options across tools in `LoadToolset`:
  - When `WithStrict(true)` is provided, validate each tool individually for unused secure parameters.
  - When `WithStrict(false)` is provided (default), aggregate used keys across the set and return an error only if a secure parameter is not used by any tool (`validation failed for toolset '%s': unused secure parameters could not be applied to any tool: %s`).

# Testing
- Added unit tests in `client_test.go` verifying `LoadTool` and `LoadToolset` with secure parameter options across strict and permissive validation modes.
