### PR TITLE
feat(tbadk): support secure parameters in ADK tools and client

### DIFF
--- a/tbadk/client.go
+++ b/tbadk/client.go
@@ -50,10 +50,10 @@ func NewToolboxClient(url string, opts ...core.ClientOption) (ToolboxClient, err
 // LoadToolset fetches  a collection of tools from the Toolbox server
 //
 // Inputs:
-//   - name: Name of the toolset to be loaded.Set this arg to "" to load the default toolset
+//   - name: Name of the toolset to be loaded. Set this arg to "" to load the default toolset.
 //   - ctx: The context to control the lifecycle of the request.
 //   - opts: A variadic list of ToolOption functions. These can include WithStrict
-//     and options for auth or bound params that may apply to tools in the set.
+//     and options for auth, bound params, or secure params that may apply to tools in the set.
 //
 // Returns:
 //
@@ -85,8 +85,8 @@ func (tc ToolboxClient) LoadToolset(name string, ctx context.Context, opts ...co
 // Inputs:
 //   - name: The specific name of the tool to load.
 //   - ctx: The context to control the lifecycle of the request.
-//   - opts: A variadic list of ToolOption functions to configure auth tokens
-//     or bind parameters for this tool.
+//   - opts: A variadic list of ToolOption functions to configure auth tokens,
+//     bind parameters, or bind secure parameters for this tool.
 //
 // Returns:
 //

--- a/tbadk/tool.go
+++ b/tbadk/tool.go
@@ -117,12 +117,12 @@ func (tt ToolboxTool) Run(ctx agent.Context, args any) (result map[string]any, e
 
 // ToolFrom creates a new, more specialized tool from an existing one by applying
 // additional options. This is useful for creating variations of a tool with
-// different bound parameters / auth tokens without modifying the original and
+// different bound parameters, secure parameters, or auth tokens without modifying the original and
 // all provided options must be applicable.
 //
 // Inputs:
 //   - opts: A variadic list of ToolOption functions to further configure the
-//     new tool, such as binding more parameters.
+//     new tool, such as binding parameters, binding secure parameters, or configuring auth tokens.
 //
 // Returns:
 //
@@ -135,5 +135,4 @@ func (tt ToolboxTool) ToolFrom(opts ...core.ToolOption) (ToolboxTool, error) {
 	}
 
 	return toADKTool(coreTool)
-
 }

--- a/tbadk/utils.go
+++ b/tbadk/utils.go
@@ -24,7 +24,7 @@ import (
 
 func toADKTool(t *core.ToolboxTool) (ToolboxTool, error) {
 	if t == nil {
-		return ToolboxTool{}, fmt.Errorf("nil tool recieved")
+		return ToolboxTool{}, fmt.Errorf("nil tool received")
 	}
 
 	paramsJSON, err := t.InputSchema()

--- a/tbadk/utils_test.go
+++ b/tbadk/utils_test.go
@@ -60,6 +60,9 @@ func createCoreTool(t *testing.T, toolName string, schema core.ToolSchema) (*cor
 		"description": schema.Description,
 		"inputSchema": convertParamsToJSONSchema(schema.Parameters),
 	}
+	if len(schema.SecureParameters) > 0 {
+		mcpToolDef["secureInputSchema"] = convertParamsToJSONSchema(schema.SecureParameters)
+	}
 
 	// Setup a Mock MCP Server (JSON-RPC 2.0)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -80,7 +83,7 @@ func createCoreTool(t *testing.T, toolName string, schema core.ToolSchema) (*cor
 		case "initialize":
 			// Handshake
 			result = map[string]any{
-				"protocolVersion": "2025-06-18", // Matches latest default
+				"protocolVersion": "2026-07-28",
 				"capabilities":    map[string]any{"tools": map[string]any{}},
 				"serverInfo": map[string]any{
 					"name":    "mock-server",
@@ -94,6 +97,12 @@ func createCoreTool(t *testing.T, toolName string, schema core.ToolSchema) (*cor
 			// List available tools
 			result = map[string]any{
 				"tools": []any{mcpToolDef},
+			}
+		case "tools/call":
+			result = map[string]any{
+				"content": []map[string]any{
+					{"type": "text", "text": "result-success"},
+				},
 			}
 		default:
 			// Ignore other methods for this test
@@ -110,7 +119,7 @@ func createCoreTool(t *testing.T, toolName string, schema core.ToolSchema) (*cor
 		_ = json.NewEncoder(w).Encode(resp)
 	}))
 
-	//  Create Client, defaults to Latest MCP (v2025-06-18)
+	// Create Client, defaults to Latest MCP (v2026-07-28)
 	client, err := core.NewToolboxClient(server.URL, core.WithHTTPClient(server.Client()))
 	if err != nil {
 		server.Close()
@@ -229,4 +238,47 @@ func TestToADKTool(t *testing.T) {
 		}
 	})
 
+	t.Run("Secure Parameters Isolation and Binding", func(t *testing.T) {
+		toolSchema := core.ToolSchema{
+			Description: "Tool with secure params",
+			Parameters: []core.ParameterSchema{
+				{Name: "public_query", Type: "string", Required: true, Description: "Public search query"},
+			},
+			SecureParameters: []core.ParameterSchema{
+				{Name: "api_key", Type: "string", Required: true, Description: "Secret API token"},
+			},
+		}
+
+		coreTool, server := createCoreTool(t, "secureSearch", toolSchema)
+		defer server.Close()
+
+		adkTool, err := toADKTool(coreTool)
+		if err != nil {
+			t.Fatalf("toADKTool() unexpected error = %v", err)
+		}
+
+		// Verify genai.FunctionDeclaration strictly excludes secure params
+		decl := adkTool.Declaration()
+		if decl == nil {
+			t.Fatal("expected non-nil Declaration()")
+		}
+		if decl.Parameters == nil || len(decl.Parameters.Properties) != 1 {
+			t.Fatalf("expected exactly 1 property in FunctionDeclaration, got %v", decl.Parameters)
+		}
+		if _, exists := decl.Parameters.Properties["public_query"]; !exists {
+			t.Errorf("expected public_query in FunctionDeclaration")
+		}
+		if _, exists := decl.Parameters.Properties["api_key"]; exists {
+			t.Errorf("CRITICAL: secure parameter 'api_key' leaked into genai.FunctionDeclaration")
+		}
+
+		// Test ToolFrom with WithBindSecureParamString on ADK tool
+		boundADKTool, err := adkTool.ToolFrom(core.WithBindSecureParamString("api_key", "secret-token-123"))
+		if err != nil {
+			t.Fatalf("ToolFrom failed: %v", err)
+		}
+		if len(boundADKTool.SecureParameters()) != 0 {
+			t.Errorf("expected 0 unbound secure parameters after binding, got %d", len(boundADKTool.SecureParameters()))
+		}
+	})
 }


### PR DESCRIPTION
# Summary
Adds Secure Parameters support to the Google GenAI ADK adapter package (`tbadk`).

# Changes
- Ensure `toADKTool` constructs `genai.FunctionDeclaration` strictly from `coreTool.InputSchema()`, guaranteeing secure parameters are never exposed to the Gemini model declaration.
- Update `ToolFrom(opts ...core.ToolOption) (ToolboxTool, error)` on `tbadk.ToolboxTool` to delegate to `core.ToolboxTool.ToolFrom` and re-wrap the adapted ADK tool.
- Update docstrings for `LoadTool` and `LoadToolset` in `tbadk/client.go` to document secure parameter options.
- Fix typo `recieved` -> `received` in `tbadk/utils.go`.

# Testing
- Added unit tests in `tbadk/utils_test.go` (`TestToADKTool/Secure_Parameters_Isolation_and_Binding`) verifying `genai.FunctionDeclaration` excludes secure parameters and `ToolFrom` successfully binds secure parameters on ADK tools.
